### PR TITLE
chore: detect forgotten .meta file commit

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -63,8 +63,7 @@ jobs:
       image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
       - run: apt-get update && apt-get install git -y
-      # v2 was accidentally fall back to http. let's use v1 instead.
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       # activate Unity from manual license file(ulf)
       - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
         env:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -63,7 +63,9 @@ jobs:
       image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
       # Ubuntu 18.04 git is too old, use ppa latest git.
-      - run: add-apt-repository ppa:git-core/ppa && apt-get update && apt-get install git -y
+      - run: |
+          apt-get update && apt-get install --no-install-recommends -y software-properties-common && add-apt-repository -y ppa:git-core/ppa
+          apt-get update && apt-get install --no-install-recommends -y git
       - uses: actions/checkout@v2
       # activate Unity from manual license file(ulf)
       - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -63,7 +63,8 @@ jobs:
       image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
       - run: apt-get update && apt-get install git -y
-      - uses: actions/checkout@v2
+      # v2 was accidentally fall back to http. let's use v1 instead.
+      - uses: actions/checkout@v1
       # activate Unity from manual license file(ulf)
       - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
         env:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -87,10 +87,10 @@ jobs:
         run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
         working-directory: src/MagicOnion.Client.Unity
 
-      - name: check missing .meta is exists
+      - name: check all .meta is commited
         run: |
           if git ls-files --others --exclude-standard -t | grep --regexp='[.]meta$'; then
-            echo "Detected forgotten commit .meta file."
+            echo "Detected .meta file generated. Do you forgot commit a .meta file?"
             exit 1
           else
             echo "Great, all .meta files are commited."

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -84,6 +84,16 @@ jobs:
         run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
         working-directory: src/MagicOnion.Client.Unity
 
+      - name: check missing .meta is exists
+        run: |
+          if git ls-files --others --exclude-standard -t | grep --regexp='[.]meta$'; then
+            echo "Detected forgotten commit .meta file."
+            exit 1
+          else
+            echo "Great, all .meta files are commited."
+          fi
+        working-directory: src/MagicOnion.Client.Unity
+
       # Store artifacts.
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -62,7 +62,8 @@ jobs:
       # https://hub.docker.com/r/gableroux/unity3d/tags
       image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
-      - run: apt-get update && apt-get install git -y
+      # Ubuntu 18.04 git is too old, use ppa latest git.
+      - run: add-apt-repository ppa:git-core/ppa && apt-get update && apt-get install git -y
       - uses: actions/checkout@v2
       # activate Unity from manual license file(ulf)
       - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -80,8 +80,7 @@ jobs:
       image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
       - run: apt-get update && apt-get install git -y
-      # v2 was accidentally fall back to http. let's use v1 instead.
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       # activate Unity from manual license file(ulf)
       - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
         env:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -80,7 +80,8 @@ jobs:
       image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
       - run: apt-get update && apt-get install git -y
-      - uses: actions/checkout@v2
+      # v2 was accidentally fall back to http. let's use v1 instead.
+      - uses: actions/checkout@v1
       # activate Unity from manual license file(ulf)
       - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
         env:


### PR DESCRIPTION
## TL;DR

Detect forgotten Unity `.meta` commit.

Use `git ls-files` to detect unstaged file generated via Unity Load on `export package`. (Unity Build Only)

* [x] Not a .meta produce commit should not fail.
* [x] .meta forgotten commit should fail.

## Sample

fail when .meta was generated.

https://github.com/Cysharp/MagicOnion/runs/1733409932

![image](https://user-images.githubusercontent.com/3856350/105147377-742de280-5b44-11eb-811c-bb2787998aff.png)

success when no .meta generated.

https://github.com/Cysharp/MagicOnion/runs/1733447897

![image](https://user-images.githubusercontent.com/3856350/105148340-9bd17a80-5b45-11eb-9248-2d9a8cd919bd.png)

## OMAKE

github actions checkout@v2 was fall back to http, due to container installed git was 2.17 and too old. Added ppa git and it works.