### PR TITLE
feat: use UNITY_PACKAGE_VERSION to specify package version on export

### DIFF
--- a/src/MagicOnion.Client.Unity/Assets/Scripts/Editor/PackageExporter.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/Editor/PackageExporter.cs
@@ -9,14 +9,17 @@ public static class PackageExporter
     [MenuItem("Tools/Export Unitypackage")]
     public static void Export()
     {
+        var version = Environment.GetEnvironmentVariable("UNITY_PACKAGE_VERSION");
+
         // configure
-        var exportPath = "./MagicOnion.Client.Unity.unitypackage";
         var roots = new[]
         {
             "Scripts/MagicOnion",
             "Scripts/MagicOnion.Abstractions",
             "Scripts/MagicOnion.Unity",
         };
+        var fileName = string.IsNullOrEmpty(version) ? "MagicOnion.Client.Unity.unitypackage" : $"MagicOnion.Client.Unity.{version}.unitypackage";
+        var exportPath = "./" + fileName;
 
         var packageTargetAssets = roots
             .SelectMany(root =>


### PR DESCRIPTION
## TL;DR

* Add version info to Exported unity package.

## Summary

Follow to other Unity Repository, in this case ZLogger.

> https://github.com/Cysharp/ZLogger/blob/4983386ec686ca80d2e6335569e39e1168c73f11/src/ZLogger.Unity/Assets/Editor/PackageExporter.cs