### PR TITLE
fix: open telemetry metrics format to fit prometheus scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -1505,6 +1505,8 @@ Default configuration key is `MagicOnion:OpenTelemery`.
 MagicOnion.OpenTelemetry offers extensions for IServiceCollection, `AddMagicOnionOpenTelemetry`.
 Register `MagicOnionOpenTelemetryOptions`, `Action<MagicOnionOpenTelemetryMeterFactoryOption>` and `Action<TracerBuilder>` to configure MeterFactory & TracerFactory.
 
+> TIPS: `AddMagicOnionOpenTelemetry` register MagicOnionOpenTelemetryOptions, MeterFactory and TracerFactory as Singleton for you.
+
 ```csharp
 await MagicOnionHost.CreateDefaultBuilder()
     .UseMagicOnion()
@@ -1527,7 +1529,6 @@ await MagicOnionHost.CreateDefaultBuilder()
     })
 ```
 
-`AddMagicOnionOpenTelemetry` register MagicOnionOpenTelemetryOptions, MeterFactory and TracerFactory as Singleton for you.
 
 **(optional) add PrometheusExporterMetricsService for prometheus exporter.**
 
@@ -1579,7 +1580,7 @@ await MagicOnionHost.CreateDefaultBuilder()
         {
             options.Service.GlobalFilters.Add(new OpenTelemetryCollectorFilterAttribute());
             options.Service.GlobalStreamingHubFilters.Add(new OpenTelemetryHubCollectorFilterAttribute());
-            options.Service.MagicOnionLogger = new OpenTelemetryCollectorLogger(meterFactory, null);
+            options.Service.MagicOnionLogger = new OpenTelemetryCollectorLogger(meterFactory);
         });
     })
     .RunConsoleAsync();
@@ -1607,31 +1608,34 @@ Zipkin tracer will be shown as below.
 Prometheus Metrics will be shown as like follows.
 
 ```txt
-MagicOnion_measure_StreamingHubRequest{MagicOnion_keys_Method="/IChatHub/LeaveAsync"} 9 1589966049901
-MagicOnion_measure_StreamingHubRequest{MagicOnion_keys_Method="/IChatHub/GenerateException"} 0 1589966049901
-MagicOnion_measure_StreamingHubRequest{MagicOnion_keys_Method="/IChatHub/SendMessageAsync"} 9 1589966049901
-MagicOnion_measure_StreamingHubRequest{MagicOnion_keys_Method="/IChatHub/JoinAsync"} 0 1589966049901
-# HELP MagicOnion_measure_StreamingHubDisconnectMagicOnionMagicOnion/measure/StreamingHubDisconnect
-# TYPE MagicOnion_measure_StreamingHubDisconnect counter
-MagicOnion_measure_StreamingHubDisconnect{MagicOnion_keys_Method="/IChatHub/Connect"} 1 1589966049901
-# HELP MagicOnion_measure_UnaryRequestMagicOnionMagicOnion/measure/UnaryRequest
-# TYPE MagicOnion_measure_UnaryRequest counter
-MagicOnion_measure_UnaryRequest{MagicOnion_keys_Method="/IChatService/GenerateException"} 1 1589966049901
-# HELP MagicOnion_measure_StreamingHubConnectMagicOnionMagicOnion/measure/StreamingHubConnect
-# TYPE MagicOnion_measure_StreamingHubConnect counter
-MagicOnion_measure_StreamingHubConnect{MagicOnion_keys_Method="/IChatHub/Connect"} 0 1589966049901
-# HELP MagicOnion_measure_UnaryResponseSizeMagicOnionMagicOnion/measure/UnaryResponseSize
-# TYPE MagicOnion_measure_UnaryResponseSize summary
-MagicOnion/measure/UnaryResponseSize_sum{MagicOnion_keys_Method="/IChatService/GenerateException"} 0 1589966049901
-MagicOnion/measure/UnaryResponseSize_count{MagicOnion_keys_Method="/IChatService/GenerateException"} 1 1589966049901
-MagicOnion/measure/UnaryResponseSize{MagicOnion_keys_Method="/IChatService/GenerateException",quantile="0"} 0 1589966049901
-MagicOnion/measure/UnaryResponseSize{MagicOnion_keys_Method="/IChatService/GenerateException",quantile="1"} 0 1589966049901
-# HELP MagicOnion_measure_StreamingHubElapsedMagicOnionMagicOnion/measure/StreamingHubElapsed
-# TYPE MagicOnion_measure_StreamingHubElapsed summary
-MagicOnion/measure/StreamingHubElapsed_sum{MagicOnion_keys_Method="/IChatHub/LeaveAsync"} 4.108 1589966049901
-MagicOnion/measure/StreamingHubElapsed_count{MagicOnion_keys_Method="/IChatHub/LeaveAsync"} 1 1589966049901
-MagicOnion/measure/StreamingHubElapsed{MagicOnion_keys_Method="/IChatHub/LeaveAsync",quantile="0"} 4.108 1589966049901
-MagicOnion/measure/StreamingHubElapsed{MagicOnion_keys_Method="/IChatHub/LeaveAsync",quantile="1"} 4.108 1589966049901
+# HELP magiconion_buildservicedefinition_duration_millisecondsMagicOnionmagiconion_buildservicedefinition_duration_milliseconds
+# TYPE magiconion_buildservicedefinition_duration_milliseconds summary
+magiconion_buildservicedefinition_duration_milliseconds_sum{method="EndBuildServiceDefinition"} 0 1591066746669
+magiconion_buildservicedefinition_duration_milliseconds_count{method="EndBuildServiceDefinition"} 0 1591066746669
+magiconion_buildservicedefinition_duration_milliseconds{method="EndBuildServiceDefinition",quantile="0"} 1.7976931348623157E+308 1591066746669
+magiconion_buildservicedefinition_duration_milliseconds{method="EndBuildServiceDefinition",quantile="1"} -1.7976931348623157E+308 1591066746669
+# HELP magiconion_broadcast_request_sizeMagicOnionmagiconion_broadcast_request_size
+# TYPE magiconion_broadcast_request_size summary
+magiconion_broadcast_request_size_sum{GroupName="SampleRoom"} 0 1591066746669
+magiconion_broadcast_request_size_count{GroupName="SampleRoom"} 0 1591066746669
+magiconion_broadcast_request_size{GroupName="SampleRoom",quantile="0"} 9.223372036854776E+18 1591066746669
+magiconion_broadcast_request_size{GroupName="SampleRoom",quantile="1"} -9.223372036854776E+18 1591066746669
+# HELP magiconion_streaminghub_elapsed_millisecondsMagicOnionmagiconion_streaminghub_elapsed_milliseconds
+# TYPE magiconion_streaminghub_elapsed_milliseconds summary
+magiconion_streaminghub_elapsed_milliseconds_sum{methodType="DuplexStreaming"} 0 1591066746669
+magiconion_streaminghub_elapsed_milliseconds_count{methodType="DuplexStreaming"} 0 1591066746669
+magiconion_streaminghub_elapsed_milliseconds{methodType="DuplexStreaming",quantile="0"} 1.7976931348623157E+308 1591066746669
+magiconion_streaminghub_elapsed_milliseconds{methodType="DuplexStreaming",quantile="1"} -1.7976931348623157E+308 1591066746670
+# HELP magiconion_unary_response_sizeMagicOnionmagiconion_unary_response_size
+# TYPE magiconion_unary_response_size summary
+magiconion_unary_response_size_sum{method="/IChatService/GenerateException"} 0 1591066746669
+magiconion_unary_response_size_count{method="/IChatService/GenerateException"} 0 1591066746669
+magiconion_unary_response_size{method="/IChatService/GenerateException",quantile="0"} 9.223372036854776E+18 1591066746669
+magiconion_unary_response_size{method="/IChatService/GenerateException",quantile="1"} -9.223372036854776E+18 1591066746669
+magiconion_unary_response_size_sum{methodType="Unary"} 0 1591066746669
+magiconion_unary_response_size_count{methodType="Unary"} 0 1591066746669
+magiconion_unary_response_size{methodType="Unary",quantile="0"} 9.223372036854776E+18 1591066746669
+magiconion_unary_response_size{methodType="Unary",quantile="1"} -9.223372036854776E+18 1591066746669
 ```
 
 You may find `MagicOnion/measure/BuildServiceDefinition{MagicOnion_keys_Method="EndBuildServiceDefinition",quantile="0"}` are collected, and other metrics will shown as #HELP.
@@ -1643,14 +1647,23 @@ They will export when Unary/StreamingHub request is comming.
 
 Add defaultTags when register `OpenTelemetryCollectorLogger`.
 
+* Want replace magiconion metrics prefix to my magiconion metrics.
+
+Set metricsPrefix when register `OpenTelemetryCollectorLogger`.
+If you pass `yourprefix`, then metrics prefix will change to followings.
+
+```
+yourprefix_buildservicedefinition_duration_milliseconds_sum{method="EndBuildServiceDefinition"} 66.7148 1591066185908
+```
+
 * Want contain `version` tag to your metrics.
 
-Add version when register `OpenTelemetryCollectorLogger`
+Add version when register `OpenTelemetryCollectorLogger`.
 
 This should output like follows, however current opentelemetry-dotnet Prometheus exporter not respect version tag.
 
 ```
-MagicOnion/measure/BuildServiceDefinition_count{MagicOnion_keys_Method="EndBuildServiceDefinition",version="1.0.0"}
+magiconion_buildservicedefinition_duration_milliseconds_sum{method="EndBuildServiceDefinition",version="1.0.0"} 66.7148 1591066185908
 ```
 
 #### try visualization on localhost

--- a/src/MagicOnion.OpenTelemetry/OpenTelemetryCollectorLogger.cs
+++ b/src/MagicOnion.OpenTelemetry/OpenTelemetryCollectorLogger.cs
@@ -171,7 +171,7 @@ namespace MagicOnion.OpenTelemetry
             var spanContext = default(SpanContext);
             var label = CreateLabel(context);
             streamingHubElapsedMeasure.Record(spanContext, elapsed, label);
-            streamingHubRequestCounter.Add(spanContext, responseSize, label);
+            streamingHubResponseSizeMeasure.Record(spanContext, responseSize, label);
             if (isErrorOrInterrupted)
             {
                 streamingHubErrorCounter.Add(spanContext, 1, label);

--- a/src/MagicOnion.OpenTelemetry/OpenTelemetryCollectorLogger.cs
+++ b/src/MagicOnion.OpenTelemetry/OpenTelemetryCollectorLogger.cs
@@ -15,15 +15,18 @@ namespace MagicOnion.OpenTelemetry
     /// </summary>
     public class OpenTelemetryCollectorLogger : IMagicOnionLogger
     {
-        static readonly string MethodKey = "MagicOnion/keys/Method";
+        static readonly string MethodKey = "method";
+        static readonly string MethodTypeKey = "methodType";
         readonly IEnumerable<KeyValuePair<string, string>> defaultLabels;
         readonly ConcurrentDictionary<string, HashSet<KeyValuePair<string, string>>> labelCache = new ConcurrentDictionary<string, HashSet<KeyValuePair<string, string>>>();
+        readonly ConcurrentDictionary<string, HashSet<KeyValuePair<string, string>>> broadcastLabelCache = new ConcurrentDictionary<string, HashSet<KeyValuePair<string, string>>>();
 
         readonly MeasureMetric<double> buildServiceDefinitionMeasure;
         readonly CounterMetric<long> unaryRequestCounter;
         readonly MeasureMetric<long> unaryResponseSizeMeasure;
         readonly CounterMetric<long> unaryErrorCounter;
         readonly MeasureMetric<double> unaryElapsedMeasure;
+
         readonly CounterMetric<long> streamingHubErrorCounter;
         readonly MeasureMetric<double> streamingHubElapsedMeasure;
         readonly CounterMetric<long> streamingHubRequestCounter;
@@ -31,7 +34,11 @@ namespace MagicOnion.OpenTelemetry
         readonly CounterMetric<long> streamingHubConnectCounter;
         readonly CounterMetric<long> streamingHubDisconnectCounter;
 
-        public OpenTelemetryCollectorLogger(MeterFactory meterFactory, string version = null, IEnumerable<KeyValuePair<string, string>> defaultLabels = null)
+        readonly CounterMetric<long> broadcastRequestCounter;
+        readonly MeasureMetric<long> broadcastRequestSizeMeasure;
+        readonly CounterMetric<long> broadcastGroupCounter;
+
+        public OpenTelemetryCollectorLogger(MeterFactory meterFactory, string metricsPrefix = "magiconion", string version = null, IEnumerable<KeyValuePair<string, string>> defaultLabels = null)
         {
             if (meterFactory == null) throw new ArgumentNullException(nameof(meterFactory));
 
@@ -42,28 +49,37 @@ namespace MagicOnion.OpenTelemetry
             var meter = meterFactory.GetMeter("MagicOnion", version);
 
             // Service build time. ms
-            buildServiceDefinitionMeasure = meter.CreateDoubleMeasure("MagicOnion/measure/BuildServiceDefinition"); // sum
+            buildServiceDefinitionMeasure = meter.CreateDoubleMeasure($"{metricsPrefix}_buildservicedefinition_duration_milliseconds"); // sum
+
             // Unary request count. num
-            unaryRequestCounter = meter.CreateInt64Counter("MagicOnion/measure/UnaryRequest"); // sum
+            unaryRequestCounter = meter.CreateInt64Counter($"{metricsPrefix}_unary_requests_count"); // sum
             // Unary API response size. bytes
-            unaryResponseSizeMeasure = meter.CreateInt64Measure("MagicOnion/measure/UnaryResponseSize"); // sum
+            unaryResponseSizeMeasure = meter.CreateInt64Measure($"{metricsPrefix}_unary_response_size"); // sum
             // Unary API error Count. num
-            unaryErrorCounter = meter.CreateInt64Counter("MagicOnion/measure/UnaryErrorCount"); // sum
+            unaryErrorCounter = meter.CreateInt64Counter($"{metricsPrefix}_unary_error_count"); // sum
             // Unary API elapsed time. ms
-            unaryElapsedMeasure = meter.CreateDoubleMeasure("MagicOnion/measure/UnaryElapsed"); // sum
+            unaryElapsedMeasure = meter.CreateDoubleMeasure($"{metricsPrefix}_unary_elapsed_milliseconds"); // sum
+
             // StreamingHub API error Count. num
-            streamingHubErrorCounter = meter.CreateInt64Counter("MagicOnion/measure/StreamingHubErrorCount"); // sum
+            streamingHubErrorCounter = meter.CreateInt64Counter($"{metricsPrefix}_streaminghub_error_count"); // sum
             // StreamingHub API elapsed time. ms
-            streamingHubElapsedMeasure = meter.CreateDoubleMeasure("MagicOnion/measure/StreamingHubElapsed"); // sum
+            streamingHubElapsedMeasure = meter.CreateDoubleMeasure($"{metricsPrefix}_streaminghub_elapsed_milliseconds"); // sum
             // StreamingHub request count. num
-            streamingHubRequestCounter = meter.CreateInt64Counter("MagicOnion/measure/StreamingHubRequest"); // sum
+            streamingHubRequestCounter = meter.CreateInt64Counter($"{metricsPrefix}_streaminghub_requests_count"); // sum
             // StreamingHub API response size. bytes
-            streamingHubResponseSizeMeasure = meter.CreateInt64Measure("MagicOnion/measure/StreamingHubResponseSize"); // sum
+            streamingHubResponseSizeMeasure = meter.CreateInt64Measure($"{metricsPrefix}_streaminghub_response_size"); // sum
             // ConnectCount - DisconnectCount = current connect count. (successfully disconnected)
             // StreamingHub connect count. num
-            streamingHubConnectCounter = meter.CreateInt64Counter("MagicOnion/measure/StreamingHubConnect"); // sum
+            streamingHubConnectCounter = meter.CreateInt64Counter($"{metricsPrefix}_streaminghub_connect_count"); // sum
             // StreamingHub disconnect count. num
-            streamingHubDisconnectCounter = meter.CreateInt64Counter("MagicOnion/measure/StreamingHubDisconnect"); // sum
+            streamingHubDisconnectCounter = meter.CreateInt64Counter($"{metricsPrefix}_streaminghub_disconnect_count"); // sum
+
+            // HubBroadcast request count. num
+            broadcastRequestCounter = meter.CreateInt64Counter($"{metricsPrefix}_broadcast_requests_count"); // sum
+            // HubBroadcast request size. num
+            broadcastRequestSizeMeasure = meter.CreateInt64Measure($"{metricsPrefix}_broadcast_request_size"); // sum
+            // HubBroadcast group count. num
+            broadcastGroupCounter = meter.CreateInt64Counter($"{metricsPrefix}_broadcast_group_count"); // sum
         }
 
         IEnumerable<KeyValuePair<string, string>> CreateLabel(ServiceContext context)
@@ -72,8 +88,9 @@ namespace MagicOnion.OpenTelemetry
             var value = context.CallContext.Method;
             var label = labelCache.GetOrAdd(value, new HashSet<KeyValuePair<string, string>>(defaultLabels)
             {
-                new KeyValuePair<string, string>( MethodKey, value),
+                new KeyValuePair<string, string>( MethodKey, context.CallContext.Method),
             });
+            label.Add(new KeyValuePair<string, string>(MethodTypeKey, MethodTypeToString(context.MethodType)));
             return label;
         }
         IEnumerable<KeyValuePair<string, string>> CreateLabel(StreamingHubContext context)
@@ -84,6 +101,7 @@ namespace MagicOnion.OpenTelemetry
             {
                 new KeyValuePair<string, string>( MethodKey, value),
             });
+            label.Add(new KeyValuePair<string, string>(MethodTypeKey, MethodTypeToString(context.ServiceContext.MethodType)));
             return label;
         }
         IEnumerable<KeyValuePair<string, string>> CreateLabel(string value)
@@ -91,6 +109,14 @@ namespace MagicOnion.OpenTelemetry
             var label = labelCache.GetOrAdd(value, new HashSet<KeyValuePair<string, string>>(defaultLabels)
             {
                 new KeyValuePair<string, string>( MethodKey, value),
+            });
+            return label;
+        }
+        IEnumerable<KeyValuePair<string, string>> CreateBroadcastLabel(string value)
+        {
+            var label = broadcastLabelCache.GetOrAdd(value, new HashSet<KeyValuePair<string, string>>(defaultLabels)
+            {
+                new KeyValuePair<string, string>( "GroupName", value),
             });
             return label;
         }
@@ -154,7 +180,10 @@ namespace MagicOnion.OpenTelemetry
 
         public void InvokeHubBroadcast(string groupName, int responseSize, int broadcastGroupCount)
         {
-            // TODO:require more debugging aid(broadcast methodName).
+            var spanContext = default(SpanContext);
+            broadcastRequestCounter.Add(spanContext, 1, CreateBroadcastLabel(groupName));
+            broadcastGroupCounter.Add(spanContext, broadcastGroupCount, CreateBroadcastLabel(groupName));
+            broadcastRequestSizeMeasure.Record(spanContext, responseSize, CreateBroadcastLabel(groupName));
         }
 
         public void ReadFromStream(ServiceContext context, byte[] readData, Type type, bool complete)
@@ -163,6 +192,23 @@ namespace MagicOnion.OpenTelemetry
 
         public void WriteToStream(ServiceContext context, byte[] writeData, Type type)
         {
+        }
+
+        string MethodTypeToString(MethodType type)
+        {
+            switch (type)
+            {
+                case MethodType.Unary:
+                    return "Unary";
+                case MethodType.ClientStreaming:
+                    return "ClientStreaming";
+                case MethodType.ServerStreaming:
+                    return "ServerStreaming";
+                case MethodType.DuplexStreaming:
+                    return "DuplexStreaming";
+                default:
+                    return ((int)type).ToString();
+            }
         }
     }
 }


### PR DESCRIPTION
## TL;DR

* add: Hub broadcast metrics.

![image](https://user-images.githubusercontent.com/3856350/83476052-af52a700-a4ca-11ea-9d40-5775d82907a1.png)

* fix: metrics name to fit Prometheus scrape rule.
    * Prometheus now can scrape MagicOnion metrics.

![image](https://user-images.githubusercontent.com/3856350/83474751-b3c99080-a4c7-11ea-841a-f8deda4961bc.png)

* fix: collect streamingHubResponseSizeMeasure.

## Summary

Previously, opentelemetry-dotnet handles metrics name to convert `/` into `_` but now they leave it as is. Therefore breaking change had been occur as Prometheus scrape failed to retrieve correct position of metrics text.

* change to small letter metrics.
  * common metrics are using small letters only, can use Capital.
* change metrics name to match common metrics naming rule.

## NOTES

### Changes

previous metrics format with prometheus exporter.

```
# HELP MagicOnion_measure_BuildServiceDefinitionMagicOnionMagicOnion/measure/BuildServiceDefinition
# TYPE MagicOnion_measure_BuildServiceDefinition summary
MagicOnion/measure/BuildServiceDefinition_sum{MagicOnion_keys_Method="EndBuildServiceDefinition"} 104.734 1589855037710
MagicOnion/measure/BuildServiceDefinition_count{MagicOnion_keys_Method="EndBuildServiceDefinition"} 1 1589855037710
MagicOnion/measure/BuildServiceDefinition{MagicOnion_keys_Method="EndBuildServiceDefinition",quantile="0"} 104.734 1589855037710
MagicOnion/measure/BuildServiceDefinition{MagicOnion_keys_Method="EndBuildServiceDefinition",quantile="1"} 104.734 1589855037710
```

current

```
# HELP magiconion_buildservicedefinition_duration_millisecondsMagicOnionmagiconion_buildservicedefinition_duration_milliseconds
# TYPE magiconion_buildservicedefinition_duration_milliseconds summary
magiconion_buildservicedefinition_duration_milliseconds_sum{method="EndBuildServiceDefinition"} 66.7148 1591066185908
magiconion_buildservicedefinition_duration_milliseconds_count{method="EndBuildServiceDefinition"} 1 1591066185908
magiconion_buildservicedefinition_duration_milliseconds{method="EndBuildServiceDefinition",quantile="0"} 66.7148 1591066185908
magiconion_buildservicedefinition_duration_milliseconds{method="EndBuildServiceDefinition",quantile="1"} 66.7148 1591066185909
```
