### PR TITLE
Ignore OperationCanceledException thrown when a client disconnects.

### DIFF
--- a/src/MagicOnion.Server/Hubs/StreamingHub.cs
+++ b/src/MagicOnion.Server/Hubs/StreamingHub.cs
@@ -99,6 +99,11 @@ namespace MagicOnion.Server.Hubs
                 await OnConnecting();
                 await HandleMessageAsync();
             }
+            catch (OperationCanceledException)
+            {
+                // NOTE: If DuplexStreaming is disconnected by the client, OperationCanceledException will be thrown.
+                //       However, such behavior is expected. the exception can be ignored.
+            }
             catch (IOException ex) when (ex.InnerException is ConnectionAbortedException)
             {
                 // NOTE: If DuplexStreaming is disconnected by the client, IOException will be thrown.


### PR DESCRIPTION
Ignore OperationCanceledException thrown when a client disconnects.
An OperationCanceledException is thrown if a client disconnects while waiting for `IAsyncStreamReader.MoveNext`. But that is expected behavior.