### PR TITLE
Better exception message

### DIFF
--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClientBase.cs
@@ -115,7 +115,17 @@ namespace MagicOnion.Client
                                     var offset = (int)messagePackReader.Consumed;
                                     var rest = new ArraySegment<byte>(data, offset, data.Length - offset);
                                     var error = MessagePackSerializer.Deserialize<string>(rest, serializerOptions);
-                                    (future as ITaskCompletion).TrySetException(new RpcException(new Status((StatusCode)statusCode, detail), error));
+                                    var ex = default(RpcException);
+                                    if (string.IsNullOrWhiteSpace(error))
+                                    {
+                                        ex = new RpcException(new Status((StatusCode)statusCode, detail));
+                                    }
+                                    else
+                                    {
+                                        ex = new RpcException(new Status((StatusCode)statusCode, detail), detail + Environment.NewLine + error);
+                                    }
+
+                                    (future as ITaskCompletion).TrySetException(ex);
                                 }
                             }
                             else

--- a/src/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/src/MagicOnion.Client/StreamingHubClientBase.cs
@@ -115,7 +115,17 @@ namespace MagicOnion.Client
                                     var offset = (int)messagePackReader.Consumed;
                                     var rest = new ArraySegment<byte>(data, offset, data.Length - offset);
                                     var error = MessagePackSerializer.Deserialize<string>(rest, serializerOptions);
-                                    (future as ITaskCompletion).TrySetException(new RpcException(new Status((StatusCode)statusCode, detail), error));
+                                    var ex = default(RpcException);
+                                    if (string.IsNullOrWhiteSpace(error))
+                                    {
+                                        ex = new RpcException(new Status((StatusCode)statusCode, detail));
+                                    }
+                                    else
+                                    {
+                                        ex = new RpcException(new Status((StatusCode)statusCode, detail), detail + Environment.NewLine + error);
+                                    }
+
+                                    (future as ITaskCompletion).TrySetException(ex);
                                 }
                             }
                             else

--- a/src/MagicOnion.Server/Hubs/StreamingHub.cs
+++ b/src/MagicOnion.Server/Hubs/StreamingHub.cs
@@ -219,7 +219,7 @@ namespace MagicOnion.Server.Hubs
                         {
                             isErrorOrInterrupted = true;
                             Context.MethodHandler.logger.Error(ex, context);
-                            await context.WriteErrorMessage((int)StatusCode.Internal, "Erorr on " + handler.ToString(), ex, Context.MethodHandler.isReturnExceptionStackTraceInErrorDetail);
+                            await context.WriteErrorMessage((int)StatusCode.Internal, $"An error occurred while processing handler '{handler.ToString()}'.", ex, Context.MethodHandler.isReturnExceptionStackTraceInErrorDetail);
                         }
                         finally
                         {

--- a/src/MagicOnion.Server/ReturnStatusException.cs
+++ b/src/MagicOnion.Server/ReturnStatusException.cs
@@ -1,4 +1,4 @@
-﻿using Grpc.Core;
+using Grpc.Core;
 using System;
 
 namespace MagicOnion
@@ -9,6 +9,7 @@ namespace MagicOnion
         public string Detail { get; private set; }
 
         public ReturnStatusException(StatusCode statusCode, string detail)
+            : base($"The method has returned the status code '{statusCode}'." + (string.IsNullOrWhiteSpace(detail) ? "" : $" (Detail={detail})"))
         {
             this.StatusCode = statusCode;
             this.Detail = detail;


### PR DESCRIPTION
On the client side, clarify the message of exceptions thrown by StreamingHub handler.

## Before
### Unhandled Exception with IsReturnExceptionStackTraceInErrorDetail=true
```
Unhandled exception. Grpc.Core.RpcException: System.InvalidOperationException: shinu
   at MyApp.Server.Hubs.TimerHub.SetAsync(TimeSpan interval)
   ...
```

### Unhandled Exception with IsReturnExceptionStackTraceInErrorDetail=false
```
Unhandled exception. Grpc.Core.RpcException: Exception of type 'Grpc.Core.RpcException' was thrown.
   at MagicOnion.Client.StreamingHubClientBase`2.WriteMessageWithResponseAsync[TRequest,TResponse](Int32 methodId, TRequest message)
   ...
```

### ReturnStatusException
```
Unhandled exception. Grpc.Core.RpcException: Exception of type 'Grpc.Core.RpcException' was thrown.
   at MagicOnion.Client.StreamingHubClientBase`2.WriteMessageWithResponseAsync[TRequest,TResponse](Int32 methodId, TRequest message)
   ...
```

## After
### Unhandled Exception with IsReturnExceptionStackTraceInErrorDetail=true
```
Unhandled exception. Grpc.Core.RpcException: An error occurred while processing handler 'ITimerHub/SetAsync'.
System.InvalidOperationException: shinu
   at MyApp.Server.Hubs.TimerHub.SetAsync(TimeSpan interval)
   ...
```

### Unhandled Exception with IsReturnExceptionStackTraceInErrorDetail=false
```
Unhandled exception. Grpc.Core.RpcException: Status(StatusCode="Internal", Detail="An error occurred while processing handler 'ITimerHub/SetAsync'.")
   at MagicOnion.Client.StreamingHubClientBase`2.WriteMessageWithResponseAsync[TRequest,TResponse](Int32 methodId, TRequest message)
   ...
```

### ReturnStatusException
```
Unhandled exception. Grpc.Core.RpcException: Status(StatusCode="AlreadyExists", Detail="Sudeniaru")
   at MagicOnion.Client.StreamingHubClientBase`2.WriteMessageWithResponseAsync[TRequest,TResponse](Int32 methodId, TRequest message)
   ...
```