### PR TITLE
feat: Bump OpenTelemetry to 0.5.0-beta2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1416,6 +1416,8 @@ Open `http://localhost:5432`, you can see swagger view.
 
 ### Telemetry
 
+**Supported OpenTelemetry-dotnet version: [0.5.0-beta.2](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/0.5.0-beta)**
+
 MagicOnion offer OpenTelemetry support with `MagicOnion.OpenTelemetry` package.
 Let's see overview and how to try on localhost.
 
@@ -1524,14 +1526,16 @@ await MagicOnionHost.CreateDefaultBuilder()
             // open-telemetry with Prometheus exporter
             meterOptions.MetricExporter = new PrometheusExporter(new PrometheusExporterOptions() { Url = options.MetricsExporterEndpoint });
         },
-        (options, tracerBuilder) =>
+        (options, provider, tracerBuilder) =>
         {
             // open-telemetry with Zipkin exporter
-            tracerBuilder.UseZipkin(o =>
+            tracerBuilder.AddZipkinExporter(o =>
             {
-                o.ServiceName = options.ServiceName;
+                o.ServiceName = "MyApp";
                 o.Endpoint = new Uri(options.TracerExporterEndpoint);
             });
+            // ConsoleExporter will show current tracer activity
+            tracerBuilder.AddConsoleExporter();
         });
     })
 ```
@@ -1551,6 +1555,7 @@ If you use Prometheus Exporter and require Prometheus Server to recieve pull req
     services.AddMagicOnionOpenTelemetry((options, meterOptions) =>
     {
         // your metrics exporter implementation.
+        meterOptions.MetricExporter = new PrometheusExporter(new PrometheusExporterOptions() { Url = options.MetricsExporterEndpoint });
     },
     (options, tracerBuilder) =>
     {
@@ -1585,9 +1590,9 @@ await MagicOnionHost.CreateDefaultBuilder()
         var meterFactory = services.BuildServiceProvider().GetService<MeterFactory>();
         services.Configure<MagicOnionHostingOptions>(options =>
         {
-            options.Service.GlobalFilters.Add(new OpenTelemetryCollectorFilterAttribute());
-            options.Service.GlobalStreamingHubFilters.Add(new OpenTelemetryHubCollectorFilterAttribute());
-            options.Service.MagicOnionLogger = new OpenTelemetryCollectorLogger(meterFactory);
+            options.Service.GlobalFilters.Add(new OpenTelemetryCollectorFilterFactoryAttribute());
+            options.Service.GlobalStreamingHubFilters.Add(new OpenTelemetryHubCollectorFilterFactoryAttribute());
+            options.Service.MagicOnionLogger = new OpenTelemetryCollectorLogger(meterProvider);
         });
     })
     .RunConsoleAsync();
@@ -1597,12 +1602,13 @@ await MagicOnionHost.CreateDefaultBuilder()
 
 All implementation is done, let's Debug run MagicOnion and confirm you can see metrics and tracer.
 
-SampleApp `ChatApp.Server.Telemery` offers sample for Prometheus Metrics exporter and Zipkin Tracer exporter.
+SampleApp `samples/ChatApp.Telemetry/ChatApp.Server` offers sample for Prometheus Metrics exporter and Zipkin Tracer exporter.
 
 Run Zipkin on Docker to recieve tracer from ChatApp.Server.Telemery.
 
 ```shell
-docker run --rm -p 9411:9411 openzipkin/zipkin
+cd samples/ChatApp.Telemetry
+docker-compose -f docker-compose.telemetry.yaml up
 ```
 
 * Prometheus metrics wlll show on http://localhost:9184/metrics.
@@ -1650,11 +1656,11 @@ They will export when Unary/StreamingHub request is comming.
 
 **tips**
 
-* Want insert your own tag to default metrics.
+* Want insert your own tag to default metrics?
 
 Add defaultTags when register `OpenTelemetryCollectorLogger`.
 
-* Want replace magiconion metrics prefix to my magiconion metrics.
+* Want replace magiconion metrics prefix to my magiconion metrics?
 
 Set metricsPrefix when register `OpenTelemetryCollectorLogger`.
 If you pass `yourprefix`, then metrics prefix will change to followings.
@@ -1663,7 +1669,7 @@ If you pass `yourprefix`, then metrics prefix will change to followings.
 yourprefix_buildservicedefinition_duration_milliseconds_sum{method="EndBuildServiceDefinition"} 66.7148 1591066185908
 ```
 
-* Want contain `version` tag to your metrics.
+* Want contain `version` tag to your metrics?
 
 Add version when register `OpenTelemetryCollectorLogger`.
 
@@ -1673,7 +1679,71 @@ This should output like follows, however current opentelemetry-dotnet Prometheus
 magiconion_buildservicedefinition_duration_milliseconds_sum{method="EndBuildServiceDefinition",version="1.0.0"} 66.7148 1591066185908
 ```
 
+#### implement your own trace
+
+Here's Zipkin Tracer sample with MagicOnion.OpenTelemetry.
+
+![image](https://user-images.githubusercontent.com/3856350/91792704-1a8a5180-ec51-11ea-84d6-b05b201eda7b.png)
+
+Let's see example trace.
+MagicOnion.OpenTelemetry automatically trace each StreamingHub and Unary request.
+
+![image](https://user-images.githubusercontent.com/3856350/91793243-9e910900-ec52-11ea-8d2a-a10b6fbc93fe.png)
+
+If you want add your own application trace, use `ActivitySource` which automatically injected by MagicOnion.
+
+![image](https://user-images.githubusercontent.com/3856350/91793396-09424480-ec53-11ea-8c93-a21d1590d06a.png)
+
+Code sample.
+
+```csharp
+public class ChatHub : StreamingHubBase<IChatHub, IChatHubReceiver>, IChatHub
+{
+    private ActivitySource activitySource;
+
+    public ChatHub(ActivitySource activitySource)
+    {
+        this.activitySource = activitySource;
+    }
+
+    public async Task JoinAsync(JoinRequest request)
+    {
+        // your logic
+
+        // Trace database operation dummy.
+        using (var activity = activitySource.StartActivity("db:room/insert", ActivityKind.Internal))
+        {
+            // this is sample. use orm or any safe way.
+            activity.SetTag("table", "rooms");
+            activity.SetTag("query", $"INSERT INTO rooms VALUES (0, '{request.RoomName}', '{request.UserName}', '1');");
+            activity.SetTag("parameter.room", request.RoomName);
+            activity.SetTag("parameter.username", request.UserName);
+            await Task.Delay(TimeSpan.FromMilliseconds(2));
+        }
+    }
+}
+```
+
+If you don't want your Trace relates to invoked mehod, use `this.Context.GetTraceContext()` to get your Context's trace directly.
+
+```csharp
+// if you don't want set relation to this method, but directly this streaming hub, set hub trace context to your activiy.
+var hubTraceContext = this.Context.GetTraceContext();
+using (var activity = activitySource.StartActivity("sample:hub_context_relation", ActivityKind.Internal, hubTraceContext))
+{
+    // this is sample. use orm or any safe way.
+    activity.SetTag("message", "this span has no relationship with this method but has with hub context.");
+}
+```
+
+![image](https://user-images.githubusercontent.com/3856350/91793693-dd738e80-ec53-11ea-8a50-a1fbd6fb4cd0.png)
+
+
 #### implement your own metrics
+
+Here's Prometheus exporter sample with MagicOnion.OpenTelemetry.
+
+![image](https://user-images.githubusercontent.com/3856350/91793545-72c25300-ec53-11ea-92f6-e1f167054926.png)
 
 Implement `IMagicOnionLogger` to configure your metrics. You can collect metrics when following callbacks are invoked by filter.
 

--- a/samples/ChatApp.Telemetry/ChatApp.Server/ChatApp.Server.csproj
+++ b/samples/ChatApp.Telemetry/ChatApp.Server/ChatApp.Server.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="0.4.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="0.4.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="0.4.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="0.5.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="0.5.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="0.5.0-beta.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ChatApp.Telemetry/ChatApp.Server/ChatHub.cs
+++ b/samples/ChatApp.Telemetry/ChatApp.Server/ChatHub.cs
@@ -1,8 +1,10 @@
 using ChatApp.Shared.Hubs;
 using ChatApp.Shared.MessagePackObjects;
+using MagicOnion.Server;
 using MagicOnion.Server.Hubs;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace ChatApp.Server
@@ -15,22 +17,56 @@ namespace ChatApp.Server
     {
         private IGroup room;
         private string myName;
+        private ActivitySource activitySource;
+
+        public ChatHub(ActivitySource activitySource)
+        {
+            this.activitySource = activitySource;
+        }
 
         public async Task JoinAsync(JoinRequest request)
         {
             this.room = await this.Group.AddAsync(request.RoomName);
-
             this.myName = request.UserName;
 
             this.Broadcast(this.room).OnJoin(request.UserName);
-        }
 
+            // dummy external operation db.
+            using (var activity = activitySource.StartActivity("db:room/insert", ActivityKind.Internal))
+            {
+                // this is sample. use orm or any safe way.
+                activity.SetTag("table", "rooms");
+                activity.SetTag("query", $"INSERT INTO rooms VALUES (0, '{request.RoomName}', '{request.UserName}', '1');");
+                activity.SetTag("parameter.room", request.RoomName);
+                activity.SetTag("parameter.username", request.UserName);
+                await Task.Delay(TimeSpan.FromMilliseconds(2));
+            }
+
+            // if you don't want set relation to this method, but directly this streaming hub, set hub trace context to your activiy.
+            var hubTraceContext = this.Context.GetTraceContext();
+            using (var activity = activitySource.StartActivity("sample:hub_context_relation", ActivityKind.Internal, hubTraceContext))
+            {
+                // this is sample. use orm or any safe way.
+                activity.SetTag("message", "this span has no relationship with this method but has with hub context.");
+            }
+        }
 
         public async Task LeaveAsync()
         {
             await this.room.RemoveAsync(this.Context);
 
             this.Broadcast(this.room).OnLeave(this.myName);
+
+            // dummy external operation.
+            using (var activity = activitySource.StartActivity("db:room/update", ActivityKind.Internal))
+            {
+                // this is sample. use orm or any safe way.
+                activity.SetTag("table", "rooms");
+                activity.SetTag("query", $"UPDATE rooms SET status=0 WHERE id={this.room.GroupName} AND name='{this.myName}';");
+                activity.SetTag("parameter.room", this.room.GroupName);
+                activity.SetTag("parameter.username", this.myName);
+                await Task.Delay(TimeSpan.FromMilliseconds(2));
+            }
         }
 
         public async Task SendMessageAsync(string message)
@@ -38,12 +74,30 @@ namespace ChatApp.Server
             var response = new MessageResponse { UserName = this.myName, Message = message };
             this.Broadcast(this.room).OnSendMessage(response);
 
+            // dummy external operation.
+            using (var activity = activitySource.StartActivity($"redis:message_room_{room.GroupName}", ActivityKind.Internal))
+            {
+                activity.SetTag("parameter.room", room.GroupName);
+                activity.SetTag("parameter.username", myName);
+                await Task.Delay(TimeSpan.FromMilliseconds(1));
+            }
+
             await Task.CompletedTask;
         }
 
-        public Task GenerateException(string message)
+        public async Task GenerateException(string message)
         {
-            throw new Exception(message);
+            var ex = new Exception(message);
+
+            // dummy external operation.
+            using (var activity = activitySource.StartActivity("db:errors/insert", ActivityKind.Internal))
+            {
+                // this is sample. use orm or any safe way.
+                activity.SetTag("table", "errors");
+                activity.SetTag("query", $"INSERT INTO rooms VALUES ('{ex.Message}', '{ex.StackTrace}');");
+                await Task.Delay(TimeSpan.FromMilliseconds(2));
+            }
+            throw ex;
         }
 
         // It is not called because it is a method as a sample of arguments.

--- a/samples/ChatApp.Telemetry/ChatApp.Server/ChatService.cs
+++ b/samples/ChatApp.Telemetry/ChatApp.Server/ChatService.cs
@@ -1,15 +1,34 @@
-﻿using ChatApp.Shared.Services;
+using ChatApp.Shared.Services;
 using MagicOnion;
 using MagicOnion.Server;
 using MessagePack;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace ChatApp.Server
 {
     public class ChatService : ServiceBase<IChatService>, IChatService
     {
-        public UnaryResult<Nil> GenerateException(string message)
+        private ActivitySource activitySource;
+
+        public ChatService(ActivitySource activitySource)
         {
-            throw new System.NotImplementedException();
+            this.activitySource = activitySource;
+        }
+
+        public async UnaryResult<Nil> GenerateException(string message)
+        {
+            var ex = new System.NotImplementedException();
+            // dummy external operation.
+            using (var activity = activitySource.StartActivity("db:errors/insert", ActivityKind.Internal))
+            {
+                // this is sample. use orm or any safe way.
+                activity.SetTag("table", "errors");
+                activity.SetTag("query", $"INSERT INTO rooms VALUES ('{ex.Message}', '{ex.StackTrace}');");
+                await Task.Delay(TimeSpan.FromMilliseconds(2));
+            }
+            throw ex;
         }
 
         public UnaryResult<Nil> SendReportAsync(string message)

--- a/samples/ChatApp.Telemetry/ChatApp.Server/Program.cs
+++ b/samples/ChatApp.Telemetry/ChatApp.Server/Program.cs
@@ -49,7 +49,7 @@ namespace ChatApp.Server
                     {
                         options.Service.GlobalFilters.Add(new OpenTelemetryCollectorFilterFactoryAttribute());
                         options.Service.GlobalStreamingHubFilters.Add(new OpenTelemetryHubCollectorFilterFactoryAttribute());
-                        options.Service.MagicOnionLogger = new OpenTelemetryCollectorLogger(meterProvider);
+                        options.Service.MagicOnionLogger = new OpenTelemetryCollectorLogger(meterProvider, version: "0.5.0-beta.2");
                     });
                 })
                 .RunConsoleAsync();

--- a/samples/ChatApp.Telemetry/ChatApp.Server/Program.cs
+++ b/samples/ChatApp.Telemetry/ChatApp.Server/Program.cs
@@ -38,7 +38,7 @@ namespace ChatApp.Server
                             o.Endpoint = new Uri(options.TracerExporterEndpoint);
                         });
                         // ConsoleExporter will show current tracer activity
-                        //tracerBuilder.AddConsoleExporter();
+                        tracerBuilder.AddConsoleExporter();
                     });
                     services.AddHostedService<PrometheusExporterMetricsService>();
                 })

--- a/samples/ChatApp.Telemetry/ChatApp.Server/Program.cs
+++ b/samples/ChatApp.Telemetry/ChatApp.Server/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Exporter.Prometheus;
+using OpenTelemetry.Exporter.Zipkin;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using System;
@@ -31,13 +32,13 @@ namespace ChatApp.Server
                     (options, provider, tracerBuilder) =>
                     {
                         // open-telemetry with Zipkin exporter
-                        tracerBuilder.UseZipkinExporter(o =>
+                        tracerBuilder.AddZipkinExporter(o =>
                         {
                             o.ServiceName = "ChatApp.Server";
                             o.Endpoint = new Uri(options.TracerExporterEndpoint);
                         });
                         // ConsoleExporter will show current tracer activity
-                        tracerBuilder.UseConsoleExporter();
+                        //tracerBuilder.AddConsoleExporter();
                     });
                     services.AddHostedService<PrometheusExporterMetricsService>();
                 })
@@ -46,8 +47,8 @@ namespace ChatApp.Server
                     var meterProvider = services.BuildServiceProvider().GetService<MeterProvider>();
                     services.Configure<MagicOnionHostingOptions>(options =>
                     {
-                        options.Service.GlobalFilters.Add(new OpenTelemetryCollectorFilterAttribute());
-                        options.Service.GlobalStreamingHubFilters.Add(new OpenTelemetryHubCollectorFilterAttribute());
+                        options.Service.GlobalFilters.Add(new OpenTelemetryCollectorFilterFactoryAttribute());
+                        options.Service.GlobalStreamingHubFilters.Add(new OpenTelemetryHubCollectorFilterFactoryAttribute());
                         options.Service.MagicOnionLogger = new OpenTelemetryCollectorLogger(meterProvider);
                     });
                 })

--- a/samples/ChatApp.Telemetry/README.md
+++ b/samples/ChatApp.Telemetry/README.md
@@ -2,8 +2,10 @@
 
 Provides a sample of a simple chat app using MagicOnion + OpenTelemetry.
 
-Please see here about MagicOnion itself.  
-https://github.com/Cysharp/MagicOnion
+This is Sample Serverside MagicOnion with OpenTelemetry implementation for Prometheus and Zipkin exporters.
+You can launch via Visual Studio 2019, open `MagicOnion.sln` > samples > set `ChatApp.Server(samples/ChatApp.Telemetry/ChatApp.Server)` project as start up and Start Debug.
+
+> Addtional note: If you want run MagiconOnion with telemetry containers please follow to the [README](https://github.com/Cysharp/MagicOnion#try-visualization-on-localhost)
 
 ## Getting started
 
@@ -13,6 +15,7 @@ To run simple ChatApp.Server,
 2. Run `ChatScene` from UnityEditor.  
 
 If you want launch on Container, see [Container support](#container-support) section.
+
 
 ### ChatApp.Server
 

--- a/samples/ChatApp/README.md
+++ b/samples/ChatApp/README.md
@@ -24,13 +24,6 @@ If you want launch on Container, see [Container support](#container-support) sec
 This is Sample Serverside MagicOnion.
 You can lanunch via Visual Studio 2019, open `MagicOnion.sln` > samples > set `ChatApp.Server` project as start up and Start Debug.
 
-### ChatApp.Server.Telemetry
-
-This is Sample Serverside MagicOnion with OpenTelemetry implementation for Prometheus and Zipkin exporters.
-You can lanunch via Visual Studio 2019, open `MagicOnion.sln` > samples > set `ChatApp.Server.Telemetry` project as start up and Start Debug.
-
-> Addtional note: If you want run MagiconOnion with telemetry containers please follow to the [README](https://github.com/Cysharp/MagicOnion#try-visualization-on-localhost)
-
 ### ChatApp.Unity
 
 Sample Clientside Unity.

--- a/sandbox/Sandbox.NetCoreServer/Sandbox.NetCoreServer.csproj
+++ b/sandbox/Sandbox.NetCoreServer/Sandbox.NetCoreServer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -18,7 +18,6 @@
         <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-        <PackageReference Include="OpenTelemetry" Version="0.1.0-alpha-86593" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MagicOnion.OpenTelemetry/MagicOnion.OpenTelemetry.csproj
+++ b/src/MagicOnion.OpenTelemetry/MagicOnion.OpenTelemetry.csproj
@@ -18,7 +18,8 @@
     <PackageId>MagicOnion.OpenTelemetry</PackageId>
     <Description>Telemetry Extensions of MagicOnion.</Description>
     <PackageTags>$(PackageTags);OpenTelemetry</PackageTags>
-    <VersionSuffix>beta.402.0</VersionSuffix>
+    <!-- Match to OpenTelemetry-dotnet beta version -->
+    <VersionSuffix>beta-050.2</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MagicOnion.OpenTelemetry/MagicOnion.OpenTelemetry.csproj
+++ b/src/MagicOnion.OpenTelemetry/MagicOnion.OpenTelemetry.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -24,9 +25,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="OpenTelemetry" Version="0.4.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="0.4.0-beta.2" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0-preview.7.20364.11" />
+    <PackageReference Include="OpenTelemetry" Version="0.5.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="0.5.0-beta.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MagicOnion.OpenTelemetry/MagicOnionTelemetry.cs
+++ b/src/MagicOnion.OpenTelemetry/MagicOnionTelemetry.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace MagicOnion.OpenTelemetry
+{
+    public static class MagicOnionTelemetry
+    {
+        public const string ServiceContextItemKeyTrace = ".TraceContext";
+    }
+}

--- a/src/MagicOnion.OpenTelemetry/OpenTelemetryFilterAttributes.cs
+++ b/src/MagicOnion.OpenTelemetry/OpenTelemetryFilterAttributes.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using MagicOnion.Server;
 using MagicOnion.Server.Hubs;
@@ -10,22 +12,22 @@ namespace MagicOnion.OpenTelemetry
     /// Collect OpenTelemetry Tracing for Global filter. Handle Unary and most outside logging.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
-    public class OpenTelemetryCollectorFilterAttribute : Attribute, IMagicOnionFilterFactory<MagicOnionFilterAttribute>
+    public class OpenTelemetryCollectorFilterFactoryAttribute : Attribute, IMagicOnionFilterFactory<MagicOnionFilterAttribute>
     {
         public int Order { get; set; }
 
-        public MagicOnionFilterAttribute CreateInstance(IServiceLocator serviceLocator)
+        MagicOnionFilterAttribute IMagicOnionFilterFactory<MagicOnionFilterAttribute>.CreateInstance(IServiceLocator serviceLocator)
         {
-            return new OpenTelemetryCollectorFilter(serviceLocator.GetService<TracerProvider>(), serviceLocator.GetService<MagicOnionOpenTelemetryOptions>());
+            return new OpenTelemetryCollectorFilterAttribute(serviceLocator.GetService<TracerProvider>(), serviceLocator.GetService<MagicOnionOpenTelemetryOptions>());
         }
     }
 
-    internal class OpenTelemetryCollectorFilter : MagicOnionFilterAttribute
+    internal class OpenTelemetryCollectorFilterAttribute : MagicOnionFilterAttribute
     {
         readonly TracerProvider tracerProvider;
         readonly MagicOnionOpenTelemetryOptions telemetryOption;
 
-        public OpenTelemetryCollectorFilter(TracerProvider tracerProvider, MagicOnionOpenTelemetryOptions telemetryOption)
+        public OpenTelemetryCollectorFilterAttribute(TracerProvider tracerProvider, MagicOnionOpenTelemetryOptions telemetryOption)
         {
             this.tracerProvider = tracerProvider;
             this.telemetryOption = telemetryOption;
@@ -63,14 +65,14 @@ namespace MagicOnion.OpenTelemetry
                     await next(context);
 
                     span.SetAttribute("grpc.status_code", ((long)context.CallContext.Status.StatusCode).ToString());
-                    span.Status = OpenTelemetrygRpcStatusHelper.ConvertStatus(context.CallContext.Status.StatusCode);
+                    //span.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.CallContext.Status.StatusCode));
                 }
                 catch (Exception ex)
                 {
                     span.SetAttribute("exception", ex.ToString());
                     span.SetAttribute("grpc.status_code", ((long)context.CallContext.Status.StatusCode).ToString());
                     span.SetAttribute("grpc.status_detail", context.CallContext.Status.Detail);
-                    span.Status = OpenTelemetrygRpcStatusHelper.ConvertStatus(context.CallContext.Status.StatusCode);
+                    //span.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.CallContext.Status.StatusCode));
                     throw;
                 }
             }
@@ -81,22 +83,24 @@ namespace MagicOnion.OpenTelemetry
     /// Collect OpenTelemetry Tracing for StreamingHub Filter. Handle Streaming Hub logging.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
-    public class OpenTelemetryHubCollectorFilterAttribute : Attribute, IMagicOnionFilterFactory<StreamingHubFilterAttribute>
+    public class OpenTelemetryHubCollectorFilterFactoryAttribute : Attribute, IMagicOnionFilterFactory<StreamingHubFilterAttribute>
     {
         public int Order { get; set; }
 
-        public StreamingHubFilterAttribute CreateInstance(IServiceLocator serviceLocator)
+        StreamingHubFilterAttribute IMagicOnionFilterFactory<StreamingHubFilterAttribute>.CreateInstance(IServiceLocator serviceLocator)
         {
-            return new OpenTelemetryHubCollectorFilter(serviceLocator.GetService<TracerProvider>(), serviceLocator.GetService<MagicOnionOpenTelemetryOptions>());
+            return new OpenTelemetryHubCollectorFilterAttribute(serviceLocator.GetService<TracerProvider>(), serviceLocator.GetService<MagicOnionOpenTelemetryOptions>());
         }
     }
 
-    internal class OpenTelemetryHubCollectorFilter : StreamingHubFilterAttribute
+    internal class OpenTelemetryHubCollectorFilterAttribute : StreamingHubFilterAttribute
     {
         readonly TracerProvider tracerProvider;
         readonly MagicOnionOpenTelemetryOptions telemetryOption;
 
-        public OpenTelemetryHubCollectorFilter(TracerProvider tracerProvider, MagicOnionOpenTelemetryOptions telemetryOption)
+        private static readonly ConcurrentDictionary<Guid, SpanContext> _contextState = new ConcurrentDictionary<Guid, SpanContext>();
+
+        public OpenTelemetryHubCollectorFilterAttribute(TracerProvider tracerProvider, MagicOnionOpenTelemetryOptions telemetryOption)
         {
             this.tracerProvider = tracerProvider;
             this.telemetryOption = telemetryOption;
@@ -106,44 +110,106 @@ namespace MagicOnion.OpenTelemetry
         {
             // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/rpc.md#grpc
 
+            await NextTracer(context, next);
+            //await NextSource(context, next);
+        }
+
+        private async ValueTask NextSource(StreamingHubContext context, Func<StreamingHubContext, ValueTask> next)
+        {
+            using var source = new ActivitySource(telemetryOption.ActivitySourceName);
+            using var activity = source.StartActivity($"{context.ServiceContext.MethodType}:/{context.Path}", ActivityKind.Server);
+
+            try
+            {
+                activity.SetTag("grpc.method", context.ServiceContext.MethodType.ToString());
+                activity.SetTag("rpc.system", "grpc");
+                activity.SetTag("rpc.service", context.ServiceContext.ServiceType.Name);
+                activity.SetTag("rpc.method", $"/{context.Path}");
+                // todo: context.CallContext.Peer/Host format is https://github.com/grpc/grpc/blob/master/doc/naming.md and not uri standard.
+                activity.SetTag("net.peer.ip", context.ServiceContext.CallContext.Peer);
+                activity.SetTag("net.host.name", context.ServiceContext.CallContext.Host);
+                activity.SetTag("message.type", "RECIEVED");
+                activity.SetTag("message.id", context.ServiceContext.ContextId.ToString());
+                activity.SetTag("message.uncompressed_size", context.Request.Length.ToString());
+
+                // todo: net.peer.name not report on tracer. use custom tag
+                activity.SetTag("magiconion.peer.ip", context.ServiceContext.CallContext.Peer);
+                activity.SetTag("magiconion.auth.enabled", (!string.IsNullOrEmpty(context.ServiceContext.CallContext.AuthContext.PeerIdentityPropertyName)).ToString());
+                activity.SetTag("magiconion.auth.peer.authenticated", context.ServiceContext.CallContext.AuthContext.IsPeerAuthenticated.ToString());
+
+                await next(context);
+
+                activity.SetTag("grpc.status_code", ((long)context.ServiceContext.CallContext.Status.StatusCode).ToString());
+                activity.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.ServiceContext.CallContext.Status.StatusCode));
+            }
+            catch (Exception ex)
+            {
+                activity.SetTag("exception", ex.ToString());
+                activity.SetTag("grpc.status_code", ((long)context.ServiceContext.CallContext.Status.StatusCode).ToString());
+                activity.SetTag("grpc.status_detail", context.ServiceContext.CallContext.Status.Detail);
+                activity.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.ServiceContext.CallContext.Status.StatusCode));
+                throw;
+            }
+        }
+
+        private async ValueTask NextTracer(StreamingHubContext context, Func<StreamingHubContext, ValueTask> next)
+        {
+            Console.WriteLine($"{context.ConnectionId} / {context.ServiceContext.ContextId} : {context.Path}");
+
             // TracerName must match with ActivitySource name.
             var tracer = tracerProvider.GetTracer(telemetryOption.ActivitySourceName, telemetryOption.TracerVersion);
 
             // Client -> Server incoming filter
             // span name must be `$package.$service/$method` but MagicOnion has no $package.
-            using (var span = tracer.StartSpan($"{context.ServiceContext.MethodType}:/{context.Path}", SpanKind.Server))
+            if (_contextState.TryGetValue(context.ServiceContext.ContextId, out var parentSpan))
             {
-                try
-                {
-                    span.SetAttribute("grpc.method", context.ServiceContext.MethodType.ToString());
-                    span.SetAttribute("rpc.system", "grpc");
-                    span.SetAttribute("rpc.service", context.ServiceContext.ServiceType.Name);
-                    span.SetAttribute("rpc.method", $"/{context.Path}");
-                    // todo: context.CallContext.Peer/Host format is https://github.com/grpc/grpc/blob/master/doc/naming.md and not uri standard.
-                    span.SetAttribute("net.peer.ip", context.ServiceContext.CallContext.Peer);
-                    span.SetAttribute("net.host.name", context.ServiceContext.CallContext.Host);
-                    span.SetAttribute("message.type", "RECIEVED");
-                    span.SetAttribute("message.id", context.ServiceContext.ContextId.ToString());
-                    span.SetAttribute("message.uncompressed_size", context.Request.Length.ToString());
+                using var span = tracer.StartSpan($"{context.ServiceContext.MethodType}:/{context.Path}", SpanKind.Server, parentSpan);
+                await SpanExec(context, next, span);
+            }
+            else
+            {
+                using var span = tracer.StartSpan($"{context.ServiceContext.MethodType}:/{context.Path}", SpanKind.Server);
+                //_contextState.TryAdd(context.ServiceContext.ContextId, span.Context);
+                await SpanExec(context, next, span);
+            }
+        }
 
-                    // todo: net.peer.name not report on tracer. use custom tag
-                    span.SetAttribute("magiconion.peer.ip", context.ServiceContext.CallContext.Peer);
-                    span.SetAttribute("magiconion.auth.enabled", (!string.IsNullOrEmpty(context.ServiceContext.CallContext.AuthContext.PeerIdentityPropertyName)).ToString());
-                    span.SetAttribute("magiconion.auth.peer.authenticated", context.ServiceContext.CallContext.AuthContext.IsPeerAuthenticated.ToString());
+        private static async Task SpanExec(StreamingHubContext context, Func<StreamingHubContext, ValueTask> next, TelemetrySpan span)
+        {
+            try
+            {
+                span.SetAttribute("grpc.method", context.ServiceContext.MethodType.ToString());
+                span.SetAttribute("rpc.system", "grpc");
+                span.SetAttribute("rpc.service", context.ServiceContext.ServiceType.Name);
+                span.SetAttribute("rpc.method", $"/{context.Path}");
+                // todo: context.CallContext.Peer/Host format is https://github.com/grpc/grpc/blob/master/doc/naming.md and not uri standard.
+                span.SetAttribute("net.peer.ip", context.ServiceContext.CallContext.Peer);
+                span.SetAttribute("net.host.name", context.ServiceContext.CallContext.Host);
+                span.SetAttribute("message.type", "RECIEVED");
+                span.SetAttribute("message.id", context.ServiceContext.ContextId.ToString());
+                span.SetAttribute("message.uncompressed_size", context.Request.Length.ToString());
 
-                    await next(context);
+                // todo: net.peer.name not report on tracer. use custom tag
+                span.SetAttribute("magiconion.peer.ip", context.ServiceContext.CallContext.Peer);
+                span.SetAttribute("magiconion.auth.enabled", (!string.IsNullOrEmpty(context.ServiceContext.CallContext.AuthContext.PeerIdentityPropertyName)).ToString());
+                span.SetAttribute("magiconion.auth.peer.authenticated", context.ServiceContext.CallContext.AuthContext.IsPeerAuthenticated.ToString());
 
-                    span.SetAttribute("grpc.status_code", ((long)context.ServiceContext.CallContext.Status.StatusCode).ToString());
-                    span.Status = OpenTelemetrygRpcStatusHelper.ConvertStatus(context.ServiceContext.CallContext.Status.StatusCode);
-                }
-                catch (Exception ex)
-                {
-                    span.SetAttribute("exception", ex.ToString());
-                    span.SetAttribute("grpc.status_code", ((long)context.ServiceContext.CallContext.Status.StatusCode).ToString());
-                    span.SetAttribute("grpc.status_detail", context.ServiceContext.CallContext.Status.Detail);
-                    span.Status = OpenTelemetrygRpcStatusHelper.ConvertStatus(context.ServiceContext.CallContext.Status.StatusCode);
-                    throw;
-                }
+                await next(context);
+
+                span.SetAttribute("grpc.status_code", ((long)context.ServiceContext.CallContext.Status.StatusCode).ToString());
+                //span.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.ServiceContext.CallContext.Status.StatusCode));
+            }
+            catch (Exception ex)
+            {
+                span.SetAttribute("exception", ex.ToString());
+                span.SetAttribute("grpc.status_code", ((long)context.ServiceContext.CallContext.Status.StatusCode).ToString());
+                span.SetAttribute("grpc.status_detail", context.ServiceContext.CallContext.Status.Detail);
+                //span.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.ServiceContext.CallContext.Status.StatusCode));
+                throw;
+            }
+            finally
+            {
+                //_contextState.TryRemove(context.ServiceContext.ContextId, out var _);
             }
         }
     }

--- a/src/MagicOnion.OpenTelemetry/OpenTelemetryFilterAttributes.cs
+++ b/src/MagicOnion.OpenTelemetry/OpenTelemetryFilterAttributes.cs
@@ -41,6 +41,9 @@ namespace MagicOnion.OpenTelemetry
             // span name must be `$package.$service/$method` but MagicOnion has no $package.
             using var activity = source.StartActivity($"{context.MethodType}:{context.CallContext.Method}", ActivityKind.Server);
 
+            // add trace context to service context. it allows user to add their span directly to this context.
+            context.SetTraceContext(activity.Context);
+
             try
             {
                 activity.SetTag("grpc.method", context.MethodType.ToString());
@@ -105,6 +108,9 @@ namespace MagicOnion.OpenTelemetry
             // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/rpc.md#grpc
 
             using var activity = source.StartActivity($"{context.ServiceContext.MethodType}:/{context.Path}", ActivityKind.Server);
+
+            // add trace context to service context. it allows user to add their span directly to this hub
+            context.SetTraceContext(activity.Context);
 
             try
             {

--- a/src/MagicOnion.OpenTelemetry/OpenTelemetryFilterAttributes.cs
+++ b/src/MagicOnion.OpenTelemetry/OpenTelemetryFilterAttributes.cs
@@ -18,18 +18,18 @@ namespace MagicOnion.OpenTelemetry
 
         MagicOnionFilterAttribute IMagicOnionFilterFactory<MagicOnionFilterAttribute>.CreateInstance(IServiceLocator serviceLocator)
         {
-            return new OpenTelemetryCollectorFilterAttribute(serviceLocator.GetService<TracerProvider>(), serviceLocator.GetService<MagicOnionOpenTelemetryOptions>());
+            return new OpenTelemetryCollectorFilterAttribute(serviceLocator.GetService<ActivitySource>(), serviceLocator.GetService<MagicOnionOpenTelemetryOptions>());
         }
     }
 
     internal class OpenTelemetryCollectorFilterAttribute : MagicOnionFilterAttribute
     {
-        readonly TracerProvider tracerProvider;
+        readonly ActivitySource source;
         readonly MagicOnionOpenTelemetryOptions telemetryOption;
 
-        public OpenTelemetryCollectorFilterAttribute(TracerProvider tracerProvider, MagicOnionOpenTelemetryOptions telemetryOption)
+        public OpenTelemetryCollectorFilterAttribute(ActivitySource activitySource, MagicOnionOpenTelemetryOptions telemetryOption)
         {
-            this.tracerProvider = tracerProvider;
+            this.source = activitySource;
             this.telemetryOption = telemetryOption;
         }
 
@@ -37,44 +37,40 @@ namespace MagicOnion.OpenTelemetry
         {
             // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/rpc.md#grpc
 
-            // TracerName must match with ActivitySource name.
-            var tracer = tracerProvider.GetTracer(telemetryOption.ActivitySourceName, telemetryOption.TracerVersion);
-
             // Client -> Server incoming filter
             // span name must be `$package.$service/$method` but MagicOnion has no $package.
-            using (var span = tracer.StartSpan($"{context.MethodType}:{context.CallContext.Method}", SpanKind.Server))
+            using var activity = source.StartActivity($"{context.MethodType}:{context.CallContext.Method}", ActivityKind.Server);
+
+            try
             {
-                try
-                {
-                    span.SetAttribute("grpc.method", context.MethodType.ToString());
-                    span.SetAttribute("rpc.system", "grpc");
-                    span.SetAttribute("rpc.service", context.ServiceType.Name);
-                    span.SetAttribute("rpc.method", context.CallContext.Method);
-                    // todo: context.CallContext.Peer/Host format is https://github.com/grpc/grpc/blob/master/doc/naming.md and not uri standard.
-                    span.SetAttribute("net.peer.name", context.CallContext.Peer);
-                    span.SetAttribute("net.host.name", context.CallContext.Host);
-                    span.SetAttribute("message.type", "RECIEVED");
-                    span.SetAttribute("message.id", context.ContextId.ToString());
-                    span.SetAttribute("message.uncompressed_size", context.GetRawRequest()?.LongLength.ToString() ?? "0");
+                activity.SetTag("grpc.method", context.MethodType.ToString());
+                activity.SetTag("rpc.system", "grpc");
+                activity.SetTag("rpc.service", context.ServiceType.Name);
+                activity.SetTag("rpc.method", context.CallContext.Method);
+                // todo: context.CallContext.Peer/Host format is https://github.com/grpc/grpc/blob/master/doc/naming.md and not uri standard.
+                activity.SetTag("net.peer.name", context.CallContext.Peer);
+                activity.SetTag("net.host.name", context.CallContext.Host);
+                activity.SetTag("message.type", "RECIEVED");
+                activity.SetTag("message.id", context.ContextId.ToString());
+                activity.SetTag("message.uncompressed_size", context.GetRawRequest()?.LongLength.ToString() ?? "0");
 
-                    // todo: net.peer.name not report on tracer. use custom tag
-                    span.SetAttribute("magiconion.peer.ip", context.CallContext.Peer);
-                    span.SetAttribute("magiconion.auth.enabled", (!string.IsNullOrEmpty(context.CallContext.AuthContext.PeerIdentityPropertyName)).ToString());
-                    span.SetAttribute("magiconion.auth.peer.authenticated", context.CallContext.AuthContext.IsPeerAuthenticated.ToString());
+                // todo: net.peer.name not report on tracer. use custom tag
+                activity.SetTag("magiconion.peer.ip", context.CallContext.Peer);
+                activity.SetTag("magiconion.auth.enabled", (!string.IsNullOrEmpty(context.CallContext.AuthContext.PeerIdentityPropertyName)).ToString());
+                activity.SetTag("magiconion.auth.peer.authenticated", context.CallContext.AuthContext.IsPeerAuthenticated.ToString());
 
-                    await next(context);
+                await next(context);
 
-                    span.SetAttribute("grpc.status_code", ((long)context.CallContext.Status.StatusCode).ToString());
-                    //span.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.CallContext.Status.StatusCode));
-                }
-                catch (Exception ex)
-                {
-                    span.SetAttribute("exception", ex.ToString());
-                    span.SetAttribute("grpc.status_code", ((long)context.CallContext.Status.StatusCode).ToString());
-                    span.SetAttribute("grpc.status_detail", context.CallContext.Status.Detail);
-                    //span.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.CallContext.Status.StatusCode));
-                    throw;
-                }
+                activity.SetTag("grpc.status_code", ((long)context.CallContext.Status.StatusCode).ToString());
+                activity.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.CallContext.Status.StatusCode));
+            }
+            catch (Exception ex)
+            {
+                activity.SetTag("exception", ex.ToString());
+                activity.SetTag("grpc.status_code", ((long)context.CallContext.Status.StatusCode).ToString());
+                activity.SetTag("grpc.status_detail", context.CallContext.Status.Detail);
+                activity.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.CallContext.Status.StatusCode));
+                throw;
             }
         }
     }
@@ -89,20 +85,18 @@ namespace MagicOnion.OpenTelemetry
 
         StreamingHubFilterAttribute IMagicOnionFilterFactory<StreamingHubFilterAttribute>.CreateInstance(IServiceLocator serviceLocator)
         {
-            return new OpenTelemetryHubCollectorFilterAttribute(serviceLocator.GetService<TracerProvider>(), serviceLocator.GetService<MagicOnionOpenTelemetryOptions>());
+            return new OpenTelemetryHubCollectorFilterAttribute(serviceLocator.GetService<ActivitySource>(), serviceLocator.GetService<MagicOnionOpenTelemetryOptions>());
         }
     }
 
     internal class OpenTelemetryHubCollectorFilterAttribute : StreamingHubFilterAttribute
     {
-        readonly TracerProvider tracerProvider;
+        readonly ActivitySource source;
         readonly MagicOnionOpenTelemetryOptions telemetryOption;
 
-        private static readonly ConcurrentDictionary<Guid, SpanContext> _contextState = new ConcurrentDictionary<Guid, SpanContext>();
-
-        public OpenTelemetryHubCollectorFilterAttribute(TracerProvider tracerProvider, MagicOnionOpenTelemetryOptions telemetryOption)
+        public OpenTelemetryHubCollectorFilterAttribute(ActivitySource activitySource, MagicOnionOpenTelemetryOptions telemetryOption)
         {
-            this.tracerProvider = tracerProvider;
+            this.source = activitySource;
             this.telemetryOption = telemetryOption;
         }
 
@@ -110,13 +104,6 @@ namespace MagicOnion.OpenTelemetry
         {
             // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/rpc.md#grpc
 
-            await NextTracer(context, next);
-            //await NextSource(context, next);
-        }
-
-        private async ValueTask NextSource(StreamingHubContext context, Func<StreamingHubContext, ValueTask> next)
-        {
-            using var source = new ActivitySource(telemetryOption.ActivitySourceName);
             using var activity = source.StartActivity($"{context.ServiceContext.MethodType}:/{context.Path}", ActivityKind.Server);
 
             try
@@ -151,66 +138,5 @@ namespace MagicOnion.OpenTelemetry
                 throw;
             }
         }
-
-        private async ValueTask NextTracer(StreamingHubContext context, Func<StreamingHubContext, ValueTask> next)
-        {
-            Console.WriteLine($"{context.ConnectionId} / {context.ServiceContext.ContextId} : {context.Path}");
-
-            // TracerName must match with ActivitySource name.
-            var tracer = tracerProvider.GetTracer(telemetryOption.ActivitySourceName, telemetryOption.TracerVersion);
-
-            // Client -> Server incoming filter
-            // span name must be `$package.$service/$method` but MagicOnion has no $package.
-            if (_contextState.TryGetValue(context.ServiceContext.ContextId, out var parentSpan))
-            {
-                using var span = tracer.StartSpan($"{context.ServiceContext.MethodType}:/{context.Path}", SpanKind.Server, parentSpan);
-                await SpanExec(context, next, span);
-            }
-            else
-            {
-                using var span = tracer.StartSpan($"{context.ServiceContext.MethodType}:/{context.Path}", SpanKind.Server);
-                //_contextState.TryAdd(context.ServiceContext.ContextId, span.Context);
-                await SpanExec(context, next, span);
-            }
-        }
-
-        private static async Task SpanExec(StreamingHubContext context, Func<StreamingHubContext, ValueTask> next, TelemetrySpan span)
-        {
-            try
-            {
-                span.SetAttribute("grpc.method", context.ServiceContext.MethodType.ToString());
-                span.SetAttribute("rpc.system", "grpc");
-                span.SetAttribute("rpc.service", context.ServiceContext.ServiceType.Name);
-                span.SetAttribute("rpc.method", $"/{context.Path}");
-                // todo: context.CallContext.Peer/Host format is https://github.com/grpc/grpc/blob/master/doc/naming.md and not uri standard.
-                span.SetAttribute("net.peer.ip", context.ServiceContext.CallContext.Peer);
-                span.SetAttribute("net.host.name", context.ServiceContext.CallContext.Host);
-                span.SetAttribute("message.type", "RECIEVED");
-                span.SetAttribute("message.id", context.ServiceContext.ContextId.ToString());
-                span.SetAttribute("message.uncompressed_size", context.Request.Length.ToString());
-
-                // todo: net.peer.name not report on tracer. use custom tag
-                span.SetAttribute("magiconion.peer.ip", context.ServiceContext.CallContext.Peer);
-                span.SetAttribute("magiconion.auth.enabled", (!string.IsNullOrEmpty(context.ServiceContext.CallContext.AuthContext.PeerIdentityPropertyName)).ToString());
-                span.SetAttribute("magiconion.auth.peer.authenticated", context.ServiceContext.CallContext.AuthContext.IsPeerAuthenticated.ToString());
-
-                await next(context);
-
-                span.SetAttribute("grpc.status_code", ((long)context.ServiceContext.CallContext.Status.StatusCode).ToString());
-                //span.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.ServiceContext.CallContext.Status.StatusCode));
-            }
-            catch (Exception ex)
-            {
-                span.SetAttribute("exception", ex.ToString());
-                span.SetAttribute("grpc.status_code", ((long)context.ServiceContext.CallContext.Status.StatusCode).ToString());
-                span.SetAttribute("grpc.status_detail", context.ServiceContext.CallContext.Status.Detail);
-                //span.SetStatus(OpenTelemetrygRpcStatusHelper.ConvertStatus(context.ServiceContext.CallContext.Status.StatusCode));
-                throw;
-            }
-            finally
-            {
-                //_contextState.TryRemove(context.ServiceContext.ContextId, out var _);
-            }
-        }
-    }
+   }
 }

--- a/src/MagicOnion.OpenTelemetry/OpenTelemetryServiceCollectionExtensions.cs
+++ b/src/MagicOnion.OpenTelemetry/OpenTelemetryServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
+using System.Diagnostics;
 
 namespace MagicOnion.OpenTelemetry
 {
@@ -73,6 +74,7 @@ namespace MagicOnion.OpenTelemetry
                     configureTracerProvider(options, provider, builder);
                 });
                 services.AddSingleton(tracerFactory);
+                services.AddSingleton(new ActivitySource(options.ActivitySourceName));
             }
 
             return services;

--- a/src/MagicOnion.OpenTelemetry/OpenTelemetryServiceCollectionExtensions.cs
+++ b/src/MagicOnion.OpenTelemetry/OpenTelemetryServiceCollectionExtensions.cs
@@ -48,12 +48,11 @@ namespace MagicOnion.OpenTelemetry
                 var meterFactoryOption = new MagicOnionOpenTelemetryMeterFactoryOption();
                 configureMeterProvider(options, meterFactoryOption);
 
-                MeterProvider.SetDefault(Sdk.CreateMeterProvider(builder =>
-                {
-                    builder.SetMetricProcessor(meterFactoryOption.MetricProcessor);
-                    builder.SetMetricExporter(meterFactoryOption.MetricExporter);
-                    builder.SetMetricPushInterval(meterFactoryOption.MetricPushInterval);
-                }));
+                MeterProvider.SetDefault(Sdk.CreateMeterProviderBuilder()
+                    .SetProcessor(meterFactoryOption.MetricProcessor)
+                    .SetExporter(meterFactoryOption.MetricExporter)
+                    .SetPushInterval(meterFactoryOption.MetricPushInterval)
+                    .Build());
 
                 services.AddSingleton(meterFactoryOption.MetricExporter);
                 services.AddSingleton(MeterProvider.Default);
@@ -67,10 +66,10 @@ namespace MagicOnion.OpenTelemetry
                     throw new NullReferenceException(nameof(options.ActivitySourceName));
                 }
 
-                var tracerFactory = services.AddOpenTelemetry((provider, builder) =>
+                var tracerFactory = services.AddOpenTelemetryTracerProvider((provider, builder) =>
                 {
                     // ActivitySourceName must match to TracerName.
-                    builder.AddActivitySource(options.ActivitySourceName);
+                    builder.AddSource(options.ActivitySourceName);
                     configureTracerProvider(options, provider, builder);
                 });
                 services.AddSingleton(tracerFactory);

--- a/src/MagicOnion.OpenTelemetry/ServiceContextTelemetryExtensions.cs
+++ b/src/MagicOnion.OpenTelemetry/ServiceContextTelemetryExtensions.cs
@@ -1,0 +1,54 @@
+using MagicOnion.OpenTelemetry;
+using MagicOnion.Server.Hubs;
+using System.Diagnostics;
+
+// ReSharper disable once CheckNamespace
+
+namespace MagicOnion.Server
+{
+    public static class ServiceContextTelemetryExtensions
+    {
+        /// <summary>
+        /// Set the trace context with this service context
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="activityContext"></param>
+        internal static void SetTraceContext(this ServiceContext context, ActivityContext activityContext)
+        {
+            context.Items[MagicOnionTelemetry.ServiceContextItemKeyTrace] = activityContext;
+        }
+
+        /// <summary>
+        /// Gets the trace context associated with this service context.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static ActivityContext GetTraceContext(this ServiceContext context)
+        {
+            return (ActivityContext)context.Items[MagicOnionTelemetry.ServiceContextItemKeyTrace];
+        }
+    }
+
+    public static class StreamingHubContextTelemetryExtensions
+    {
+        /// <summary>
+        /// Set the trace context with this streaming hub context
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="activityContext"></param>
+        internal static void SetTraceContext(this StreamingHubContext context, ActivityContext activityContext)
+        {
+            context.Items[MagicOnionTelemetry.ServiceContextItemKeyTrace] = activityContext;
+        }
+
+        /// <summary>
+        /// Gets the trace context associated with this streaming hub context.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static ActivityContext GetTraceContext(this StreamingHubContext context)
+        {
+            return (ActivityContext)context.Items[MagicOnionTelemetry.ServiceContextItemKeyTrace];
+        }
+    }
+}


### PR DESCRIPTION
## TL;DR

OpenTelemetry 0.5.0-beta support.

## Add

* Add `ActivitySource` to DI.
* Add ActivityContext to `StreamingHub.Context` and `ServiceContext`.
* Add Application Trace sample to `samples/ChatApp.Telemetry/ChatApp.Server`.

## Breaking Change

* Rename `OpenTelemetryCollectorFilterAttribute` -> `OpenTelemetryCollectorFilterFactoryAttribute`.
* Rename `OpenTelemetryHubCollectorFilterAttribute` -> `OpenTelemetryHubCollectorFilterFactoryAttribute`.

## Internal Change

* Use `ActivitySource` instead of `TracerProvider` to record tracer.
* Remove reference `System.Diagnostics.DiagnosticSource` 0.5.0 preview.