### PR TITLE
feat: bump minimum unity version to 2018.4.13f1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ MagicOnion client supports a wide range of platforms, including .NET Framework 4
 - Client-side (MagicOnion.Client)
     - .NET Standard 2.1 (.NET Core 3.x+, .NET 5.0+, Xamarin)
     - .NET Standard 2.0 (.NET Framework 4.6.1+, Universal Windows Platform, .NET Core 2.x)
-    - Unity 2018.3+
+    - Unity 2018.4.13f1+
 
 ## Quick Start
 ### Server-side project
@@ -856,7 +856,7 @@ public class MyFirstService : ServiceBase<IMyFirstService>, IMyFirstService
 # Clients
 
 ## Support for Unity client
-MagicOnion supports Unity version, which is available for `.NET 4.x` runtime and C# 7.3 or later. (Unity 2018.3+)
+MagicOnion supports Unity version, which is available for `.NET 4.x` runtime and Unity 2018.4.13f1+ or latest. (C# 7.3)
 
 Using MagicOnion with Unity client requires the following four things:
 
@@ -1293,7 +1293,7 @@ public interface IMyFirstService : IService<IMyFirstService>
 // Server
 public class MyFirstService : ServiceBase<IMyFirstService>, IMyFirstService
 {
-    // VisualStudio 2017(C# 7.0), Unity 2018.3 supports return `async UnaryResult` directly
+    // VisualStudio 2017(C# 7.0), Unity 2018.3+ supports return `async UnaryResult` directly
     // I recommend disable async-warning on project level. <NoWarn>1998</NoWarn>
     public async UnaryResult<string> SumAsync(int x, int y)
     {
@@ -1377,7 +1377,7 @@ Client sample.
 ```csharp
 static async Task UnaryRun(IMyFirstService client)
 {
-    // await(C# 7.0, Unity 2018.3)
+    // await(C# 7.0, Unity 2018.3+)
     var vvvvv = await client.SumAsync(10, 20);
     Console.WriteLine("SumAsync:" + vvvvv);
     

--- a/README.md
+++ b/README.md
@@ -856,7 +856,7 @@ public class MyFirstService : ServiceBase<IMyFirstService>, IMyFirstService
 # Clients
 
 ## Support for Unity client
-MagicOnion supports Unity version, which is available for `.NET 4.x` runtime and Unity 2018.4.13f1+ or latest. (C# 7.3)
+MagicOnion supports from Unity version 2018.4.13f1 and above, which is available for `.NET 4.x` runtime and C# 7.3 or latest.
 
 Using MagicOnion with Unity client requires the following four things:
 

--- a/samples/ChatApp.Telemetry/README.md
+++ b/samples/ChatApp.Telemetry/README.md
@@ -115,12 +115,7 @@ Now ChatApp.Unity can access to ChatApp.Server running on kubernetes.
 
 ## ChatApp.Unity
 
-Sample Clientside Unity.
-You can ran with Unity from 2018.4.5f1 and higher then start on unity editor.
-
-> TIPS: confirmed run on 2019.1.10f1
-
-Now unity client automatically connect to MagicOnion Server, try chat app!
+Sample Clientside Unity automatically connect to MagicOnion Server on play.
 
 ## Check Telemetry
 

--- a/samples/ChatApp/ChatApp.Unity/ProjectSettings/ProjectVersion.txt
+++ b/samples/ChatApp/ChatApp.Unity/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.4.5f1
+m_EditorVersion: 2018.4.13f1

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/package.json
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/package.json
@@ -2,7 +2,7 @@
     "name": "com.cysharp.magiconion",
     "displayName": "MagicOnion",
     "version": "4.0.4",
-    "unity": "2018.3",
+    "unity": "2018.4",
     "description": "Unified Realtime/API framework for .NET platform and Unity.",
     "keywords": [
       "grpc",

--- a/src/MagicOnion.Client.Unity/ProjectSettings/ProjectVersion.txt
+++ b/src/MagicOnion.Client.Unity/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.3.3f1
+m_EditorVersion: 2018.4.13f1


### PR DESCRIPTION
## TL;DR

Now MagicOnion minimum support Unity version is 2018.4.13f1 and above.

* update README
* update package.json
* update MagicOnion.Client.Unity version
* update ChatApp sample Unity version

ChatApp on 2018.4.13f1

![image](https://user-images.githubusercontent.com/3856350/105814236-6e2c7b80-5ff4-11eb-89d8-75767bbbe42e.png)
