### PR TITLE
Fix compatibility with Microsoft.Extensions.Hosting 3.0.0

### DIFF
--- a/sandbox/Sandbox.Hosting/Program.cs
+++ b/sandbox/Sandbox.Hosting/Program.cs
@@ -49,7 +49,7 @@ namespace Sandbox.Hosting
                 .RunConsoleAsync();
 
 
-            var isDevelopment = Environment.GetEnvironmentVariable("NETCORE_ENVIRONMENT") == "Development";
+            var isDevelopment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") == "Development";
             var creds = isDevelopment ? ChannelCredentials.Insecure : new SslCredentials(File.ReadAllText("./server.crt"));
 
             var clientMyService = MagicOnionClient.Create<IMyService>(new Channel("localhost", 12345, creds));

--- a/sandbox/Sandbox.Hosting/Properties/launchSettings.json
+++ b/sandbox/Sandbox.Hosting/Properties/launchSettings.json
@@ -1,15 +1,20 @@
 {
   "profiles": {
+    "Sandbox.Hosting": {
+      "commandName": "Project",
+      "environmentVariables": {
+      }
+    },
     "Sandbox.Hosting (Development)": {
       "commandName": "Project",
       "environmentVariables": {
-        "NETCORE_ENVIRONMENT": "Development"
+        "DOTNET_ENVIRONMENT": "Development"
       }
     },
     "Sandbox.Hosting (Production)": {
       "commandName": "Project",
       "environmentVariables": {
-        "NETCORE_ENVIRONMENT": "Production"
+        "DOTNET_ENVIRONMENT": "Production"
       }
     }
   }

--- a/src/MagicOnion.Hosting/MagicOnionHost.cs
+++ b/src/MagicOnion.Hosting/MagicOnionHost.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
@@ -97,6 +97,12 @@ namespace MagicOnion.Hosting
         internal static void ConfigureHostConfigurationHosting2_2(IHostBuilder builder)
         {
             builder.UseContentRoot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+
+            builder.ConfigureHostConfiguration(config =>
+            {
+                // NOTE: Treat prefix "DOTNET_" as the same as Microsoft.Extensions.Hosting 3.x.
+                config.AddEnvironmentVariables(prefix: "DOTNET_");
+            });
         }
 
         internal static void ConfigureAppConfigurationHosting2_2(IHostBuilder builder)

--- a/src/MagicOnion.Hosting/MagicOnionHost.cs
+++ b/src/MagicOnion.Hosting/MagicOnionHost.cs
@@ -97,11 +97,6 @@ namespace MagicOnion.Hosting
         internal static void ConfigureHostConfigurationHosting2_2(IHostBuilder builder)
         {
             builder.UseContentRoot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-
-            builder.ConfigureHostConfiguration(config =>
-            {
-                config.AddEnvironmentVariables(prefix: "NETCORE_");
-            });
         }
 
         internal static void ConfigureAppConfigurationHosting2_2(IHostBuilder builder)
@@ -132,6 +127,10 @@ namespace MagicOnion.Hosting
         {
             builder.ConfigureHostConfiguration(config =>
             {
+                // NOTE: This is backward compatibility for older versions.
+                // It's strongly recommended to use "DOTNET_" prefix expected by GenericHost. (e.g. DOTNET_ENVIRONMENT)
+                config.AddEnvironmentVariables(prefix: "NETCORE_");
+
                 config.AddInMemoryCollection(new[] { new KeyValuePair<string, string>(HostDefaults.ApplicationKey, Assembly.GetExecutingAssembly().GetName().Name) });
             });
 

--- a/src/MagicOnion.Hosting/MagicOnionHost.cs
+++ b/src/MagicOnion.Hosting/MagicOnionHost.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using MagicOnion.Hosting.Logging;
 using System.Reflection;
 
@@ -62,32 +63,48 @@ namespace MagicOnion.Hosting
         /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder CreateDefaultBuilder(bool useSimpleConsoleLogger, LogLevel minSimpleConsoleLoggerLogLevel, string hostEnvironmentVariable)
         {
-            var builder = new HostBuilder();
+            var builder = CreateDefaultBuilderHosting3_0_Or_Later() ??
+                          CreateDefaultBuilderHosting2_2();
 
             ConfigureHostConfigurationDefault(builder, hostEnvironmentVariable);
-            ConfigureAppConfigurationDefault(builder);
             ConfigureLoggingDefault(builder, useSimpleConsoleLogger, minSimpleConsoleLoggerLogLevel);
 
             return builder;
         }
 
-        internal static void ConfigureHostConfigurationDefault(IHostBuilder builder, string hostEnvironmentVariable)
+        private static IHostBuilder CreateDefaultBuilderHosting3_0_Or_Later()
+        {
+            // Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(string args[]);
+            var hostingHostType = Type.GetType("Microsoft.Extensions.Hosting.Host, Microsoft.Extensions.Hosting");
+            if (hostingHostType == null) return null;
+            var createDefaultBuilderMethod = hostingHostType.GetMethod("CreateDefaultBuilder", BindingFlags.Static | BindingFlags.Public, null, new[] { typeof(string[]) }, null);
+
+            return (IHostBuilder)createDefaultBuilderMethod.Invoke(null, new [] { default(string) });
+        }
+
+        // TODO: When upgrading Microsoft.Extensions.Hosting to v3.x, We need to remove these workarounds and use `Host.CreateDefaultBuilder`.
+        #region Implementation for Microsoft.Extensions.Hosting 2.2
+        private static IHostBuilder CreateDefaultBuilderHosting2_2()
+        {
+            var builder = new HostBuilder();
+
+            ConfigureHostConfigurationHosting2_2(builder);
+            ConfigureAppConfigurationHosting2_2(builder);
+
+            return builder;
+        }
+
+        internal static void ConfigureHostConfigurationHosting2_2(IHostBuilder builder)
         {
             builder.UseContentRoot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
 
             builder.ConfigureHostConfiguration(config =>
             {
                 config.AddEnvironmentVariables(prefix: "NETCORE_");
-                config.AddInMemoryCollection(new[] { new KeyValuePair<string, string>(HostDefaults.ApplicationKey, Assembly.GetExecutingAssembly().GetName().Name) });
             });
-
-            if (!string.IsNullOrWhiteSpace(hostEnvironmentVariable))
-            {
-                builder.UseEnvironment(System.Environment.GetEnvironmentVariable(hostEnvironmentVariable) ?? "Production");
-            }
         }
 
-        internal static void ConfigureAppConfigurationDefault(IHostBuilder builder)
+        internal static void ConfigureAppConfigurationHosting2_2(IHostBuilder builder)
         {
             builder.ConfigureAppConfiguration((hostingContext, config) =>
             {
@@ -109,6 +126,20 @@ namespace MagicOnion.Hosting
                 config.AddEnvironmentVariables();
             });
         }
+        #endregion
+
+        internal static void ConfigureHostConfigurationDefault(IHostBuilder builder, string hostEnvironmentVariable)
+        {
+            builder.ConfigureHostConfiguration(config =>
+            {
+                config.AddInMemoryCollection(new[] { new KeyValuePair<string, string>(HostDefaults.ApplicationKey, Assembly.GetExecutingAssembly().GetName().Name) });
+            });
+
+            if (!string.IsNullOrWhiteSpace(hostEnvironmentVariable))
+            {
+                builder.UseEnvironment(System.Environment.GetEnvironmentVariable(hostEnvironmentVariable) ?? "Production");
+            }
+        }
 
         internal static void ConfigureLoggingDefault(IHostBuilder builder, bool useSimpleConsoleLogger, LogLevel minSimpleConsoleLoggerLogLevel)
         {
@@ -116,6 +147,13 @@ namespace MagicOnion.Hosting
             {
                 builder.ConfigureLogging(logging =>
                 {
+                    // Use SimpleConsoleLogger instead of the default ConsoleLogger.
+                    var consoleLogger = logging.Services.FirstOrDefault(x => x.ImplementationType?.FullName == "Microsoft.Extensions.Logging.Console.ConsoleLoggerProvider");
+                    if (consoleLogger != null)
+                    {
+                        logging.Services.Remove(consoleLogger);
+                    }
+
                     logging.AddSimpleConsole();
                     logging.AddFilter<SimpleConsoleLoggerProvider>((category, level) =>
                     {


### PR DESCRIPTION
When a project is running MagicOnion.Hosting with Microsoft.Extensions.Hosting 3.0.0, `MagicOnionHost.CreateDefaultBuilder` throws exception.

Because, Microsoft.Extensions.Hosting 3.0.0 deprecated `IHostingEnvironment` and changed `HostingEnvironment` property type of `HostBuilderContext`. As a result, `MagicOnionHost` is incompatible with Microsoft.Extensions.Hosting 3.0.0.

- ref: https://github.com/aspnet/Announcements/issues/344