### PR TITLE
Write a marker that is the beginning of the stream.

### DIFF
--- a/.github/workflows/build-canary.yml
+++ b/.github/workflows/build-canary.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "master"
-      - "feature/BetterStreamingHubClientErrors"
+      - "hotfix/WriteEmptyResponse"
     tags:
       - "!*" # not a tag push
 


### PR DESCRIPTION
## Background
Starting with version 4.1, StreamingHub has changed to send out a response header when a connection is initiated and wait on the client. As a result, in reverse proxy deployments such as AWS ALB, buffering occurs and there is a delay (1-5s) before the connection is established.

## Workaround
The server will send out a dummy StreamingHub method response message after connecting. This prevents the reverse proxy from buffering it.