### PR TITLE
fix: create release should refer after push sha

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -7,9 +7,8 @@ on:
     tags:
       - "!*" # not a tag push
   pull_request:
-    types:
-      - opened
-      - synchronize
+    branches:
+      - "master"
 
 jobs:
   build-dotnet:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -19,8 +19,8 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
-      DOTNET_SDK_VERSION_3: "3.1.403"
-      DOTNET_SDK_VERSION_5: "5.0.100"
+      DOTNET_SDK_VERSION_3: "3.1.x"
+      DOTNET_SDK_VERSION_5: "5.0.x"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
       - run: dotnet test ./tests/MagicOnion.Generator.Tests/ -c Debug
 
   build-unity:
-    if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]')) && ((github.event == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:'))"
+    if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]')) && ((github.event_name == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:'))"
     strategy:
       matrix:
         unity: ["2019.3.9f1", "2020.1.0b5"]

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,12 +42,15 @@ jobs:
         run: echo "SHA ${SHA}"
         env:
           SHA: ${{ steps.commit.outputs.sha }}
+      - name: tag
+        run: git tag ${{ env.GIT_TAG }}
+        if: env.DRY_RUN == 'false'
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
-          tags: false
+          tags: true
         if: env.DRY_RUN == 'false'
       - name: Push changes (dry_run)
         uses: ad-m/github-push-action@master
@@ -66,8 +69,8 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
-      DOTNET_SDK_VERSION_3: "3.1.403"
-      DOTNET_SDK_VERSION_5: "5.0.100"
+      DOTNET_SDK_VERSION_3: "3.1.x"
+      DOTNET_SDK_VERSION_5: "5.0.x"
     steps:
       - run: echo ${{ needs.update-packagejson.outputs.sha }}
       - uses: actions/checkout@v2
@@ -175,7 +178,7 @@ jobs:
     steps:
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 3.1.x
       # Create Release
       - uses: actions/create-release@v1
         id: create_release

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,15 +12,17 @@ on:
         default: "false"
 
 env:
+  GIT_TAG: ${{ github.event.inputs.tag }}
+  DRY_RUN: ${{ github.event.inputs.dry_run }}
   DRY_RUN_BRANCH_PREFIX: "test_release"
+  DOTNET_SDK_VERISON_3: 3.1.x
+  DOTNET_SDK_VERISON_5: 5.0.x
 
 jobs:
   update-packagejson:
     runs-on: ubuntu-latest
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       TARGET_FILE: ./src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/package.json
-      DRY_RUN: ${{ github.event.inputs.dry_run }}
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
     steps:
@@ -65,12 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
-      DOTNET_SDK_VERSION_3: "3.1.x"
-      DOTNET_SDK_VERSION_5: "5.0.x"
     steps:
       - run: echo ${{ needs.update-packagejson.outputs.sha }}
       - uses: actions/checkout@v2
@@ -131,8 +130,6 @@ jobs:
         include:
           - unity: 2019.3.9f1
             license: UNITY_2019_3
-    env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
@@ -184,11 +181,10 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
-      GIT_TAG: ${{ github.event.inputs.tag }}
     steps:
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: "${{ env.DOTNET_SDK_VERSION_3 }}"
       # Create Release
       - uses: actions/create-release@v1
         id: create_release
@@ -226,8 +222,6 @@ jobs:
     if: github.event.inputs.dry_run == 'true'
     needs: [build-dotnet, build-unity]
     runs-on: ubuntu-latest
-    env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
     steps:
       - name: Delete branch
         uses: dawidd6/action-delete-branch@v3

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -165,7 +165,7 @@ jobs:
 
   create-release:
     if: github.event.inputs.dry_run == 'false'
-    needs: [build-dotnet, build-unity]
+    needs: [update-packagejson, build-dotnet, build-unity]
     runs-on: ubuntu-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -184,6 +184,7 @@ jobs:
         with:
           tag_name: ${{ env.GIT_TAG }}
           release_name: Ver.${{ env.GIT_TAG }}
+          commitish: ${{ needs.update-packagejson.outputs.sha }}
           draft: true
           prerelease: false
       - uses: actions/download-artifact@v2-preview

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -160,6 +160,16 @@ jobs:
         env:
           UNITY_PACKAGE_VERSION: ${{ env.GIT_TAG }}
 
+      - name: check all .meta is commited
+        run: |
+          if git ls-files --others --exclude-standard -t | grep --regexp='[.]meta$'; then
+            echo "Detected .meta file generated. Do you forgot commit a .meta file?"
+            exit 1
+          else
+            echo "Great, all .meta files are commited."
+          fi
+        working-directory: src/MagicOnion.Client.Unity
+
       # Store artifacts.
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
## TL;DR

* fix: release included package.json is old.
* fix: release not bind to tag (tag not generated)
* fix: merge commit not invoke unity build
* add: missing .meta check on release
* chore: use latest .NET SDK for build
* refactor: move github.inputs to global env.

## Summary

create_release looking into github.ref by default, but it should see after push sha.

> ref: https://github.com/actions/create-release

![image](https://user-images.githubusercontent.com/3856350/106711378-c5f16500-663a-11eb-83e4-7d6e7d20128f.png)
