### PR TITLE
Fix logging configurations.

### DIFF
--- a/sandbox/Sandbox.Hosting/appsettings.json
+++ b/sandbox/Sandbox.Hosting/appsettings.json
@@ -38,5 +38,14 @@
         ]
       }
     ]
+  },
+  "Logging": {
+    "MagicOnion.Hosting.Logging.SimpleConsoleLoggerProvider": {
+      "LogLevel": {
+        "Default": "Trace",
+        "System": "Information",
+        "Microsoft": "Information"
+      }
+    }
   }
 }

--- a/src/MagicOnion.Hosting/MagicOnion.Hosting.csproj
+++ b/src/MagicOnion.Hosting/MagicOnion.Hosting.csproj
@@ -30,6 +30,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
     </ItemGroup>
 

--- a/src/MagicOnion.Hosting/MagicOnionHost.cs
+++ b/src/MagicOnion.Hosting/MagicOnionHost.cs
@@ -169,15 +169,20 @@ namespace MagicOnion.Hosting
                     }
 
                     logging.AddSimpleConsole();
-                    logging.AddFilter<SimpleConsoleLoggerProvider>((category, level) =>
+                    logging.AddFilter((providerName, category, level) =>
                     {
-                        // omit system message
-                        if (category.StartsWith("Microsoft.Extensions.Hosting.Internal"))
+                        if (providerName == typeof(SimpleConsoleLogger).FullName)
                         {
-                            if (level <= LogLevel.Debug) return false;
+                            // omit system message
+                            if (category.StartsWith("Microsoft.Extensions.Hosting.Internal"))
+                            {
+                                if (level <= LogLevel.Debug) return false;
+                            }
+
+                            return level >= minSimpleConsoleLoggerLogLevel;
                         }
 
-                        return level >= minSimpleConsoleLoggerLogLevel;
+                        return true;
                     });
                 });
             }

--- a/src/MagicOnion.Hosting/MagicOnionHost.cs
+++ b/src/MagicOnion.Hosting/MagicOnionHost.cs
@@ -90,6 +90,7 @@ namespace MagicOnion.Hosting
 
             ConfigureHostConfigurationHosting2_2(builder);
             ConfigureAppConfigurationHosting2_2(builder);
+            ConfigureLoggingHosting2_2(builder);
 
             return builder;
         }
@@ -125,6 +126,14 @@ namespace MagicOnion.Hosting
                 }
 
                 config.AddEnvironmentVariables();
+            });
+        }
+
+        internal static void ConfigureLoggingHosting2_2(IHostBuilder builder)
+        {
+            builder.ConfigureLogging((hostContext, logging) =>
+            {
+                logging.AddConfiguration(hostContext.Configuration.GetSection("Logging"));
             });
         }
         #endregion


### PR DESCRIPTION
This PR fixes two problems with logging configurations.

1. Logging configurations are ignored when running with Microsoft.Extensions.Hosting 2.2. (https://github.com/Cysharp/MagicOnion/commit/e842cf0bec987fde6c28769f7e059a5cf89ec714)
2. Logging configuration for `SimpleConsoleLoggerProvider` is always ignored. (https://github.com/Cysharp/MagicOnion/commit/45568935f2147e6124b93ff1006d1eb7bb9ec46d)