### PR TITLE
chore: bump dotnet core to 3.1.202 addresss security vulnerabilities

### DIFF
--- a/.github/workflows/build-canary.yml
+++ b/.github/workflows/build-canary.yml
@@ -13,7 +13,7 @@ jobs:
     if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]'))"
     strategy:
       matrix:
-        dotnet: ["3.1.201"] # support latest only
+        dotnet: ["3.1.202"] # support latest only
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -16,7 +16,7 @@ jobs:
     if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]'))"
     strategy:
       matrix:
-        dotnet: ["3.1.201"] # support latest only
+        dotnet: ["3.1.202"] # support latest only
     runs-on: ubuntu-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,7 +9,7 @@ jobs:
   build-dotnet:
     strategy:
       matrix:
-        dotnet: ["3.1.201"] # support latest only
+        dotnet: ["3.1.202"] # support latest only
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:


### PR DESCRIPTION
## TL;DR

.NET SDK 3.1.202 addresses security vulnerabilities.

## Ref

> https://github.com/dotnet/core/blob/eda7ba66218cb4354293b6991c66d0b9bc13c853/release-notes/3.1/3.1.4/3.1.4.md#cve-2020-1108-net-core-denial-of-service-vulnerability