### PR TITLE
Hide a invoke filter helper method in a stack trace.

### DIFF
--- a/sandbox/Sandbox.Hosting/Program.cs
+++ b/sandbox/Sandbox.Hosting/Program.cs
@@ -22,7 +22,7 @@ namespace Sandbox.Hosting
 
             var hostTask = MagicOnionHost.CreateDefaultBuilder()
                 //.UseMagicOnion()
-                .UseMagicOnion(types: new[] { typeof(MyService) })
+                .UseMagicOnion(types: new[] { typeof(MyService), typeof(MyHub) })
                 .UseMagicOnion(configurationName: "MagicOnion-Management", types: new[] { typeof(ManagementService) })
                 .ConfigureServices((hostContext, services) =>
                 {
@@ -34,6 +34,8 @@ namespace Sandbox.Hosting
                             // options.Service.GlobalStreamingHubFilters.Add(new MyStreamingHubFilterAttribute(logger));
 
                             options.Service.GlobalFilters.Add<MyFilterAttribute>();
+                            options.Service.GlobalFilters.Add<MyFilter2Attribute>();
+                            options.Service.GlobalFilters.Add<MyFilter3Attribute>();
                             // options.Service.GlobalFilters.Add(new MyFilterAttribute(logger));
 
                             // options.ServerPorts = new[]{ new MagicOnionHostingServerPortOptions(){ Port = opti
@@ -56,6 +58,9 @@ namespace Sandbox.Hosting
             var clientManagementService = MagicOnionClient.Create<IManagementService>(new Channel("localhost", 23456, creds));
             var result = await clientMyService.HelloAsync();
             var result2 = await clientManagementService.FooBarAsync();
+
+            var clientHub = StreamingHubClient.Connect<IMyHub, IMyHubReceiver>(new Channel("localhost", 12345, creds), null);
+            var result3 = await clientHub.HelloAsync();
 
             await hostTask;
         }
@@ -95,6 +100,17 @@ namespace Sandbox.Hosting
         }
     }
 
+    public class MyFilter2Attribute : MagicOnionFilterAttribute
+    {
+        public override async ValueTask Invoke(ServiceContext context, Func<ServiceContext, ValueTask> next) => await next(context);
+    }
+
+
+    public class MyFilter3Attribute : MagicOnionFilterAttribute
+    {
+        public override async ValueTask Invoke(ServiceContext context, Func<ServiceContext, ValueTask> next) => await next(context);
+    }
+
     public interface IMyService : IService<IMyService>
     {
         UnaryResult<string> HelloAsync();
@@ -120,6 +136,21 @@ namespace Sandbox.Hosting
         public async UnaryResult<int> FooBarAsync()
         {
             return 123456789;
+        }
+    }
+
+    public interface IMyHub : IStreamingHub<IMyHub, IMyHubReceiver>
+    {
+        Task<string> HelloAsync();
+    }
+    public interface IMyHubReceiver
+    { }
+
+    public class MyHub : StreamingHubBase<IMyHub, IMyHubReceiver>, IMyHub
+    {
+        public Task<string> HelloAsync()
+        {
+            return Task.FromResult("Konnnichiwa!");
         }
     }
 }

--- a/src/MagicOnion/Server/Hubs/StreamingHubHandler.cs
+++ b/src/MagicOnion/Server/Hubs/StreamingHubHandler.cs
@@ -167,8 +167,7 @@ namespace MagicOnion.Server.Hubs
             foreach (var filterFactory in this.filters.Reverse())
             {
                 var newFilter = filterFactory.CreateInstance(serviceLocator);
-                var next_ = next; // capture reference
-                next = (ctx) => newFilter.Invoke(ctx, next_);
+                next = new InvokeHelper<StreamingHubContext, Func<StreamingHubContext, ValueTask>>(newFilter.Invoke, next).GetDelegate();
             }
 
             return next;

--- a/src/MagicOnion/Server/InvokeHelper.cs
+++ b/src/MagicOnion/Server/InvokeHelper.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MagicOnion.Server
+{
+    internal class InvokeHelper<TArg1, TDelegate>
+        where TDelegate : Delegate
+    {
+        public Func<TArg1, TDelegate, ValueTask> Invoke;
+        public TDelegate Next;
+
+        private static readonly Func<InvokeHelper<TArg1, TDelegate>, TDelegate> InvokeNextFactory;
+
+        static InvokeHelper()
+        {
+            var fieldInvoke = typeof(InvokeHelper<TArg1, TDelegate>).GetField("Invoke");
+            var fieldNext = typeof(InvokeHelper<TArg1, TDelegate>).GetField("Next");
+            var methodInvoke = typeof(Func<TArg1, TDelegate, ValueTask>).GetMethod("Invoke");
+
+            if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Core") && Environment.Version > new Version(3, 0, 0))
+            {
+                // HACK: If the app is running on .NET Core 2.2 or earlier, the runtime hides dynamic method in the stack trace.
+                var method = new DynamicMethod("InvokeNext", typeof(ValueTask), new[] { typeof(InvokeHelper<TArg1, TDelegate>), typeof(TArg1) }, restrictedSkipVisibility: true);
+                {
+                    var il = method.GetILGenerator();
+
+                    // arg0.Invoke;
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, fieldInvoke);
+
+                    // return arg0.Invoke(arg1)
+                    il.Emit(OpCodes.Ldarg_1);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, fieldNext);
+                    il.Emit(OpCodes.Callvirt, methodInvoke);
+                    il.Emit(OpCodes.Ret);
+                }
+
+                InvokeNextFactory = (helper) => (TDelegate)method.CreateDelegate(typeof(TDelegate), helper);
+
+            }
+            else
+            {
+                // HACK: If the app is running on .NET Core 3.0 or later, the runtime hides `AggressiveInlining` method in the stack trace. (If the app is running on .NET Framework 4.x, This hack does not affect.)
+                // https://github.com/dotnet/coreclr/blob/release/3.0/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs#L343-L350
+                InvokeNextFactory = (helper) =>
+                {
+                    var invokeNext = new Func<TArg1, ValueTask>(helper.InvokeNext);
+                    return (TDelegate)Delegate.CreateDelegate(typeof(TDelegate), invokeNext.Target, invokeNext.Method);
+                };
+            }
+        }
+
+        public InvokeHelper(Func<TArg1, TDelegate, ValueTask> invoke, TDelegate next)
+        {
+            Invoke = invoke;
+            Next = next;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [DebuggerHidden]
+        private ValueTask InvokeNext(TArg1 arg1) => Invoke(arg1, Next);
+
+        public TDelegate GetDelegate() => InvokeNextFactory(this);
+    }
+}

--- a/src/MagicOnion/Server/MethodHandler.cs
+++ b/src/MagicOnion/Server/MethodHandler.cs
@@ -292,8 +292,7 @@ namespace MagicOnion.Server
             foreach (var filterFactory in this.filters.Reverse())
             {
                 var newFilter = filterFactory.CreateInstance(serviceLocator);
-                var next_ = next; // capture reference
-                next = (ctx) => newFilter.Invoke(ctx, next_);
+                next = new InvokeHelper<ServiceContext, Func<ServiceContext, ValueTask>>(newFilter.Invoke, next).GetDelegate();
             }
 
             return next;


### PR DESCRIPTION
If an app is running on .NET Core, Hide a invoke filter helper method in a stack trace by using a **hack**.

## Before
![image](https://user-images.githubusercontent.com/9012/68530724-6ed4e580-034e-11ea-91c2-3aea9006375d.png)

```
   at Sandbox.Hosting.MyService.HelloAsync() in C:\Users\Tomoyo\Source\Repos\MagicOnion\sandbox\Sandbox.Hosting\Program.cs:line 147
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at MagicOnion.CompilerServices.AsyncUnaryResultMethodBuilder`1.Start[TStateMachine](TStateMachine& stateMachine) in C:\Users\Tomoyo\Source\Repos\MagicOnion\src\MagicOnion\CompilerServices\AsyncUnaryResultMethodBuilder.cs:line 21
   at Sandbox.Hosting.MyService.HelloAsync()
   at lambda_method(Closure , ServiceContext )
   at Sandbox.Hosting.MyFilter3Attribute.Invoke(ServiceContext context, Func`2 next) in C:\Users\Tomoyo\Source\Repos\MagicOnion\sandbox\Sandbox.Hosting\Program.cs:line 130
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Sandbox.Hosting.MyFilter3Attribute.Invoke(ServiceContext context, Func`2 next)
   at MagicOnion.Server.MethodHandler.<>c__DisplayClass45_0.<BuildMethodBodyWithFilter>b__0(ServiceContext ctx) in C:\Users\Tomoyo\Source\Repos\MagicOnion\src\MagicOnion\Server\MethodHandler.cs:line 296
   at Sandbox.Hosting.MyFilter2Attribute.Invoke(ServiceContext context, Func`2 next) in C:\Users\Tomoyo\Source\Repos\MagicOnion\sandbox\Sandbox.Hosting\Program.cs:line 112
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Sandbox.Hosting.MyFilter2Attribute.Invoke(ServiceContext context, Func`2 next)
   at MagicOnion.Server.MethodHandler.<>c__DisplayClass45_0.<BuildMethodBodyWithFilter>b__0(ServiceContext ctx) in C:\Users\Tomoyo\Source\Repos\MagicOnion\src\MagicOnion\Server\MethodHandler.cs:line 296
   at Sandbox.Hosting.MyFilterAttribute.Invoke(ServiceContext context, Func`2 next) in C:\Users\Tomoyo\Source\Repos\MagicOnion\sandbox\Sandbox.Hosting\Program.cs:line 95
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Sandbox.Hosting.MyFilterAttribute.Invoke(ServiceContext context, Func`2 next)
   at MagicOnion.Server.MethodHandler.<>c__DisplayClass45_0.<BuildMethodBodyWithFilter>b__0(ServiceContext ctx) in C:\Users\Tomoyo\Source\Repos\MagicOnion\src\MagicOnion\Server\MethodHandler.cs:line 296
   at MagicOnion.Server.MethodHandler.UnaryServerMethod[TRequest,TResponse](Byte[] request, ServerCallContext context) in C:\Users\Tomoyo\Source\Repos\MagicOnion\src\MagicOnion\Server\MethodHandler.cs:line 367
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at MagicOnion.Server.MethodHandler.UnaryServerMethod[TRequest,TResponse](Byte[] request, ServerCallContext context)
   at Grpc.Core.Internal.UnaryServerCallHandler`2.HandleCall(ServerRpcNew newRpc, CompletionQueueSafeHandle cq)
```

## After
![image](https://user-images.githubusercontent.com/9012/68530758-b196bd80-034e-11ea-86fb-5536d47b2180.png)

```
   at Sandbox.Hosting.MyService.HelloAsync() in C:\Users\Tomoyo\Source\Repos\MagicOnion\sandbox\Sandbox.Hosting\Program.cs:line 147
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at MagicOnion.CompilerServices.AsyncUnaryResultMethodBuilder`1.Start[TStateMachine](TStateMachine& stateMachine) in C:\Users\Tomoyo\Source\Repos\MagicOnion\src\MagicOnion\CompilerServices\AsyncUnaryResultMethodBuilder.cs:line 21
   at Sandbox.Hosting.MyService.HelloAsync()
   at lambda_method(Closure , ServiceContext )
   at Sandbox.Hosting.MyFilter3Attribute.Invoke(ServiceContext context, Func`2 next) in C:\Users\Tomoyo\Source\Repos\MagicOnion\sandbox\Sandbox.Hosting\Program.cs:line 130
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Sandbox.Hosting.MyFilter3Attribute.Invoke(ServiceContext context, Func`2 next)
   at Sandbox.Hosting.MyFilter2Attribute.Invoke(ServiceContext context, Func`2 next) in C:\Users\Tomoyo\Source\Repos\MagicOnion\sandbox\Sandbox.Hosting\Program.cs:line 112
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Sandbox.Hosting.MyFilter2Attribute.Invoke(ServiceContext context, Func`2 next)
   at Sandbox.Hosting.MyFilterAttribute.Invoke(ServiceContext context, Func`2 next) in C:\Users\Tomoyo\Source\Repos\MagicOnion\sandbox\Sandbox.Hosting\Program.cs:line 95
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Sandbox.Hosting.MyFilterAttribute.Invoke(ServiceContext context, Func`2 next)
   at MagicOnion.Server.MethodHandler.UnaryServerMethod[TRequest,TResponse](Byte[] request, ServerCallContext context) in C:\Users\Tomoyo\Source\Repos\MagicOnion\src\MagicOnion\Server\MethodHandler.cs:line 365
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at MagicOnion.Server.MethodHandler.UnaryServerMethod[TRequest,TResponse](Byte[] request, ServerCallContext context)
   at Grpc.Core.Internal.UnaryServerCallHandler`2.HandleCall(ServerRpcNew newRpc, CompletionQueueSafeHandle cq)
```