### PR TITLE
fix: streaming hub isErrorOrInterrupted is ignored

### DIFF
--- a/src/MagicOnion/Server/Hubs/StreamingHub.cs
+++ b/src/MagicOnion/Server/Hubs/StreamingHub.cs
@@ -174,6 +174,7 @@ namespace MagicOnion.Server.Hubs
                         }
                         catch (Exception ex)
                         {
+                            isErrorOrInterrupted = true;
                             LogError(ex, context);
                             await context.WriteErrorMessage((int)StatusCode.Internal, "Erorr on " + handler.ToString(), ex, Context.MethodHandler.isReturnExceptionStackTraceInErrorDetail);
                         }


### PR DESCRIPTION
## TL;DR

`isErrorOrInterrupted` should be `true` when streaming hub throws exception on length 3.

