### PR TITLE
chore: new docker image to build

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -7,9 +7,8 @@ on:
     tags:
       - "!*" # not a tag push
   pull_request:
-    types:
-      - opened
-      - synchronize
+    branches:
+      - "master"
 
 jobs:
   build-dotnet:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -49,29 +49,18 @@ jobs:
     if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]')) && ((github.event_name == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:'))"
     strategy:
       matrix:
-        unity: ["2019.3.9f1", "2020.1.0b5"]
+        unity: ["2019.3.9f1", "2019.4.13f1", "2020.1.12f1"]
         include:
           - unity: 2019.3.9f1
-            license: UNITY_2019_3
-          - unity: 2020.1.0b5
-            license: UNITY_2020_1
+            license: UNITY_LICENSE_2019
+          - unity: 2019.4.13f1
+            license: UNITY_LICENSE_2019
+          - unity: 2020.1.12f1
+            license: UNITY_LICENSE_2020
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container:
-      # https://hub.docker.com/r/gableroux/unity3d/tags
-      image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
-      # Ubuntu 18.04 git is too old, use ppa latest git.
-      - run: |
-          apt-get update && apt-get install --no-install-recommends -y software-properties-common && add-apt-repository -y ppa:git-core/ppa
-          apt-get update && apt-get install --no-install-recommends -y git
       - uses: actions/checkout@v2
-      # activate Unity from manual license file(ulf)
-      - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
-        env:
-          UNITY_LICENSE: ${{ secrets[matrix.license] }}
-      - name: Activate Unity, always returns a success. But if a subsequent run fails, the activation may have failed(if succeeded, shows `Next license update check is after` and not shows other message(like GUID != GUID). If fails not). In that case, upload the artifact's .alf file to https://license.unity3d.com/manual to get the .ulf file and set it to secrets.
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
 
       # todo: prepare runtime unit test
       # Execute scripts: RuntimeUnitTestToolkit
@@ -82,9 +71,17 @@ jobs:
       #   run: ./src/ZLogger.Unity/bin/UnitTest/StandaloneLinux64_Mono2x/test
 
       # execute scripts/Export Package
+      # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
       - name: Export unitypackage
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
-        working-directory: src/MagicOnion.Client.Unity
+        uses: game-ci/unity-builder@v2.0-alpha-6
+        env:
+          UNITY_LICENSE: ${{ secrets[matrix.license] }}
+        with:
+          projectPath: src/MagicOnion.Client.Unity
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: StandaloneLinux64
+          buildMethod: PackageExporter.Export
+          versioning: None
 
       - name: check all .meta is commited
         run: |

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -19,8 +19,8 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
-      DOTNET_SDK_VERSION_3: "3.1.403"
-      DOTNET_SDK_VERSION_5: "5.0.100"
+      DOTNET_SDK_VERSION_3: "3.1.x"
+      DOTNET_SDK_VERSION_5: "5.0.x"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
       - run: dotnet test ./tests/MagicOnion.Generator.Tests/ -c Debug
 
   build-unity:
-    if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]')) && ((github.event == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:'))"
+    if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]')) && ((github.event_name == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:'))"
     strategy:
       matrix:
         unity: ["2019.3.9f1", "2020.1.0b5"]

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,12 +42,15 @@ jobs:
         run: echo "SHA ${SHA}"
         env:
           SHA: ${{ steps.commit.outputs.sha }}
+      - name: tag
+        run: git tag ${{ env.GIT_TAG }}
+        if: env.DRY_RUN == 'false'
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
-          tags: false
+          tags: true
         if: env.DRY_RUN == 'false'
       - name: Push changes (dry_run)
         uses: ad-m/github-push-action@master
@@ -66,8 +69,8 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
-      DOTNET_SDK_VERSION_3: "3.1.403"
-      DOTNET_SDK_VERSION_5: "5.0.100"
+      DOTNET_SDK_VERSION_3: "3.1.x"
+      DOTNET_SDK_VERSION_5: "5.0.x"
     steps:
       - run: echo ${{ needs.update-packagejson.outputs.sha }}
       - uses: actions/checkout@v2
@@ -175,7 +178,7 @@ jobs:
     steps:
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 3.1.x
       # Create Release
       - uses: actions/create-release@v1
         id: create_release

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,15 +12,17 @@ on:
         default: "false"
 
 env:
+  GIT_TAG: ${{ github.event.inputs.tag }}
+  DRY_RUN: ${{ github.event.inputs.dry_run }}
   DRY_RUN_BRANCH_PREFIX: "test_release"
+  DOTNET_SDK_VERISON_3: 3.1.x
+  DOTNET_SDK_VERISON_5: 5.0.x
 
 jobs:
   update-packagejson:
     runs-on: ubuntu-latest
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       TARGET_FILE: ./src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/package.json
-      DRY_RUN: ${{ github.event.inputs.dry_run }}
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
     steps:
@@ -65,12 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
-      DOTNET_SDK_VERSION_3: "3.1.x"
-      DOTNET_SDK_VERSION_5: "5.0.x"
     steps:
       - run: echo ${{ needs.update-packagejson.outputs.sha }}
       - uses: actions/checkout@v2
@@ -131,8 +130,6 @@ jobs:
         include:
           - unity: 2019.3.9f1
             license: UNITY_2019_3
-    env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
@@ -184,11 +181,10 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
-      GIT_TAG: ${{ github.event.inputs.tag }}
     steps:
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: "${{ env.DOTNET_SDK_VERSION_3 }}"
       # Create Release
       - uses: actions/create-release@v1
         id: create_release
@@ -226,8 +222,6 @@ jobs:
     if: github.event.inputs.dry_run == 'true'
     needs: [build-dotnet, build-unity]
     runs-on: ubuntu-latest
-    env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
     steps:
       - name: Delete branch
         uses: dawidd6/action-delete-branch@v3

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -165,7 +165,7 @@ jobs:
 
   create-release:
     if: github.event.inputs.dry_run == 'false'
-    needs: [build-dotnet, build-unity]
+    needs: [update-packagejson, build-dotnet, build-unity]
     runs-on: ubuntu-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -184,6 +184,7 @@ jobs:
         with:
           tag_name: ${{ env.GIT_TAG }}
           release_name: Ver.${{ env.GIT_TAG }}
+          commitish: ${{ needs.update-packagejson.outputs.sha }}
           draft: true
           prerelease: false
       - uses: actions/download-artifact@v2-preview

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -129,33 +129,26 @@ jobs:
         unity: ["2019.3.9f1"]
         include:
           - unity: 2019.3.9f1
-            license: UNITY_2019_3
+            license: UNITY_LICENSE_2019
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container:
-      # https://hub.docker.com/r/gableroux/unity3d/tags
-      image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
-      # Ubuntu 18.04 git is too old, use ppa latest git.
-      - run: |
-          apt-get update && apt-get install --no-install-recommends -y software-properties-common && add-apt-repository -y ppa:git-core/ppa
-          apt-get update && apt-get install --no-install-recommends -y git
       - uses: actions/checkout@v2
         with:
           ref: ${{ needs.update-packagejson.outputs.sha }}
-      # activate Unity from manual license file(ulf)
-      - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
+      # execute scripts/Export Package
+      # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
+      - name: Export unitypackage
+        uses: game-ci/unity-builder@v2.0-alpha-6
         env:
           UNITY_LICENSE: ${{ secrets[matrix.license] }}
-      - name: Activate Unity, always returns a success. But if a subsequent run fails, the activation may have failed(if succeeded, shows `Next license update check is after` and not shows other message(like GUID != GUID). If fails not). In that case, upload the artifact's .alf file to https://license.unity3d.com/manual to get the .ulf file and set it to secrets.
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
-
-      # execute scripts/Export Package
-      - name: Export unitypackage
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
-        working-directory: src/MagicOnion.Client.Unity
-        env:
           UNITY_PACKAGE_VERSION: ${{ env.GIT_TAG }}
+        with:
+          projectPath: src/MagicOnion.Client.Unity
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: StandaloneLinux64
+          buildMethod: PackageExporter.Export
+          versioning: None
 
       - name: check all .meta is commited
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -160,6 +160,16 @@ jobs:
         env:
           UNITY_PACKAGE_VERSION: ${{ env.GIT_TAG }}
 
+      - name: check all .meta is commited
+        run: |
+          if git ls-files --others --exclude-standard -t | grep --regexp='[.]meta$'; then
+            echo "Detected .meta file generated. Do you forgot commit a .meta file?"
+            exit 1
+          else
+            echo "Great, all .meta files are commited."
+          fi
+        working-directory: src/MagicOnion.Client.Unity
+
       # Store artifacts.
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
Please merge after #407 is merged.

## TL;DR

* change: ci image update to unityci/editor.
* change: unity ci to build with actions.

## Summary

* gableroux/unity3d is deprecated and moved to unityci/editor.
* Unity License Activation / Build is handle with actions `game-ci/unity-builder`, no more direct batch mode call.

## Effect

* ALF/ULF License is not compatible with gableroux/unity3d, new ULF is used in unityci/editor.
