### PR TITLE
fix: unity build error

### DIFF
--- a/src/MagicOnion.Client.Unity/Assets/Scripts/Editor/UnityCloudBuildConfiguration.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/Editor/UnityCloudBuildConfiguration.cs
@@ -2,7 +2,9 @@ using System.IO;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.Callbacks;
+#if UNITY_IPHONE
 using UnityEditor.iOS.Xcode;
+#endif
 
 public static class UnityCloudBuildConfiguration
 {


### PR DESCRIPTION
## Error

```
2020-08-05T05:20:48.1152112Z Assets/Scripts/Editor/UnityCloudBuildConfiguration.cs(5,19): error CS0234: The type or namespace name 'iOS' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)
2020-08-05T05:20:48.1153543Z -----EndCompilerOutput---------------
2020-08-05T05:20:48.1154747Z - Finished script compilation in 1.573984 seconds
2020-08-05T05:20:48.1156343Z Assets/Scripts/Editor/UnityCloudBuildConfiguration.cs(5,19): error CS0234: The type or namespace name 'iOS' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)
```