### PR TITLE
doc: add SSL/TLS connection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,27 +925,27 @@ I will explain how to setup "SSL/TLS MagicOnion on localhost" with following 4 s
 * [server configuration](https://github.com/Cysharp/MagicOnion#server-configuration)
 * [client configuration](https://github.com/Cysharp/MagicOnion#client-configuration)
 
-I will use [samples/ChatApp/ChatApp.Server](https://github.com/Cysharp/MagicOnion/tree/master/samples/ChatApp/ChatApp.Server) for server project, and [samples/ChatApp/ChatApp.Unity](https://github.com/Cysharp/MagicOnion/tree/master/samples/ChatApp/ChatApp.Unity) for client project.
+Let's use [samples/ChatApp/ChatApp.Server](https://github.com/Cysharp/MagicOnion/tree/master/samples/ChatApp/ChatApp.Server) for server project, and [samples/ChatApp/ChatApp.Unity](https://github.com/Cysharp/MagicOnion/tree/master/samples/ChatApp/ChatApp.Unity) for client project.
 
 ### generate certificate
 
-Certificates are required to establish SSL/TLS with Server/Client connection.
+Certificates are required to establish SSL/TLS with Server/Client channel connection.
 Let's use [OpenSSL](https://github.com/openssl/openssl) to create required certificates.
 
 Following command will create 3 files `server.csr`, `server.key` and `server.crt`.
-gRPC/MagicOnion Server requires server.crt and server.key, and Client require server.crt for create SSL/TLS channel connection.
+gRPC/MagicOnion Server requires server.crt and server.key, and Client require server.crt.
 
 ```shell
 # move to your server project
 $ cd MagicOnion/samples/ChatApp/ChatApp.Server
 
 # generate certificates
-# NOTE: please match domain name to magic onion server host domain name
+# NOTE: CN=xxxx should match domain name to magic onion server pointing domain name
 $ openssl genrsa 2048 > server.key
 $ openssl req -new -sha256 -key server.key -out server.csr -subj "/C=JP/ST=Tokyo/L=Tokyo/O=MagicOnion Demo/OU=Dev/CN=*.example.com"
 $ openssl x509 -req -in server.csr -signkey server.key -out server.crt -days 7300 -extensions server
 
-# server will use server.crt and server.key, leave generated certificates
+# server will use server.crt and server.key, leave generated certificates.
 
 # client will use server.crt, copy certificate to StreamingAssets folder.
 $ mkdir ../ChatApp.Unity/Assets/StreamingAssets
@@ -961,8 +961,8 @@ Make sure `CN=xxxx` should match to domain that your MagicOnion Server will reci
 
 Editting `hosts` file is the simple way to redirect dummy domain request to your localhost.
 
-Let's set your CN, example is `dummy.example.com`, to you hosts. 
-Ppen hosts file and add your entry.
+Let's set your CN to you hosts, example is `dummy.example.com`. 
+Open hosts file and add your entry.
 
 ```shell
 # NOTE: edit hosts to test on localhost
@@ -991,7 +991,7 @@ pinging to dummy.example.com [127.0.0.1] 32 bytes data:
 
 **server configuration**
 
-> NOTE: Server will use **server.crt** and **server.key**, if you didn't copy OpenSSL generated `server.crt` and `server.key`, please back to [generate certificate](https://github.com/Cysharp/MagicOnion#generate-certificate) section and copy it.
+> NOTE: Server will use **server.crt** and **server.key**, if you didn't copy OpenSSL generated `server.crt` and `server.key`, please back to [generate certificate](https://github.com/Cysharp/MagicOnion#generate-certificate) section and copy them.
 
 Open `samples/ChatApp/ChatApp.Server/ChatApp.Server.csproj` and add folloging lines before `</Project>`.
 
@@ -1013,7 +1013,8 @@ Open `samples/ChatApp/ChatApp.Server/ChatApp.Server.csproj` and add folloging li
 </Project>
 ```
 
-Open `samples/ChatApp/ChatApp.Server/Program.cs`, there are default Insecure channel definition with `ServerCredentials.Insecure`, you need change this to use `SslServerCredentials`.
+Open `samples/ChatApp/ChatApp.Server/Program.cs`, there are default Insecure channel definition with `ServerCredentials.Insecure`.
+What you need is change this line to use `SslServerCredentials`.
 
 ```csharp
 new ServerPort("localhost", 12345, ServerCredentials.Insecure))
@@ -1055,7 +1056,9 @@ Hosting environment: Production
 
 > NOTE: Client will use **server.crt**, if you didn't copy OpenSSL generated `server.crt` and `server.key`, please back to [generate certificate](https://github.com/Cysharp/MagicOnion#generate-certificate) section and copy it.
 
-Open `samples/ChatApp/ChatApp.Unity/Assets/ChatComponent.cs`, channel creation is defined in `InitializeClient()`.
+Open `samples/ChatApp/ChatApp.Unity/Assets/ChatComponent.cs`, channel creation is defined as `ChannelCredentials.Insecure` in `InitializeClient()`.
+What you need tois change this line to use `SslCredentials`.
+
 
 ```csharp
 this.channel = new Channel("localhost", 12345, ChannelCredentials.Insecure);

--- a/README.md
+++ b/README.md
@@ -914,7 +914,7 @@ static async Task DuplexStreamRun(IMyFirstService client)
 
 SSL/TLS
 ---
-As [official gRPC doc](https://grpc.io/docs/guides/auth/) notes, gRPC supports SSL/TLS and MagicOnion also support SSL/TLS. 
+As [official gRPC doc](https://grpc.io/docs/guides/auth/) notes gRPC supports SSL/TLS, and MagicOnion also support SSL/TLS. 
 
 > gRPC has SSL/TLS integration and promotes the use of SSL/TLS to authenticate the server, and to encrypt all the data exchanged between the client and the server. Optional mechanisms are available for clients to provide certificates for mutual authentication
 
@@ -957,7 +957,7 @@ Make sure `CN=xxxx` should match to domain that your MagicOnion Server will reci
 
 > ATTENTION: Make sure **server.key** is very sensitive file, while **server.crt** can be public. DO NOT COPY server.key to your client.
 
-**simulate dummy domain on localhost**
+### simulate dummy domain on localhost
 
 Editting `hosts` file is the simple way to redirect dummy domain request to your localhost.
 
@@ -989,7 +989,7 @@ pinging to dummy.example.com [127.0.0.1] 32 bytes data:
 127.0.0.1 response: bytecount =32 time <1ms TTL=128
 ```
 
-**server configuration**
+### server configuration
 
 > NOTE: Server will use **server.crt** and **server.key**, if you didn't copy OpenSSL generated `server.crt` and `server.key`, please back to [generate certificate](https://github.com/Cysharp/MagicOnion#generate-certificate) section and copy them.
 
@@ -1052,7 +1052,7 @@ Application started. Press Ctrl+C to shut down.
 Hosting environment: Production
 ```
 
-**client configuration**
+### client configuration
 
 > NOTE: Client will use **server.crt**, if you didn't copy OpenSSL generated `server.crt` and `server.key`, please back to [generate certificate](https://github.com/Cysharp/MagicOnion#generate-certificate) section and copy it.
 

--- a/samples/ChatApp/ChatApp.Server/ChatApp.Server.csproj
+++ b/samples/ChatApp/ChatApp.Server/ChatApp.Server.csproj
@@ -18,4 +18,14 @@
     <Folder Include="LinkFromUnity\" />
   </ItemGroup>
 
+  <!-- FOR SSL/TLS SUPPORT -->
+  <ItemGroup>
+    <None Update="server.crt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="server.key">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/samples/ChatApp/ChatApp.Server/Program.cs
+++ b/samples/ChatApp/ChatApp.Server/Program.cs
@@ -1,7 +1,10 @@
 ﻿using Grpc.Core;
 using MagicOnion.Hosting;
 using MagicOnion.Server;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace ChatApp.Server
@@ -12,10 +15,17 @@ namespace ChatApp.Server
         {
             GrpcEnvironment.SetLogger(new Grpc.Core.Logging.ConsoleLogger());
 
+            // for SSL/TLS connection
+            //var config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
+            //var certificates = new List<KeyCertificatePair> { new KeyCertificatePair(File.ReadAllText("server.crt"), File.ReadAllText("server.key")) };
+            //var credential = new SslServerCredentials(certificates);
+
             await MagicOnionHost.CreateDefaultBuilder()
                 .UseMagicOnion(
                     new MagicOnionOptions(isReturnExceptionStackTraceInErrorDetail: true),
                     new ServerPort("localhost", 12345, ServerCredentials.Insecure))
+                    // for SSL/TLS Connection
+                    //new ServerPort(config.GetValue<string>("MAGICONION_HOST", "127.0.0.1"), 12345, credential))
                 .RunConsoleAsync();
         }
     }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/ChatComponent.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/ChatComponent.cs
@@ -3,6 +3,7 @@ using ChatApp.Shared.MessagePackObjects;
 using ChatApp.Shared.Services;
 using Grpc.Core;
 using MagicOnion.Client;
+using System.IO;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
@@ -54,6 +55,9 @@ namespace Assets.Scripts
         {
             // Initialize the Hub
             this.channel = new Channel("localhost", 12345, ChannelCredentials.Insecure);
+            // for SSL/TLS connection
+            //var serverCred = new SslCredentials(File.ReadAllText(Path.Combine(Application.streamingAssetsPath, "server.crt")));
+            //this.channel = new Channel("test.example.com", 12345, serverCred);
             this.streamingClient = StreamingHubClient.Connect<IChatHub, IChatHubReceiver>(this.channel, this);
             this.RegisterDisconnectEvent(streamingClient);
             this.client = MagicOnionClient.Create<IChatService>(this.channel);


### PR DESCRIPTION
## TL;DR

Added TLS/SSL section to the README.

## Summary

This section inform users how to use SSL/TLS with gRPC/MagicOnion with following steps.

* generate certificate
* simulate dummy domain on localhost
* server configuration
* client configuration

Every explanation is code base, not with GUI base, for user friendly reproducibility.

Also added SSL/TLS lines to server/client implementation and comment them out.