### PR TITLE
Better StreamingHubCilent Errors

### DIFF
--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
@@ -221,7 +221,6 @@ namespace ChatApp.Shared.Services {
 
 namespace ChatApp.Shared.Hubs {
     using Grpc.Core;
-    using Grpc.Core.Logging;
     using MagicOnion;
     using MagicOnion.Client;
     using MessagePack;

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnion.Shared/DynamicArgumentTuple.tt
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnion.Shared/DynamicArgumentTuple.tt
@@ -1,0 +1,91 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+
+using System;
+using MessagePack;
+using MessagePack.Formatters;
+
+namespace MagicOnion
+{
+    // T2 ~ T20
+
+<# for(var i = 2; i <= 20; i++) {
+    var typeArgs = string.Join(", ", Enumerable.Range(1, i).Select(x => string.Format("T{0}", x)));
+    var methodArgs = string.Join(", ", Enumerable.Range(1, i).Select(x => string.Format("T{0} item{0}", x)));
+    var defaultArgs = string.Join(", ", Enumerable.Range(1, i).Select(x => string.Format("T{0} default{0}", x)));
+    var itemArgs = string.Join(", ", Enumerable.Range(1, i).Select(x => string.Format("item{0}", x)));
+ #>
+    
+    [MessagePackObject]
+    public struct DynamicArgumentTuple<<#= typeArgs #>>
+    {
+<# for(var j = 1; j <= i; j++) { #>
+        [Key(<#= j - 1  #>)]
+        public readonly T<#= j#> Item<#= j #>;
+<# } #>
+
+        [SerializationConstructor]
+        public DynamicArgumentTuple(<#= methodArgs #>)
+        {
+<# for(var j = 1; j <= i; j++) { #>
+            Item<#= j#> = item<#= j #>;
+<# } #>
+        }
+    }
+
+    public class DynamicArgumentTupleFormatter<<#= typeArgs #>> : IMessagePackFormatter<DynamicArgumentTuple<<#= typeArgs #>>>
+    {
+<# for(var j = 1; j <= i; j++) { #>
+        readonly T<#= j #> default<#= j #>;
+<# } #>
+
+        public DynamicArgumentTupleFormatter(<#= defaultArgs #>)
+        {
+<# for(var j = 1; j <= i; j++) { #>
+            this.default<#= j #> = default<#= j #>;
+<# } #>
+        }
+
+        public void Serialize(ref MessagePackWriter writer, DynamicArgumentTuple<<#= typeArgs #>> value, MessagePackSerializerOptions options)
+        {
+            writer.WriteArrayHeader(<#= i #>);
+            var resolver = options.Resolver;
+<# for(var j = 1; j <= i; j++) { #>
+            resolver.GetFormatterWithVerify<T<#= j #>>().Serialize(ref writer, value.Item<#= j #>, options);
+<# } #>
+        }
+
+        public DynamicArgumentTuple<<#= typeArgs #>> Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            var resolver = options.Resolver;
+            var length = reader.ReadArrayHeader();
+
+<# for(var j = 1; j <= i; j++) { #>
+            var item<#= j #> = default<#= j #>;
+<# } #>
+
+            for (var i = 0; i < length; i++)
+            {
+                switch (i)
+                {
+<# for(var j = 1; j <= i; j++) { #>
+                    case <#= j - 1 #>:
+                        item<#= j #> = resolver.GetFormatterWithVerify<T<#= j #>>().Deserialize(ref reader, options);
+                        break;
+<# } #>
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            return new DynamicArgumentTuple<<#= typeArgs #>>(<#= itemArgs #>);
+        }
+    }
+<# } #>
+}

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnion.Shared/DynamicArgumentTuple.tt.meta
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnion.Shared/DynamicArgumentTuple.tt.meta
@@ -1,6 +1,5 @@
 fileFormatVersion: 2
-guid: 4b43caeab3711be4fa5ec77eead8cc06
-folderAsset: yes
+guid: 59615cf4be44c9742a5323cbca21b0e5
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnion.Shared/Utils.meta
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnion.Shared/Utils.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d8d85fc389f703d45933750aa9b14eae
+guid: 4e8944691aa67234997771ba1a99d79f
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnion.Shared/Utils/ReservedWhenAllPromise.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnion.Shared/Utils/ReservedWhenAllPromise.cs
@@ -1,4 +1,4 @@
-﻿#if NON_UNITY
+#if NON_UNITY
 
 using System;
 using System.Runtime.CompilerServices;

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnionClient.CCore.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnionClient.CCore.cs
@@ -1,4 +1,4 @@
-#if !NON_UNITY || NET461
+#if !NON_UNITY || NET461 || NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnionClient.NetStandard.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/MagicOnionClient.NetStandard.cs
@@ -1,4 +1,4 @@
-#if NON_UNITY && !NET461
+#if NON_UNITY && !NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.CCore.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.CCore.cs
@@ -1,7 +1,9 @@
-#if !NON_UNITY || NET461
+#if !NON_UNITY || NET461 || NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Grpc.Core;
 using MessagePack;
 
@@ -9,10 +11,17 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
+        [Obsolete("Use ConnectAsync instead.")]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             return Connect<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger);
+        }
+
+        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null, CancellationToken cancellationToken = default)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            return ConnectAsync<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger, cancellationToken);
         }
     }
 }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.NetStandard.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.NetStandard.cs
@@ -1,7 +1,9 @@
-#if NON_UNITY && !NET461
+#if NON_UNITY && !NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Net.Client;
 using MessagePack;
@@ -10,10 +12,17 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
+        [Obsolete("Use ConnectAsync instead.")]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             return Connect<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
+        }
+        
+        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null, CancellationToken cancellationToken = default)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            return ConnectAsync<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger, cancellationToken);
         }
     }
 }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClientBase.cs
@@ -9,12 +9,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using MagicOnion.Server;
 using System.Buffers;
+using System.Linq;
 
 namespace MagicOnion.Client
 {
     public abstract class StreamingHubClientBase<TStreamingHub, TReceiver>
         where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
     {
+        const string StreamingHubVersionHeaderKey = "x-magiconion-streaminghub-version";
+        const string StreamingHubVersionHeaderValue = "2";
+
         readonly string host;
         readonly CallOptions option;
         readonly CallInvoker callInvoker;
@@ -46,8 +50,9 @@ namespace MagicOnion.Client
         protected abstract Method<byte[], byte[]> DuplexStreamingAsyncMethod { get; }
 
         // call immediately after create.
-        public void __ConnectAndSubscribe(TReceiver receiver)
+        public async Task __ConnectAndSubscribeAsync(TReceiver receiver, CancellationToken cancellationToken)
         {
+            var syncContext = SynchronizationContext.Current; // capture SynchronizationContext.
             var callResult = callInvoker.AsyncDuplexStreamingCall<byte[], byte[]>(DuplexStreamingAsyncMethod, host, option);
             var streamingResult = new DuplexStreamingResult<byte[], byte[]>(
                 callResult,
@@ -58,91 +63,70 @@ namespace MagicOnion.Client
 
             this.connection = streamingResult;
             this.receiver = receiver;
-            this.subscription = StartSubscribe();
+
+            // Establish StreamingHub connection between the client and the server.
+            Metadata.Entry messageVersion = default;
+            try
+            {
+                // The client can read the response headers before any StreamingHub's message.
+                // MagicOnion.Server v4.0.x or before doesn't send any response headers. The client is incompatible with that versions.
+                // NOTE: Grpc.Net:
+                //           If the channel can not be connected, ResponseHeadersAsync will throw an exception.
+                //       C-core:
+                //           If the channel can not be connected, ResponseHeadersAsync will **return** an empty metadata.
+                var headers = await streamingResult.ResponseHeadersAsync.ConfigureAwait(false);
+                messageVersion = headers.FirstOrDefault(x => x.Key == StreamingHubVersionHeaderKey);
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Check message version of StreamingHub.
+                if (messageVersion != null && messageVersion.Value != StreamingHubVersionHeaderValue)
+                {
+                    throw new RpcException(new Status(StatusCode.Internal, $"The message version of StreamingHub mismatch between the client and the server. (ServerVersion={messageVersion?.Value}; Expected={StreamingHubVersionHeaderValue})"));
+                }
+            }
+            catch (RpcException e)
+            {
+                throw new RpcException(e.Status, $"Failed to connect to StreamingHub '{DuplexStreamingAsyncMethod.ServiceName}'. ({e.Status})");
+            }
+
+            var firstMoveNextTask = connection.RawStreamingCall.ResponseStream.MoveNext(CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token).Token);
+            if (firstMoveNextTask.IsFaulted || messageVersion == null)
+            {
+                // NOTE: Grpc.Net:
+                //           If an error is returned from `StreamingHub.Connect` method on a server-side,
+                //           ResponseStream.MoveNext synchronously returns a task that is `IsFaulted = true`.
+                //           `ConnectAsync` method should throw an exception here immediately.
+                //       C-core:
+                //           `firstMoveNextTask` is incomplete task (`IsFaulted = false`) whether ResponseHeadersAsync is failed or not.
+                //           If the channel is disconnected or the server returns an error (StatusCode != OK), awaiting the Task will throw an exception.
+                await firstMoveNextTask.ConfigureAwait(false);
+
+                // NOTE: C-core: If the execution reaches here, Connect method returns without any error (StatusCode = OK). but MessageVersion isn't provided from the server.
+                throw new RpcException(new Status(StatusCode.Internal, $"The message version of StreamingHub is not provided from the server."));
+            }
+
+            this.subscription = StartSubscribe(syncContext, firstMoveNextTask);
         }
 
         protected abstract void OnResponseEvent(int methodId, object taskCompletionSource, ArraySegment<byte> data);
         protected abstract void OnBroadcastEvent(int methodId, ArraySegment<byte> data);
 
-        async Task StartSubscribe()
+        async Task StartSubscribe(SynchronizationContext syncContext, Task<bool> firstMoveNext)
         {
-            var syncContext = SynchronizationContext.Current; // capture SynchronizationContext.
             var reader = connection.RawStreamingCall.ResponseStream;
             try
             {
-                while (await reader.MoveNext(cts.Token).ConfigureAwait(false)) // avoid Post to SyncContext(it losts one-frame per operation)
+                var moveNext = firstMoveNext;
+                while (await moveNext.ConfigureAwait(false)) // avoid Post to SyncContext(it losts one-frame per operation)
                 {
                     try
                     {
-                        // MessageFormat:
-                        // broadcast: [methodId, [argument]]
-                        // response:  [messageId, methodId, response]
-                        // error-response: [messageId, statusCode, detail, StringMessage]
-                        void ConsumeData(byte[] data)
-                        {
-                            var messagePackReader = new MessagePackReader(data);
-                            var arrayLength = messagePackReader.ReadArrayHeader();
-                            if (arrayLength == 3)
-                            {
-                                var messageId = messagePackReader.ReadInt32();
-                                object future;
-                                if (responseFutures.TryRemove(messageId, out future))
-                                {
-                                    var methodId = messagePackReader.ReadInt32();
-                                    try
-                                    {
-                                        var offset = (int)messagePackReader.Consumed;
-                                        var rest = new ArraySegment<byte>(data, offset, data.Length - offset);
-                                        OnResponseEvent(methodId, future, rest);
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        if (!(future as ITaskCompletion).TrySetException(ex))
-                                        {
-                                            throw;
-                                        }
-                                    }
-                                }
-                            }
-                            else if (arrayLength == 4)
-                            {
-                                var messageId = messagePackReader.ReadInt32();
-                                object future;
-                                if (responseFutures.TryRemove(messageId, out future))
-                                {
-                                    var statusCode = messagePackReader.ReadInt32();
-                                    var detail = messagePackReader.ReadString();
-                                    var offset = (int)messagePackReader.Consumed;
-                                    var rest = new ArraySegment<byte>(data, offset, data.Length - offset);
-                                    var error = MessagePackSerializer.Deserialize<string>(rest, serializerOptions);
-                                    (future as ITaskCompletion).TrySetException(new RpcException(new Status((StatusCode)statusCode, detail), error));
-                                }
-                            }
-                            else
-                            {
-                                var methodId = messagePackReader.ReadInt32();
-                                var offset = (int)messagePackReader.Consumed;
-                                if (syncContext != null)
-                                {
-                                    var tuple = Tuple.Create(methodId, data, offset, data.Length - offset);
-                                    syncContext.Post(state =>
-                                    {
-                                        var t = (Tuple<int, byte[], int, int>)state;
-                                        OnBroadcastEvent(t.Item1, new ArraySegment<byte>(t.Item2, t.Item3, t.Item4));
-                                    }, tuple);
-                                }
-                                else
-                                {
-                                    OnBroadcastEvent(methodId, new ArraySegment<byte>(data, offset, data.Length - offset));
-                                }
-                            }
-                        }
-
-                        ConsumeData(reader.Current);
+                        ConsumeData(syncContext, reader.Current);
                     }
                     catch (Exception ex)
                     {
-                        const string msg = "Error on consume received message, but keep subscribe.";
+                        const string msg = "An error occurred when consuming a received message, but the subscription is still alive.";
                         // log post on main thread.
                         if (syncContext != null)
                         {
@@ -153,6 +137,8 @@ namespace MagicOnion.Client
                             logger.Error(ex, msg);
                         }
                     }
+
+                    moveNext = reader.MoveNext(cts.Token);
                 }
             }
             catch (Exception ex)
@@ -161,7 +147,7 @@ namespace MagicOnion.Client
                 {
                     return;
                 }
-                const string msg = "Error on subscribing message.";
+                const string msg = "An error occurred while subscribing to messages.";
                 // log post on main thread.
                 if (syncContext != null)
                 {
@@ -190,10 +176,83 @@ namespace MagicOnion.Client
             }
         }
 
+        // MessageFormat:
+        // broadcast: [methodId, [argument]]
+        // response:  [messageId, methodId, response]
+        // error-response: [messageId, statusCode, detail, StringMessage]
+        void ConsumeData(SynchronizationContext syncContext, byte[] data)
+        {
+            var messagePackReader = new MessagePackReader(data);
+            var arrayLength = messagePackReader.ReadArrayHeader();
+            if (arrayLength == 3)
+            {
+                var messageId = messagePackReader.ReadInt32();
+                object future;
+                if (responseFutures.TryRemove(messageId, out future))
+                {
+                    var methodId = messagePackReader.ReadInt32();
+                    try
+                    {
+                        var offset = (int)messagePackReader.Consumed;
+                        var rest = new ArraySegment<byte>(data, offset, data.Length - offset);
+                        OnResponseEvent(methodId, future, rest);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (!(future as ITaskCompletion).TrySetException(ex))
+                        {
+                            throw;
+                        }
+                    }
+                }
+            }
+            else if (arrayLength == 4)
+            {
+                var messageId = messagePackReader.ReadInt32();
+                object future;
+                if (responseFutures.TryRemove(messageId, out future))
+                {
+                    var statusCode = messagePackReader.ReadInt32();
+                    var detail = messagePackReader.ReadString();
+                    var offset = (int)messagePackReader.Consumed;
+                    var rest = new ArraySegment<byte>(data, offset, data.Length - offset);
+                    var error = MessagePackSerializer.Deserialize<string>(rest, serializerOptions);
+                    var ex = default(RpcException);
+                    if (string.IsNullOrWhiteSpace(error))
+                    {
+                        ex = new RpcException(new Status((StatusCode)statusCode, detail));
+                    }
+                    else
+                    {
+                        ex = new RpcException(new Status((StatusCode)statusCode, detail), detail + Environment.NewLine + error);
+                    }
+
+                    (future as ITaskCompletion).TrySetException(ex);
+                }
+            }
+            else
+            {
+                var methodId = messagePackReader.ReadInt32();
+                var offset = (int)messagePackReader.Consumed;
+                if (syncContext != null)
+                {
+                    var tuple = Tuple.Create(methodId, data, offset, data.Length - offset);
+                    syncContext.Post(state =>
+                    {
+                        var t = (Tuple<int, byte[], int, int>)state;
+                        OnBroadcastEvent(t.Item1, new ArraySegment<byte>(t.Item2, t.Item3, t.Item4));
+                    }, tuple);
+                }
+                else
+                {
+                    OnBroadcastEvent(methodId, new ArraySegment<byte>(data, offset, data.Length - offset));
+                }
+            }
+        }
 
         protected async Task WriteMessageAsync<T>(int methodId, T message)
         {
-            ThrowIfDisposed();
+            ThrowIfDisposedOrDisconnected();
 
             byte[] BuildMessage()
             {
@@ -218,12 +277,14 @@ namespace MagicOnion.Client
         protected async Task<TResponse> WriteMessageAsyncFireAndForget<TRequest, TResponse>(int methodId, TRequest message)
         {
             await WriteMessageAsync(methodId, message).ConfigureAwait(false);
-            return default(TResponse);
+#pragma warning disable CS8603 // Possible null reference return.
+            return default;
+#pragma warning restore CS8603 // Possible null reference return.
         }
 
         protected async Task<TResponse> WriteMessageWithResponseAsync<TRequest, TResponse>(int methodId, TRequest message)
         {
-            ThrowIfDisposed();
+            ThrowIfDisposedOrDisconnected();
 
             var mid = Interlocked.Increment(ref messageId);
             var tcs = new TaskCompletionSourceEx<TResponse>(); // use Ex
@@ -252,9 +313,17 @@ namespace MagicOnion.Client
             return await tcs.Task; // wait until server return response(or error). if connection was closed, throws cancellation from DisposeAsyncCore.
         }
 
-        void ThrowIfDisposed()
+        void ThrowIfDisposedOrDisconnected()
         {
-            if (disposed) throw new ObjectDisposedException("StreamingHubClient");
+            if (disposed)
+            {
+                throw new ObjectDisposedException("StreamingHubClient", $"The StreamingHub has already been disconnected from the server.");
+            }
+
+            if (subscription == null)
+            {
+                throw new InvalidOperationException("The StreamingHub is not connected to the server yet.");
+            }
         }
 
         public Task WaitForDisconnect()

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.CCore.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.CCore.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 using MessagePack;
@@ -17,10 +18,10 @@ namespace MagicOnion.Client
             return Connect<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger);
         }
 
-        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null, CancellationToken cancellationToken = default)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
-            return ConnectAsync<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger);
+            return ConnectAsync<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger, cancellationToken);
         }
     }
 }

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.CCore.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.CCore.cs
@@ -10,7 +10,7 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
-        [Obsolete]
+        [Obsolete("Use ConnectAsync instead.")]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.CCore.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.CCore.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Grpc.Core;
 using MessagePack;
 
@@ -9,10 +10,17 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
+        [Obsolete]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             return Connect<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger);
+        }
+
+        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            return ConnectAsync<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger);
         }
     }
 }

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.NetStandard.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.NetStandard.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Net.Client;
 using MessagePack;
@@ -10,10 +11,17 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
+        [Obsolete]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             return Connect<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
+        }
+        
+        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            return ConnectAsync<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
         }
     }
 }

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.NetStandard.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.NetStandard.cs
@@ -11,7 +11,7 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
-        [Obsolete]
+        [Obsolete("Use ConnectAsync instead.")]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.NetStandard.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.NetStandard.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Net.Client;
@@ -18,10 +19,10 @@ namespace MagicOnion.Client
             return Connect<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
         }
         
-        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null, CancellationToken cancellationToken = default)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
-            return ConnectAsync<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
+            return ConnectAsync<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger, cancellationToken);
         }
     }
 }

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.cs
@@ -7,7 +7,7 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
-        [Obsolete]
+        [Obsolete("Use ConnectAsync instead.")]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
              where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.cs
@@ -12,7 +12,22 @@ namespace MagicOnion.Client
              where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             var client = CreateClient<TStreamingHub, TReceiver>(callInvoker, receiver, host, option, serializerOptions, logger);
-            _ = client.__ConnectAndSubscribeAsync(receiver);
+
+            async void ConnectAndForget()
+            {
+                var task = client.__ConnectAndSubscribeAsync(receiver);
+                try
+                {
+                    await task;
+                }
+                catch (Exception e)
+                {
+                    logger?.Error(e, "An error occurred while connecting to the server.");
+                }
+            }
+
+            ConnectAndForget();
+
             return (TStreamingHub)(object)client;
         }
 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.cs
@@ -1,6 +1,7 @@
 using Grpc.Core;
 using MessagePack;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MagicOnion.Client
@@ -15,7 +16,7 @@ namespace MagicOnion.Client
 
             async void ConnectAndForget()
             {
-                var task = client.__ConnectAndSubscribeAsync(receiver);
+                var task = client.__ConnectAndSubscribeAsync(receiver, CancellationToken.None);
                 try
                 {
                     await task;
@@ -31,11 +32,11 @@ namespace MagicOnion.Client
             return (TStreamingHub)(object)client;
         }
 
-        public static async Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+        public static async Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null, CancellationToken cancellationToken = default)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             var client = CreateClient<TStreamingHub, TReceiver>(callInvoker, receiver, host, option, serializerOptions, logger);
-            await client.__ConnectAndSubscribeAsync(receiver).ConfigureAwait(false);
+            await client.__ConnectAndSubscribeAsync(receiver, cancellationToken).ConfigureAwait(false);
             return (TStreamingHub)(object)client;
         }
         

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClient.cs
@@ -1,13 +1,31 @@
 using Grpc.Core;
 using MessagePack;
 using System;
+using System.Threading.Tasks;
 
 namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
+        [Obsolete]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
              where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            var client = CreateClient<TStreamingHub, TReceiver>(callInvoker, receiver, host, option, serializerOptions, logger);
+            _ = client.__ConnectAndSubscribeAsync(receiver);
+            return (TStreamingHub)(object)client;
+        }
+
+        public static async Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            var client = CreateClient<TStreamingHub, TReceiver>(callInvoker, receiver, host, option, serializerOptions, logger);
+            await client.__ConnectAndSubscribeAsync(receiver).ConfigureAwait(false);
+            return (TStreamingHub)(object)client;
+        }
+        
+        private static StreamingHubClientBase<TStreamingHub, TReceiver> CreateClient<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host, CallOptions option, MessagePackSerializerOptions serializerOptions, IMagicOnionClientLogger logger)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             var ctor = StreamingHubClientRegistry<TStreamingHub, TReceiver>.consturtor;
             StreamingHubClientBase<TStreamingHub, TReceiver> client = null;
@@ -25,8 +43,7 @@ namespace MagicOnion.Client
                 client = (StreamingHubClientBase<TStreamingHub, TReceiver>)(object)ctor(callInvoker, receiver, host, option, serializerOptions, logger);
             }
 
-            client.__ConnectAndSubscribe(receiver);
-            return (TStreamingHub)(object)client;
+            return client;
         }
     }
 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClientBase.cs
@@ -169,7 +169,7 @@ namespace MagicOnion.Client
                     }
                     catch (Exception ex)
                     {
-                        const string msg = "Error on consume received message, but keep subscribe.";
+                        const string msg = "An error occurred when consuming a received message, but the subscription is still alive.";
                         // log post on main thread.
                         if (syncContext != null)
                         {
@@ -188,7 +188,7 @@ namespace MagicOnion.Client
                 {
                     return;
                 }
-                const string msg = "Error on subscribing message.";
+                const string msg = "An error occurred while subscribing to messages.";
                 // log post on main thread.
                 if (syncContext != null)
                 {
@@ -283,7 +283,10 @@ namespace MagicOnion.Client
 
         void ThrowIfDisposed()
         {
-            if (disposed) throw new ObjectDisposedException("StreamingHubClient");
+            if (disposed)
+            {
+                throw new ObjectDisposedException("StreamingHubClient", $"The StreamingHub has already been disconnected from the server.");
+            }
         }
 
         public Task WaitForDisconnect()

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client/StreamingHubClientBase.cs
@@ -250,7 +250,7 @@ namespace MagicOnion.Client
 
         protected async Task WriteMessageAsync<T>(int methodId, T message)
         {
-            ThrowIfDisposed();
+            ThrowIfDisposedOrDisconnected();
 
             byte[] BuildMessage()
             {
@@ -282,7 +282,7 @@ namespace MagicOnion.Client
 
         protected async Task<TResponse> WriteMessageWithResponseAsync<TRequest, TResponse>(int methodId, TRequest message)
         {
-            ThrowIfDisposed();
+            ThrowIfDisposedOrDisconnected();
 
             var mid = Interlocked.Increment(ref messageId);
             var tcs = new TaskCompletionSourceEx<TResponse>(); // use Ex
@@ -311,11 +311,16 @@ namespace MagicOnion.Client
             return await tcs.Task; // wait until server return response(or error). if connection was closed, throws cancellation from DisposeAsyncCore.
         }
 
-        void ThrowIfDisposed()
+        void ThrowIfDisposedOrDisconnected()
         {
             if (disposed)
             {
                 throw new ObjectDisposedException("StreamingHubClient", $"The StreamingHub has already been disconnected from the server.");
+            }
+
+            if (subscription == null)
+            {
+                throw new InvalidOperationException("The StreamingHub is not connected to the server yet.");
             }
         }
 

--- a/src/MagicOnion.Client/StreamingHubClient.CCore.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.CCore.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 using MessagePack;
@@ -17,10 +18,10 @@ namespace MagicOnion.Client
             return Connect<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger);
         }
 
-        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null, CancellationToken cancellationToken = default)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
-            return ConnectAsync<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger);
+            return ConnectAsync<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger, cancellationToken);
         }
     }
 }

--- a/src/MagicOnion.Client/StreamingHubClient.CCore.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.CCore.cs
@@ -10,7 +10,7 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
-        [Obsolete]
+        [Obsolete("Use ConnectAsync instead.")]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {

--- a/src/MagicOnion.Client/StreamingHubClient.CCore.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.CCore.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Grpc.Core;
 using MessagePack;
 
@@ -9,10 +10,17 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
+        [Obsolete]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             return Connect<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger);
+        }
+
+        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(Channel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            return ConnectAsync<TStreamingHub, TReceiver>(new DefaultCallInvoker(channel), receiver, host, option, serializerOptions, logger);
         }
     }
 }

--- a/src/MagicOnion.Client/StreamingHubClient.NetStandard.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.NetStandard.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Net.Client;
 using MessagePack;
@@ -10,10 +11,17 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
+        [Obsolete]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             return Connect<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
+        }
+        
+        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            return ConnectAsync<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
         }
     }
 }

--- a/src/MagicOnion.Client/StreamingHubClient.NetStandard.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.NetStandard.cs
@@ -11,7 +11,7 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
-        [Obsolete]
+        [Obsolete("Use ConnectAsync instead.")]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {

--- a/src/MagicOnion.Client/StreamingHubClient.NetStandard.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.NetStandard.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Net.Client;
@@ -18,10 +19,10 @@ namespace MagicOnion.Client
             return Connect<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
         }
         
-        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+        public static Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(GrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null, CancellationToken cancellationToken = default)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
-            return ConnectAsync<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
+            return ConnectAsync<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger, cancellationToken);
         }
     }
 }

--- a/src/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.cs
@@ -7,7 +7,7 @@ namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
-        [Obsolete]
+        [Obsolete("Use ConnectAsync instead.")]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
              where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {

--- a/src/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.cs
@@ -12,7 +12,22 @@ namespace MagicOnion.Client
              where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             var client = CreateClient<TStreamingHub, TReceiver>(callInvoker, receiver, host, option, serializerOptions, logger);
-            _ = client.__ConnectAndSubscribeAsync(receiver);
+
+            async void ConnectAndForget()
+            {
+                var task = client.__ConnectAndSubscribeAsync(receiver);
+                try
+                {
+                    await task;
+                }
+                catch (Exception e)
+                {
+                    logger?.Error(e, "An error occurred while connecting to the server.");
+                }
+            }
+
+            ConnectAndForget();
+
             return (TStreamingHub)(object)client;
         }
 

--- a/src/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.cs
@@ -1,6 +1,7 @@
 using Grpc.Core;
 using MessagePack;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MagicOnion.Client
@@ -15,7 +16,7 @@ namespace MagicOnion.Client
 
             async void ConnectAndForget()
             {
-                var task = client.__ConnectAndSubscribeAsync(receiver);
+                var task = client.__ConnectAndSubscribeAsync(receiver, CancellationToken.None);
                 try
                 {
                     await task;
@@ -31,11 +32,11 @@ namespace MagicOnion.Client
             return (TStreamingHub)(object)client;
         }
 
-        public static async Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+        public static async Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null, CancellationToken cancellationToken = default)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             var client = CreateClient<TStreamingHub, TReceiver>(callInvoker, receiver, host, option, serializerOptions, logger);
-            await client.__ConnectAndSubscribeAsync(receiver).ConfigureAwait(false);
+            await client.__ConnectAndSubscribeAsync(receiver, cancellationToken).ConfigureAwait(false);
             return (TStreamingHub)(object)client;
         }
         

--- a/src/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.cs
@@ -1,13 +1,31 @@
 using Grpc.Core;
 using MessagePack;
 using System;
+using System.Threading.Tasks;
 
 namespace MagicOnion.Client
 {
     public static partial class StreamingHubClient
     {
+        [Obsolete]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
              where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            var client = CreateClient<TStreamingHub, TReceiver>(callInvoker, receiver, host, option, serializerOptions, logger);
+            _ = client.__ConnectAndSubscribeAsync(receiver);
+            return (TStreamingHub)(object)client;
+        }
+
+        public static async Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            var client = CreateClient<TStreamingHub, TReceiver>(callInvoker, receiver, host, option, serializerOptions, logger);
+            await client.__ConnectAndSubscribeAsync(receiver).ConfigureAwait(false);
+            return (TStreamingHub)(object)client;
+        }
+        
+        private static StreamingHubClientBase<TStreamingHub, TReceiver> CreateClient<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host, CallOptions option, MessagePackSerializerOptions serializerOptions, IMagicOnionClientLogger logger)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             var ctor = StreamingHubClientRegistry<TStreamingHub, TReceiver>.consturtor;
             StreamingHubClientBase<TStreamingHub, TReceiver> client = null;
@@ -25,8 +43,7 @@ namespace MagicOnion.Client
                 client = (StreamingHubClientBase<TStreamingHub, TReceiver>)(object)ctor(callInvoker, receiver, host, option, serializerOptions, logger);
             }
 
-            client.__ConnectAndSubscribe(receiver);
-            return (TStreamingHub)(object)client;
+            return client;
         }
     }
 

--- a/src/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/src/MagicOnion.Client/StreamingHubClientBase.cs
@@ -169,7 +169,7 @@ namespace MagicOnion.Client
                     }
                     catch (Exception ex)
                     {
-                        const string msg = "Error on consume received message, but keep subscribe.";
+                        const string msg = "An error occurred when consuming a received message, but the subscription is still alive.";
                         // log post on main thread.
                         if (syncContext != null)
                         {
@@ -188,7 +188,7 @@ namespace MagicOnion.Client
                 {
                     return;
                 }
-                const string msg = "Error on subscribing message.";
+                const string msg = "An error occurred while subscribing to messages.";
                 // log post on main thread.
                 if (syncContext != null)
                 {
@@ -283,7 +283,10 @@ namespace MagicOnion.Client
 
         void ThrowIfDisposed()
         {
-            if (disposed) throw new ObjectDisposedException("StreamingHubClient");
+            if (disposed)
+            {
+                throw new ObjectDisposedException("StreamingHubClient", $"The StreamingHub has already been disconnected from the server.");
+            }
         }
 
         public Task WaitForDisconnect()

--- a/src/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/src/MagicOnion.Client/StreamingHubClientBase.cs
@@ -250,7 +250,7 @@ namespace MagicOnion.Client
 
         protected async Task WriteMessageAsync<T>(int methodId, T message)
         {
-            ThrowIfDisposed();
+            ThrowIfDisposedOrDisconnected();
 
             byte[] BuildMessage()
             {
@@ -282,7 +282,7 @@ namespace MagicOnion.Client
 
         protected async Task<TResponse> WriteMessageWithResponseAsync<TRequest, TResponse>(int methodId, TRequest message)
         {
-            ThrowIfDisposed();
+            ThrowIfDisposedOrDisconnected();
 
             var mid = Interlocked.Increment(ref messageId);
             var tcs = new TaskCompletionSourceEx<TResponse>(); // use Ex
@@ -311,11 +311,16 @@ namespace MagicOnion.Client
             return await tcs.Task; // wait until server return response(or error). if connection was closed, throws cancellation from DisposeAsyncCore.
         }
 
-        void ThrowIfDisposed()
+        void ThrowIfDisposedOrDisconnected()
         {
             if (disposed)
             {
                 throw new ObjectDisposedException("StreamingHubClient", $"The StreamingHub has already been disconnected from the server.");
+            }
+
+            if (subscription == null)
+            {
+                throw new InvalidOperationException("The StreamingHub is not connected to the server yet.");
             }
         }
 

--- a/src/MagicOnion.Server/Hubs/StreamingHub.cs
+++ b/src/MagicOnion.Server/Hubs/StreamingHub.cs
@@ -13,6 +13,11 @@ namespace MagicOnion.Server.Hubs
         static protected readonly Task<Nil> NilTask = Task.FromResult(Nil.Default);
         static protected readonly ValueTask CompletedTask = new ValueTask();
 
+        static readonly Metadata ResponseHeaders = new Metadata()
+        {
+            { "x-magiconion-streaminghub-version", "2" },
+        };
+
         public HubGroupRepository Group { get; private set; } = default!; /* lateinit */
 
         protected Guid ConnectionId { get { return Context.ContextId; } }
@@ -116,7 +121,7 @@ namespace MagicOnion.Server.Hubs
 
             // Send a hint to the client to start sending messages.
             // The client can read the response headers before any StreamingHub's message.
-            await Context.CallContext.WriteResponseHeadersAsync(Metadata.Empty);
+            await Context.CallContext.WriteResponseHeadersAsync(ResponseHeaders);
 
             var handlers = StreamingHubHandlerRepository.GetHandlers(Context.MethodHandler);
 

--- a/src/MagicOnion.Server/Hubs/StreamingHub.cs
+++ b/src/MagicOnion.Server/Hubs/StreamingHub.cs
@@ -114,6 +114,10 @@ namespace MagicOnion.Server.Hubs
             var reader = Context.RequestStream!;
             var writer = Context.ResponseStream!;
 
+            // Send a hint to the client to start sending messages.
+            // The client can read the response headers before any StreamingHub's message.
+            await Context.CallContext.WriteResponseHeadersAsync(Metadata.Empty);
+
             var handlers = StreamingHubHandlerRepository.GetHandlers(Context.MethodHandler);
 
             // Main loop of StreamingHub.


### PR DESCRIPTION
## Breaking changes
- MagicOnion.Client (4.1.x or later) is not compatible with MagicOnion.Server v4.0.x or ealier.
    - MagicOnion.Client 4.0.x or earlier + MagicOnion.Server v4.1 is still compatible.

## Improvements
### Introduce StreamingHubClient.ConnectAsync
Added `ConnectAsync` method to wait for StreamingHub connection establishment. `ConnectAsync` will be able to catch errors while trying to connect.

For example, if the channel has not been established, or if there is an authentication error.

```csharp
try
{
    var client = await StreamingHubClient.ConnectAsync<Hub, HubReceiver>(channel, this);
    // Do stuff...
}
catch (RpcException ex)
{
    // An error occurred while connecting to the server.
}
```

> NOTE: `StreamingHubClient.Connect` is marked as deprecated. Use `ConnectAsync` instead.