### PR TITLE
Unity: Introduce gRPC channel management integration

### DIFF
--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IMagicOnionAwareGrpcChannel.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IMagicOnionAwareGrpcChannel.cs
@@ -11,18 +11,30 @@ namespace MagicOnion.Client
         /// <summary>
         /// Register the StreamingHub under the management of the channel.
         /// </summary>
-        void ManageStreamingHubClient(IStreamingHubMarker streamingHub, Func<Task> disposeAsync, Task waitForDisconnect);
+        void ManageStreamingHubClient(Type streamingHubInterfaceType, IStreamingHubMarker streamingHub, Func<Task> disposeAsync, Task waitForDisconnect);
 
         /// <summary>
         /// Gets all StreamingHubs that depends on the channel.
         /// </summary>
         /// <returns></returns>
-        IReadOnlyCollection<IStreamingHubMarker> GetAllManagedStreamingHubs();
+        IReadOnlyCollection<ManagedStreamingHubInfo> GetAllManagedStreamingHubs();
 
         /// <summary>
         /// Create a <see cref="Grpc.Core.CallInvoker"/> from the channel.
         /// </summary>
         /// <returns></returns>
         CallInvoker CreateCallInvoker();
+    }
+
+    public readonly struct ManagedStreamingHubInfo
+    {
+        public Type StreamingHubType { get; }
+        public IStreamingHubMarker Client { get; }
+
+        public ManagedStreamingHubInfo(Type streamingHubType, IStreamingHubMarker client)
+        {
+            StreamingHubType = streamingHubType;
+            Client = client;
+        }
     }
 }

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IMagicOnionAwareGrpcChannel.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IMagicOnionAwareGrpcChannel.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace MagicOnion.Client
+{
+    public interface IMagicOnionAwareGrpcChannel
+    {
+        /// <summary>
+        /// Register the StreamingHub under the management of the channel.
+        /// </summary>
+        void ManageStreamingHubClient(IStreamingHubMarker streamingHub, Func<Task> disposeAsync, Task waitForDisconnect);
+
+        /// <summary>
+        /// Gets all StreamingHubs that depends on the channel.
+        /// </summary>
+        /// <returns></returns>
+        IReadOnlyCollection<IStreamingHubMarker> GetAllManagedStreamingHubs();
+
+        /// <summary>
+        /// Create a <see cref="Grpc.Core.CallInvoker"/> from the channel.
+        /// </summary>
+        /// <returns></returns>
+        CallInvoker CreateCallInvoker();
+    }
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IMagicOnionAwareGrpcChannel.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IMagicOnionAwareGrpcChannel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 551ef9cf05981794aa4d04beceaa64d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClient.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClient.cs
@@ -8,23 +8,33 @@ namespace MagicOnion.Client
     {
         static readonly IClientFilter[] emptyFilters = Array.Empty<IClientFilter>();
 
+        public static T Create<T>(IMagicOnionAwareGrpcChannel channel)
+            where T : IService<T>
+            => Create<T>(channel.CreateCallInvoker());
+
+        public static T Create<T>(IMagicOnionAwareGrpcChannel channel, IClientFilter[] clientFilters)
+            where T : IService<T>
+            => Create<T>(channel.CreateCallInvoker(), MessagePackSerializer.DefaultOptions, clientFilters);
+
+        public static T Create<T>(IMagicOnionAwareGrpcChannel channel, MessagePackSerializerOptions serializerOptions)
+            where T : IService<T>
+            => Create<T>(channel.CreateCallInvoker(), serializerOptions, emptyFilters);
+
+        public static T Create<T>(IMagicOnionAwareGrpcChannel channel, MessagePackSerializerOptions serializerOptions, IClientFilter[] clientFilters)
+            where T : IService<T>
+            => Create<T>(channel.CreateCallInvoker(), serializerOptions, clientFilters);
+
         public static T Create<T>(CallInvoker invoker)
             where T : IService<T>
-        {
-            return Create<T>(invoker, MessagePackSerializer.DefaultOptions, emptyFilters);
-        }
+            => Create<T>(invoker, MessagePackSerializer.DefaultOptions, emptyFilters);
 
         public static T Create<T>(CallInvoker invoker, IClientFilter[] clientFilters)
             where T : IService<T>
-        {
-            return Create<T>(invoker, MessagePackSerializer.DefaultOptions, clientFilters);
-        }
+            => Create<T>(invoker, MessagePackSerializer.DefaultOptions, clientFilters);
 
         public static T Create<T>(CallInvoker invoker, MessagePackSerializerOptions serializerOptions)
             where T : IService<T>
-        {
-            return Create<T>(invoker, serializerOptions, emptyFilters);
-        }
+            => Create<T>(invoker, serializerOptions, emptyFilters);
 
         public static T Create<T>(CallInvoker invoker, MessagePackSerializerOptions serializerOptions, IClientFilter[] clientFilters)
             where T : IService<T>

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClient.cs
@@ -13,7 +13,7 @@ namespace MagicOnion.Client
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             var hubClient = Connect<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
-            channel.ManageStreamingHubClient(hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
+            channel.ManageStreamingHubClient(typeof(TStreamingHub), hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
             return hubClient;
         }
 
@@ -21,7 +21,7 @@ namespace MagicOnion.Client
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             var hubClient = await ConnectAsync<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger, cancellationToken);
-            channel.ManageStreamingHubClient(hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
+            channel.ManageStreamingHubClient(typeof(TStreamingHub), hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
             return hubClient;
         }
 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClient.cs
@@ -9,6 +9,23 @@ namespace MagicOnion.Client
     public static partial class StreamingHubClient
     {
         [Obsolete("Use ConnectAsync instead.")]
+        public static TStreamingHub Connect<TStreamingHub, TReceiver>(IMagicOnionAwareGrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            var hubClient = Connect<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
+            channel.ManageStreamingHubClient(hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
+            return hubClient;
+        }
+
+        public static async Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(IMagicOnionAwareGrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null, CancellationToken cancellationToken = default)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            var hubClient = await ConnectAsync<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger, cancellationToken);
+            channel.ManageStreamingHubClient(hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
+            return hubClient;
+        }
+
+        [Obsolete("Use ConnectAsync instead.")]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
              where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eedc01c091c179e46a65ff025c57160e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderInspector.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderInspector.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace MagicOnion.Unity.Editor
+{
+    [CustomEditor(typeof(GrpcChannelProviderHost))]
+    public class GrpcChannelProviderInspector : UnityEditor.Editor
+    {
+        private GrpcChannelProviderMonitor _monitor;
+
+        public override bool RequiresConstantRepaint()
+        {
+            return _monitor?.TryUpdate() ?? false;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            var providerHost = (GrpcChannelProviderHost)target;
+            if (providerHost == null || providerHost.Provider == null)
+            {
+                _monitor = null;
+                return;
+            }
+
+            if (_monitor == null)
+            {
+                _monitor = new GrpcChannelProviderMonitor(providerHost.Provider);
+            }
+
+            _monitor.DrawChannels();
+        }
+    }
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderInspector.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd0eb23331e403b44a34982daf91fb11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs
@@ -1,0 +1,378 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Grpc.Core;
+using UnityEditor;
+using UnityEngine;
+
+namespace MagicOnion.Unity.Editor
+{
+    public class GrpcChannelProviderMonitor
+    {
+        private readonly Dictionary<int, bool> _stackTraceFoldout = new Dictionary<int, bool>();
+        private readonly Dictionary<int, bool> _channelOptionsFoldout = new Dictionary<int, bool>();
+        private readonly Dictionary<GrpcChannelx, DataRatePoints> _historyByChannel = new Dictionary<GrpcChannelx, DataRatePoints>();
+        private readonly IGrpcChannelProvider _provider;
+        private DateTime _lastUpdatedAt;
+
+        public GrpcChannelProviderMonitor(IGrpcChannelProvider provider)
+        {
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        public bool TryUpdate()
+        {
+            if ((DateTime.Now - _lastUpdatedAt).TotalSeconds >= 1)
+            {
+                foreach (var channel in _provider.GetAllChannels())
+                {
+                    if (!_historyByChannel.TryGetValue(channel, out var history))
+                    {
+                        _historyByChannel[channel] = history = new DataRatePoints();
+                    }
+
+                    var diagInfo = ((IGrpcChannelxDiagnosticsInfo) channel);
+                    history.AddValues(diagInfo.Stats.ReceiveBytesPerSecond, diagInfo.Stats.SentBytesPerSecond);
+                }
+
+                _lastUpdatedAt = DateTime.Now;
+                return true;
+            }
+
+            return false;
+        }
+
+        public void DrawChannels()
+        {
+            var channels = _provider.GetAllChannels();
+            if (!channels.Any())
+            {
+                EditorGUILayout.HelpBox("The application has no gRPC channel yet.", MessageType.Info);
+                return;
+            }
+
+            foreach (var channel in channels)
+            {
+                var diagInfo = ((IGrpcChannelxDiagnosticsInfo)channel);
+
+                if (!_historyByChannel.TryGetValue(channel, out var history))
+                {
+                    _historyByChannel[channel] = history = new DataRatePoints();
+                }
+
+                using (new Section(() =>
+                {
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        EditorGUILayout.LabelField($"Channel:  {channel.Id} ({channel.Target}; State={channel.ChannelState})", EditorStyles.boldLabel);
+                        if (GUILayout.Button("...", GUILayout.ExpandWidth(false)))
+                        {
+                            var menu = new GenericMenu();
+                            menu.AddItem(new GUIContent("Disconnect"), false, x => { ((GrpcChannelx)x).Dispose(); }, channel);
+                            menu.ShowAsContext();
+                        }
+                    }
+                }))
+                {
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        EditorGUILayout.LabelField("Total Received Bytes", diagInfo.Stats.ReceivedBytes.ToString("#,0") + " bytes");
+                        EditorGUILayout.LabelField("Total Sent Bytes", diagInfo.Stats.SentBytes.ToString("#,0") + " bytes");
+                    }
+
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        EditorGUILayout.LabelField("Received Bytes/Sec", diagInfo.Stats.ReceiveBytesPerSecond.ToString("#,0") + " bytes/s");
+                        EditorGUILayout.LabelField("Sent Bytes/Sec", diagInfo.Stats.SentBytesPerSecond.ToString("#,0") + " bytes/s");
+                    }
+                    DrawChart(channel, history);
+
+                    var streamingHubs = ((IMagicOnionAwareGrpcChannel)channel).GetAllManagedStreamingHubs();
+                    if (streamingHubs.Any())
+                    {
+                        using (new Section("StreamingHubs"))
+                        {
+                            foreach (var streamingHub in streamingHubs)
+                            {
+                                EditorGUILayout.LabelField(streamingHub.GetType().FullName);
+                            }
+                        }
+                    }
+
+                    if (_stackTraceFoldout[channel.Id] = EditorGUILayout.Foldout(_stackTraceFoldout.TryGetValue(channel.Id, out var foldout) ? foldout : false, "StackTrace"))
+                    {
+                        var reducedStackTrace = string.Join("\n", diagInfo.StackTrace
+                            .Split('\n')
+                            .SkipWhile(x => x.StartsWith($"  at {typeof(GrpcChannelx).FullName}"))
+                            .Where(x => !x.StartsWith("  at System.Runtime.CompilerServices."))
+                            .Where(x => !x.StartsWith("  at System.Threading.ExecutionContext."))
+                            .Where(x => !x.StartsWith("  at Cysharp.Threading.Tasks.CompilerServices."))
+                            .Where(x => !x.StartsWith("  at Cysharp.Threading.Tasks.AwaiterActions."))
+                            .Where(x => !x.StartsWith("  at Cysharp.Threading.Tasks.UniTask"))
+                            .Where(x => !x.StartsWith("  at MagicOnion.Unity.GrpcChannelProviderExtensions."))
+                        );
+                        EditorGUILayout.TextArea(reducedStackTrace, GUILayout.MaxWidth(EditorGUIUtility.currentViewWidth - 40));
+                    }
+
+                    if (_channelOptionsFoldout[channel.Id] = EditorGUILayout.Foldout(_channelOptionsFoldout.TryGetValue(channel.Id, out var channelOptionsFoldout) ? channelOptionsFoldout : false, "ChannelOptions"))
+                    {
+                        using (new EditorGUI.DisabledGroupScope(true))
+                        {
+                            var prevLabelWidth = EditorGUIUtility.labelWidth;
+                            EditorGUIUtility.labelWidth = 350;
+                            foreach (var option in diagInfo.ChannelOptions)
+                            {
+                                if (option.Type == ChannelOption.OptionType.Integer)
+                                {
+                                    EditorGUILayout.IntField(option.Name, option.IntValue);
+                                }
+                                else
+                                {
+                                    EditorGUILayout.TextField(option.Name, option.StringValue);
+                                }
+                            }
+
+                            EditorGUIUtility.labelWidth = prevLabelWidth;
+                        }
+                    }
+                }
+            }
+        }
+
+        private void DrawChart(GrpcChannelx channel, DataRatePoints history)
+        {
+            // Draw Chart
+            var prevHandlesColor = Handles.color;
+            {
+                var rect = EditorGUI.IndentedRect(GUILayoutUtility.GetRect(GUILayoutUtility.GetLastRect().width, 100));
+                Handles.DrawSolidRectangleWithOutline(rect, Color.black, Color.gray);
+
+                var drawableRect = new Rect(rect.x + 2, rect.y + 2, rect.width - 4, rect.height - 4);
+                var maxCount = 60;
+                var maxY = DataUnit.GetScaleMaxValue(Math.Max(history.ReceivedValues.DefaultIfEmpty().Max(), history.SentValues.DefaultIfEmpty().Max()));
+                var dx = drawableRect.width / (float)(maxCount - 1);
+                var dy = drawableRect.height / (float)maxY;
+
+                // Grid (9 lines)
+                Handles.color = new Color(0.05f, 0.25f, 0.05f);
+                for (var i = 1; i < 10; i++)
+                {
+                    var yTop = drawableRect.y + (drawableRect.height / 10) * i;
+                    Handles.DrawLine(new Vector3(drawableRect.x, yTop), new Vector3(drawableRect.xMax, yTop));
+                }
+
+                // Label
+                Handles.Label(new Vector3(drawableRect.x, drawableRect.y), DataUnit.Humanize(maxY) + " bytes/sec");
+
+                // Values
+                Span<int> buffer = stackalloc int[60];
+                var points = new List<Vector3>();
+                {
+                    var values = history.ReceivedValues.ToSpan(buffer);
+                    for (var i = 0; i < Math.Min(maxCount, values.Length); i++)
+                    {
+                        var p = new Vector3(drawableRect.x + (drawableRect.width - (dx * i)), drawableRect.yMax - (dy * values[values.Length - i - 1]));
+                        points.Add(p);
+                    }
+
+                    Handles.color = new Color(0.33f, 0.55f, 0.33f);
+                    Handles.DrawAAPolyLine(4f, points.ToArray());
+                }
+                points.Clear();
+                {
+                    var values = history.SentValues.ToSpan(buffer);
+                    for (var i = 0; i < Math.Min(maxCount, values.Length); i++)
+                    {
+                        var p = new Vector3(drawableRect.x + (drawableRect.width - (dx * i)), drawableRect.yMax - (dy * values[values.Length - i - 1]));
+                        points.Add(p);
+                    }
+
+                    Handles.color = new Color(0.2f, 0.33f, 0.2f);
+                    Handles.DrawAAPolyLine(2f, points.ToArray());
+
+                }
+            }
+            Handles.color = prevHandlesColor;
+        }
+
+        private class DataRatePoints
+        {
+            public RingBuffer<int> ReceivedValues { get; }
+            public RingBuffer<int> SentValues { get; }
+
+            public DataRatePoints()
+            {
+                ReceivedValues = new RingBuffer<int>(60);
+                SentValues = new RingBuffer<int>(60);
+            }
+
+            public void AddValues(int receivedBytesPerSecond, int sentBytesPerSecond)
+            {
+                ReceivedValues.Add(receivedBytesPerSecond);
+                SentValues.Add(sentBytesPerSecond);
+            }
+        }
+
+        private struct Section : IDisposable
+        {
+            public Section(string label)
+            {
+                if (!string.IsNullOrWhiteSpace(label))
+                {
+                    EditorGUILayout.LabelField(label, EditorStyles.boldLabel);
+                }
+                EditorGUI.indentLevel++;
+            }
+
+            public Section(Action action)
+            {
+                action();
+                EditorGUI.indentLevel++;
+            }
+
+            public void Dispose()
+            {
+                EditorGUI.indentLevel--;
+                EditorGUILayout.Separator();
+            }
+        }
+
+        private class RingBuffer<T> : IEnumerable<T>
+        {
+            private readonly T[] _buffer;
+            private int _index = 0;
+
+            private bool IsFull => _index > _buffer.Length;
+            private int StartIndex => IsFull ? _index % _buffer.Length : 0;
+            public int Length => IsFull ? _buffer.Length : _index;
+
+            public RingBuffer(int bufferSize)
+            {
+                _buffer = new T[bufferSize];
+            }
+
+            public void Add(T item)
+            {
+                _buffer[_index++ % _buffer.Length] = item;
+            }
+
+            public Span<T> ToSpan(Span<T> buffer)
+            {
+                var index = 0;
+                foreach (var value in this)
+                {
+                    buffer[index++] = value;
+                }
+
+                return buffer.Slice(0, index);
+            }
+
+            public Enumerator GetEnumerator()
+                => new Enumerator(_buffer, _index, Length);
+
+            IEnumerator<T> IEnumerable<T>.GetEnumerator()
+                => GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator()
+                => GetEnumerator();
+
+            public struct Enumerator : IEnumerator<T>
+            {
+                private readonly T[] _buffer;
+                private readonly int _start;
+                private readonly int _length;
+
+                private int _current;
+
+                public Enumerator(T[] buffer, int start, int length)
+                {
+                    _buffer = buffer;
+                    _start = start;
+                    _length = length;
+
+                    _current = -1;
+                }
+
+                public T Current => _buffer[(_start + _current) % _length];
+
+                object IEnumerator.Current => Current;
+
+                public void Dispose()
+                {
+                }
+
+                public bool MoveNext()
+                {
+                    _current++;
+                    return (_current < _length);
+                }
+
+                public void Reset()
+                {
+                    _current = -1;
+                }
+            }
+        }
+
+        private class DataUnit
+        {
+            private static readonly long[] _scales = new long[]
+            {
+                1_000, // 1 K
+                10_000, // 10 K
+                100_000, // 100 K
+                500_000, // 500 K
+                1_000_000, // 1 M
+                2_000_000, // 2 M
+                10_000_000, // 10 M
+                20_000_000, // 20 M
+                100_000_000, // 100 M
+                200_000_000, // 200 M
+                500_000_000, // 500 M
+                1_000_000_000, // 1 G
+                10_000_000_000, // 10 G
+                20_000_000_000, // 20 G
+                50_000_000_000, // 10 G
+                100_000_000_000, // 100 G
+            };
+
+            public static long GetScaleMaxValue(long value)
+            {
+                foreach (var scale in _scales)
+                {
+                    if (value < scale)
+                    {
+                        return scale;
+                    }
+                }
+
+                return value;
+            }
+
+            public static string Humanize(long value)
+            {
+                if (value <= 1_000)
+                {
+                    return value.ToString("#,0");
+                }
+                else if (value <= 1_000_000)
+                {
+                    return (value / 1_000).ToString("#,0") + " K"; // K
+                }
+                else if (value <= 1_000_000_000)
+                {
+                    return (value / 1_000_000).ToString("#,0") + " M"; // M
+                }
+                else if (value <= 1_000_000_000_000)
+                {
+                    return (value / 1_000_000_000).ToString("#,0") + " G"; // G
+                }
+                else
+                {
+                    return (value / 1_000_000_000_000).ToString("#,0") + " T"; // T
+                }
+            }
+        }
+    }
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs
@@ -2,6 +2,10 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+#if MAGICONION_UNITASK_SUPPORT
+using Cysharp.Threading.Tasks;
+using Channel = Grpc.Core.Channel;
+#endif
 using Grpc.Core;
 using UnityEditor;
 using UnityEngine;

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs
@@ -100,7 +100,10 @@ namespace MagicOnion.Unity.Editor
                         {
                             foreach (var streamingHub in streamingHubs)
                             {
-                                EditorGUILayout.LabelField(streamingHub.GetType().FullName);
+                                EditorGUILayout.LabelField(streamingHub.StreamingHubType.FullName);
+                                EditorGUI.indentLevel++;
+                                EditorGUILayout.LabelField(streamingHub.Client.GetType().FullName);
+                                EditorGUI.indentLevel--;
                             }
                         }
                     }

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs
@@ -7,6 +7,7 @@ using Cysharp.Threading.Tasks;
 using Channel = Grpc.Core.Channel;
 #endif
 using Grpc.Core;
+using MagicOnion.Client;
 using UnityEditor;
 using UnityEngine;
 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e989c110841528748a12bedadfc77c60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderWindow.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderWindow.cs
@@ -1,0 +1,62 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace MagicOnion.Unity.Editor
+{
+    public class GrpcChannelProviderWindow : EditorWindow
+    {
+        private GrpcChannelProviderMonitor _monitor;
+        private Vector2 _scrollPosition;
+
+        [MenuItem("Window/MagicOnion/gRPC Channels")]
+        public static void Open()
+        {
+            ((EditorWindow)EditorWindow.GetWindow<GrpcChannelProviderWindow>()).Show();
+        }
+
+        private void Awake()
+        {
+            this.titleContent = new GUIContent("gRPC Channels");
+        }
+
+        private void OnGUI()
+        {
+            var providerHost = GameObject.FindObjectOfType<GrpcChannelProviderHost>();
+            if (providerHost == null)
+            {
+                EditorGUILayout.HelpBox("Cannot find a gRPC Channel Provider Host", MessageType.Info);
+                _monitor = null;
+                return;
+            }
+
+            if (_monitor == null)
+            {
+                _monitor = new GrpcChannelProviderMonitor(providerHost.Provider);
+            }
+
+            using (var scope = new EditorGUILayout.ScrollViewScope(_scrollPosition, false, false, new[] { GUILayout.Width(Screen.width) }))
+            using (new EditorGUILayout.VerticalScope(new GUIStyle()
+            {
+                padding =
+                {
+                    left = 10, top = 10,
+                    right = 10, bottom = 10,
+                }
+            }))
+            {
+                _monitor.DrawChannels();
+                _scrollPosition = scope.scrollPosition;
+            }
+        }
+
+        private void Update()
+        {
+            if (_monitor?.TryUpdate() ?? false)
+            {
+                Repaint();
+            }
+        }
+    }
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderWindow.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d09361924a82294e81ddf0c185b2124
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/MagicOnion.Unity.Editor.asmdef
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/MagicOnion.Unity.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "MagicOnion.Unity.Editor",
     "references": [
         "MagicOnion.Unity",
-        "MagicOnion.Abstractions"
+        "MagicOnion.Abstractions",
+        "UniTask"
     ],
     "includePlatforms": [
         "Editor"

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/MagicOnion.Unity.Editor.asmdef
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/MagicOnion.Unity.Editor.asmdef
@@ -1,8 +1,9 @@
 {
     "name": "MagicOnion.Unity.Editor",
     "references": [
-        "MagicOnion.Unity",
         "MagicOnion.Abstractions",
+        "MagicOnion.Client",
+        "MagicOnion.Unity",
         "UniTask"
     ],
     "includePlatforms": [

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/MagicOnion.Unity.Editor.asmdef
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/MagicOnion.Unity.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "MagicOnion.Unity.Editor",
+    "references": [
+        "MagicOnion.Unity",
+        "MagicOnion.Abstractions"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/MagicOnion.Unity.Editor.asmdef.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/MagicOnion.Unity.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 075e4292b30a5014fa3dc1112ab1052b
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProvider.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProvider.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Grpc.Core;
+using UnityEngine;
+
+namespace MagicOnion.Unity
+{
+    public static class GrpcChannelProviderExtensions
+    {
+        /// <summary>
+        /// Create a channel to the target and register the channel under the management of the provider.
+        /// </summary>
+        public static GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, GrpcChannelTarget target, ChannelOption[] channelOptions = null)
+            => provider.CreateChannel(new CreateGrpcChannelContext(provider, target, channelOptions ?? Array.Empty<ChannelOption>()));
+
+        /// <summary>
+        /// Create a channel to the target and register the channel under the management of the provider.
+        /// </summary>
+        public static GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, string host, int port, ChannelCredentials channelCredentials, ChannelOption[] channelOptions = null)
+            => provider.CreateChannel(new GrpcChannelTarget(host, port, channelCredentials), channelOptions ?? Array.Empty<ChannelOption>());
+    }
+
+    /// <summary>
+    /// Provide and manage gRPC channels for MagicOnion.
+    /// </summary>
+    public static class GrpcChannelProvider
+    {
+        private static IGrpcChannelProvider _defaultProvider;
+
+        /// <summary>
+        /// Gets a default channel provider. the provider will be initialized by <see cref="GrpcChannelProviderHost"/>.
+        /// </summary>
+        public static IGrpcChannelProvider Default
+            => _defaultProvider ?? throw new InvalidOperationException("The default GrpcChannelProvider is not configured yet. Setup GrpcChannelProviderHost or initialize manually. ");
+
+        public static void SetDefaultProvider(IGrpcChannelProvider provider)
+        {
+            _defaultProvider = provider;
+        }
+    }
+
+    /// <summary>
+    /// Provides logging for the channel provider.
+    /// </summary>
+    public sealed class LoggingGrpcChannelProvider : IGrpcChannelProvider
+    {
+        private readonly IGrpcChannelProvider _baseProvider;
+
+        public LoggingGrpcChannelProvider(IGrpcChannelProvider baseProvider)
+        {
+            _baseProvider = baseProvider ?? throw new ArgumentNullException(nameof(baseProvider));
+        }
+
+        public GrpcChannelx CreateChannel(CreateGrpcChannelContext context)
+        {
+            var channel = _baseProvider.CreateChannel(context);
+            Debug.Log($"Channel Created: {context.Target.Host}:{context.Target.Port} ({context.Target.ChannelCredentials}) [{channel.Id}]");
+            return channel;
+        }
+
+        public IReadOnlyCollection<GrpcChannelx> GetAllChannels()
+        {
+            return _baseProvider.GetAllChannels();
+        }
+
+        public void UnregisterChannel(GrpcChannelx channel)
+        {
+            _baseProvider.UnregisterChannel(channel);
+            Debug.Log($"Channel Unregistered: {channel.Target.Host}:{channel.Target.Port} [{channel.Id}]");
+        }
+
+        public void ShutdownAllChannels()
+        {
+            _baseProvider.ShutdownAllChannels();
+        }
+    }
+
+    /// <summary>
+    /// Provide and manage gRPC channels for MagicOnion.
+    /// </summary>
+    public sealed class DefaultGrpcChannelProvider : IGrpcChannelProvider
+    {
+        private readonly List<GrpcChannelx> _channels = new List<GrpcChannelx>();
+        private readonly ChannelOption[] _defaultChannelOptions;
+        private int _seq;
+
+        public DefaultGrpcChannelProvider()
+            : this(Array.Empty<ChannelOption>())
+        {
+        }
+
+        public DefaultGrpcChannelProvider(ChannelOption[] channelOptions)
+        {
+            _defaultChannelOptions = channelOptions ?? throw new ArgumentNullException(nameof(channelOptions));
+        }
+
+        /// <summary>
+        /// Create a channel to the target and register the channel under the management of the provider.
+        /// </summary>
+        public GrpcChannelx CreateChannel(CreateGrpcChannelContext context)
+        {
+            var channelOptions = CreateGrpcChannelOptions(context.ChannelOptions);
+            var id = Interlocked.Increment(ref _seq);
+            var channel = new Channel(context.Target.Host, context.Target.Port, context.Target.ChannelCredentials, channelOptions);
+            var channelHolder = new GrpcChannelx(
+                id,
+                context.Provider.UnregisterChannel /* Root provider may be wrapped outside this provider class. */,
+                channel,
+                new Uri((context.Target.ChannelCredentials == ChannelCredentials.Insecure ? "http" : "https") + $"://{context.Target.Host}:{context.Target.Port}"),
+                channelOptions
+            );
+
+            lock (_channels)
+            {
+                _channels.Add(channelHolder);
+            }
+
+            return channelHolder;
+        }
+
+        private ChannelOption[] CreateGrpcChannelOptions(ChannelOption[] channelOptions)
+        {
+            if (channelOptions == null || channelOptions.Length == 0) return _defaultChannelOptions;
+
+            return _defaultChannelOptions.Concat(channelOptions).ToArray();
+        }
+
+        public void UnregisterChannel(GrpcChannelx channel)
+        {
+            lock (_channels)
+            {
+                _channels.Remove(channel);
+            }
+        }
+
+        /// <summary>
+        /// Returns all channels under the management of the provider.
+        /// </summary>
+        /// <returns></returns>
+        public IReadOnlyCollection<GrpcChannelx> GetAllChannels()
+        {
+            lock (_channels)
+            {
+                return _channels.ToArray();
+            }
+        }
+
+        /// <summary>
+        ///  Shutdown all channels under the management of the provider.
+        /// </summary>
+        public void ShutdownAllChannels()
+        {
+            lock (_channels)
+            {
+                foreach (var channel in _channels.ToArray() /* snapshot */)
+                {
+                    try
+                    {
+                        channel.Dispose();
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogException(e);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProvider.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59e26eb7f045d024b8ee0a6847fbb37f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProviderHost.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProviderHost.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Grpc.Core;
+using UnityEngine;
+
+namespace MagicOnion.Unity
+{
+    /// <summary>
+    /// A host that integrates gRPC channel management with Unity lifecycle.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // Initialize gRPC channel provider when the application is loaded.
+    /// [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    /// public static void OnRuntimeInitialize()
+    /// {
+    ///     GrpcChannelProviderHost.Initialize(new DefaultGrpcChannelProvider(new []
+    ///     {
+    ///         new ChannelOption("grpc.keepalive_time_ms", 5000)
+    ///     }));
+    /// }
+    /// </code>
+    /// </example>
+    public class GrpcChannelProviderHost : MonoBehaviour
+    {
+        public IGrpcChannelProvider Provider { get; private set; }
+
+        /// <summary>
+        /// Initialize gRPC channel provider and the host.
+        /// </summary>
+        /// <param name="provider"></param>
+        public static void Initialize(IGrpcChannelProvider provider)
+        {
+            foreach (var instance in GameObject.FindObjectsOfType<GrpcChannelProviderHost>())
+            {
+                if (instance.gameObject != null)
+                {
+                    GameObject.Destroy(instance.gameObject);
+                }
+            }
+
+            // Create a new GrpcChannelProvider and set the provider as a default.
+            var go = new GameObject("GrpcChannelProvider");
+            var providerHost = go.AddComponent<GrpcChannelProviderHost>();
+            GameObject.DontDestroyOnLoad(go);
+
+            providerHost.InitializeCore(provider);
+        }
+
+        private void InitializeCore(IGrpcChannelProvider provider)
+        {
+            Provider = provider ?? new DefaultGrpcChannelProvider(Array.Empty<ChannelOption>());
+            GrpcChannelProvider.SetDefaultProvider(Provider);
+        }
+
+        private void OnDestroy()
+        {
+            Provider.ShutdownAllChannels();
+        }
+
+        private void OnApplicationQuit()
+        {
+            Provider.ShutdownAllChannels();
+        }
+    }
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProviderHost.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProviderHost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14c1ed26d96b81144b7f1074d8329f21
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelTarget.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelTarget.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using Grpc.Core;
+
+namespace MagicOnion.Unity
+{
+    /// <summary>
+    /// Represents gRPC channel target.
+    /// </summary>
+    public readonly struct GrpcChannelTarget
+    {
+        public string Host { get; }
+        public int Port { get; }
+        public ChannelCredentials ChannelCredentials { get; }
+
+        public GrpcChannelTarget(string host, int port, ChannelCredentials channelCredentials)
+        {
+            Host = host;
+            Port = port;
+            ChannelCredentials = channelCredentials;
+        }
+    }
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelTarget.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 133ecda02b4e38042bae5202bb8250be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
@@ -10,6 +10,7 @@ using Cysharp.Threading.Tasks;
 using Channel = Grpc.Core.Channel;
 #endif
 using Grpc.Core;
+using MagicOnion.Client;
 using MagicOnion.Unity;
 using UnityEngine;
 
@@ -90,9 +91,6 @@ namespace MagicOnion
             return _channel.CreateCallInvoker();
 #endif
         }
-
-        public static implicit operator CallInvoker(GrpcChannelx channel)
-            => channel.CreateCallInvoker();
 
         /// <summary>
         /// Connect to the target using gRPC channel. see <see cref="Grpc.Core.Channel.ConnectAsync"/>.
@@ -389,20 +387,6 @@ namespace MagicOnion
             }
         }
 #endif
-    }
-
-    public interface IMagicOnionAwareGrpcChannel
-    {
-        /// <summary>
-        /// Register the StreamingHub under the management of the channel.
-        /// </summary>
-        void ManageStreamingHubClient(IStreamingHubMarker streamingHub, Func<Task> disposeAsync, Task waitForDisconnect);
-
-        /// <summary>
-        /// Gets all StreamingHubs that depends on the channel.
-        /// </summary>
-        /// <returns></returns>
-        IReadOnlyCollection<IStreamingHubMarker> GetAllManagedStreamingHubs();
     }
 
 #if UNITY_EDITOR

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
@@ -1,0 +1,414 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using MagicOnion.Unity;
+using UnityEngine;
+
+namespace MagicOnion
+{
+    /// <summary>
+    /// gRPC Channel wrapper that managed by the channel provider.
+    /// </summary>
+    public sealed partial class GrpcChannelx : IMagicOnionAwareGrpcChannel, IDisposable
+#if UNITY_EDITOR
+        , IGrpcChannelxDiagnosticsInfo
+#endif
+#if MAGICONION_UNITASK_SUPPORT
+        , IUniTaskAsyncDisposable
+#endif
+    {
+        private readonly Action<GrpcChannelx> _onDispose;
+        private readonly Dictionary<IStreamingHubMarker, Func<Task>> _streamingHubs = new Dictionary<IStreamingHubMarker, Func<Task>>();
+        private readonly Channel _channel;
+        private bool _disposed;
+
+        public Uri Target { get; }
+        public int Id { get; }
+
+        public ChannelState ChannelState => _channel.State;
+
+#if UNITY_EDITOR
+        private readonly string _stackTrace;
+        private readonly IReadOnlyList<ChannelOption> _channelOptions;
+        private readonly ChannelStats _channelStats;
+
+        string IGrpcChannelxDiagnosticsInfo.StackTrace => _stackTrace;
+        ChannelStats IGrpcChannelxDiagnosticsInfo.Stats => _channelStats;
+        IReadOnlyList<ChannelOption> IGrpcChannelxDiagnosticsInfo.ChannelOptions => _channelOptions;
+#endif
+
+        public GrpcChannelx(int id, Action<GrpcChannelx> onDispose, Channel channel, Uri target, IReadOnlyList<ChannelOption> channelOptions)
+        {
+            Id = id;
+            Target = target;
+            _onDispose = onDispose;
+            _channel = channel;
+            _disposed = false;
+
+#if UNITY_EDITOR
+            _stackTrace = new System.Diagnostics.StackTrace().ToString();
+            _channelStats = new ChannelStats();
+            _channelOptions = channelOptions;
+#endif
+        }
+
+        /// <summary>
+        /// Create a channel to the specified target.
+        /// </summary>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        public static GrpcChannelx FromTarget(GrpcChannelTarget target)
+            => GrpcChannelProvider.Default.CreateChannel(target);
+
+        /// <summary>
+        /// Create a channel to the specified target.
+        /// </summary>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        public static GrpcChannelx FromAddress(Uri target)
+            => GrpcChannelProvider.Default.CreateChannel(target.Host, target.Port, (target.Scheme == "http" ? ChannelCredentials.Insecure : new SslCredentials()));
+
+        /// <summary>
+        /// Create a <see cref="CallInvoker"/>.
+        /// </summary>
+        /// <returns></returns>
+        public CallInvoker CreateCallInvoker()
+        {
+            ThrowIfDisposed();
+#if UNITY_EDITOR
+            return new ChannelStats.WrappedCallInvoker(((IGrpcChannelxDiagnosticsInfo)this).Stats, _channel.CreateCallInvoker());
+#else
+            return _channel.CreateCallInvoker();
+#endif
+        }
+
+        public static implicit operator CallInvoker(GrpcChannelx channel)
+            => channel.CreateCallInvoker();
+
+        /// <summary>
+        /// Connect to the target using gRPC channel. see <see cref="Grpc.Core.Channel.ConnectAsync"/>.
+        /// </summary>
+        /// <param name="deadline"></param>
+        /// <returns></returns>
+#if MAGICONION_UNITASK_SUPPORT
+        public async UniTask ConnectAsync(DateTime? deadline = null)
+#else
+        public async Task ConnectAsync(DateTime? deadline = null)
+#endif
+        {
+            ThrowIfDisposed();
+            await _channel.ConnectAsync(deadline);
+        }
+
+
+        /// <inheritdoc />
+        IReadOnlyCollection<IStreamingHubMarker> IMagicOnionAwareGrpcChannel.GetAllManagedStreamingHubs()
+        {
+            lock (_streamingHubs)
+            {
+                return _streamingHubs.Keys.ToArray();
+            }
+        }
+
+        /// <inheritdoc />
+        void IMagicOnionAwareGrpcChannel.ManageStreamingHubClient(IStreamingHubMarker streamingHub, Func<Task> disposeAsync, Task waitForDisconnect)
+        {
+            lock (_streamingHubs)
+            {
+                _streamingHubs.Add(streamingHub, disposeAsync);
+
+                // 切断されたら管理下から外す
+                Forget(WaitForDisconnectAndDisposeAsync(streamingHub, waitForDisconnect));
+            }
+        }
+
+#if MAGICONION_UNITASK_SUPPORT
+        private async UniTask WaitForDisconnectAndDisposeAsync(IStreamingHubMarker streamingHub, Task waitForDisconnect)
+#else
+        private async Task WaitForDisconnectAndDisposeAsync(IStreamingHubMarker streamingHub, Task waitForDisconnect)
+#endif
+        {
+            await waitForDisconnect;
+            DisposeStreamingHubClient(streamingHub);
+        }
+
+        private void DisposeStreamingHubClient(IStreamingHubMarker streamingHub)
+        {
+            lock (_streamingHubs)
+            {
+                if (_streamingHubs.TryGetValue(streamingHub, out var disposeAsync))
+                {
+                    try
+                    {
+                        Forget(disposeAsync());
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogException(e);
+                    }
+
+                    _streamingHubs.Remove(streamingHub);
+                }
+            }
+
+            async void Forget(Task t)
+            {
+                try
+                {
+                    await t;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
+            }
+        }
+
+        private void DisposeAllManagedStreamingHubs()
+        {
+            lock (_streamingHubs)
+            {
+                foreach (var streamingHub in _streamingHubs.Keys.ToArray() /* Snapshot */)
+                {
+                    DisposeStreamingHubClient(streamingHub);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            _disposed = true;
+            try
+            {
+                DisposeAllManagedStreamingHubs();
+                Forget(ShutdownCoreAsync());
+            }
+            finally
+            {
+                _onDispose(this);
+            }
+        }
+
+#if MAGICONION_UNITASK_SUPPORT
+        public async UniTask DisposeAsync()
+#else
+        public async Task DisposeAsync()
+#endif
+        {
+            if (_disposed) return;
+
+            _disposed = true;
+            try
+            {
+                DisposeAllManagedStreamingHubs();
+                await ShutdownCoreAsync();
+            }
+            finally
+            {
+                _onDispose(this);
+            }
+        }
+
+#if MAGICONION_UNITASK_SUPPORT
+        private async UniTask ShutdownCoreAsync()
+#else
+        private async Task ShutdownCoreAsync()
+#endif
+        {
+            await _channel.ShutdownAsync();
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(GrpcChannelx));
+        }
+
+#if MAGICONION_UNITASK_SUPPORT
+        private static async void Forget(UniTask t)
+            => t.Forget();
+#endif
+
+        private static async void Forget(Task t)
+        {
+            try
+            {
+                await t;
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+        }
+
+#if UNITY_EDITOR
+        public class ChannelStats
+        {
+            private int _sentBytes = 0;
+            private int _receivedBytes = 0;
+
+            private int _indexSentBytes;
+            private int _indexReceivedBytes;
+            private DateTime _prevSentBytesAt;
+            private DateTime _prevReceivedBytesAt;
+            private readonly int[] _sentBytesHistory = new int[10];
+            private readonly int[] _receivedBytesHistory = new int[10];
+
+            public int SentBytes => _sentBytes;
+            public int ReceivedBytes => _receivedBytes;
+
+            public int SentBytesPerSecond
+            {
+                get
+                {
+                    AddValue(ref _prevSentBytesAt, ref _indexSentBytes, _sentBytesHistory, DateTime.Now, 0);
+                    return _sentBytesHistory.Sum();
+                }
+            }
+
+            public int ReceiveBytesPerSecond
+            {
+                get
+                {
+                    AddValue(ref _prevReceivedBytesAt, ref _indexReceivedBytes, _receivedBytesHistory, DateTime.Now, 0);
+                    return _receivedBytesHistory.Sum();
+                }
+            }
+
+            public void AddSentBytes(int bytesLength)
+            {
+                Interlocked.Add(ref _sentBytes, bytesLength);
+                AddValue(ref _prevSentBytesAt, ref _indexSentBytes, _sentBytesHistory, DateTime.Now, bytesLength);
+            }
+
+            public void AddReceivedBytes(int bytesLength)
+            {
+                Interlocked.Add(ref _receivedBytes, bytesLength);
+                AddValue(ref _prevReceivedBytesAt, ref _indexReceivedBytes, _receivedBytesHistory, DateTime.Now, bytesLength);
+            }
+
+            private void AddValue(ref DateTime prev, ref int index, int[] values, DateTime d, int value)
+            {
+                lock (values)
+                {
+                    var elapsed = d - prev;
+
+                    if (elapsed.TotalMilliseconds > 1000)
+                    {
+                        index = 0;
+                        Array.Clear(values, 0, values.Length);
+                        prev = d;
+                    }
+                    else if (elapsed.TotalMilliseconds > 100)
+                    {
+                        var advance = (int)(elapsed.TotalMilliseconds / 100);
+                        for (var i = 0; i < advance; i++)
+                        {
+                            values[(++index % values.Length)] = 0;
+                        }
+                        prev = d;
+                    }
+
+                    values[index % values.Length] += value;
+                }
+            }
+
+            public class WrappedCallInvoker : CallInvoker
+            {
+                private readonly CallInvoker _baseCallInvoker;
+                private readonly ChannelStats _channelStats;
+
+
+                public WrappedCallInvoker(ChannelStats channelStats, CallInvoker callInvoker)
+                {
+                    _channelStats = channelStats;
+                    _baseCallInvoker = callInvoker;
+                }
+
+                public override TResponse BlockingUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request)
+                {
+                    //Debug.Log($"Unary(Blocking): {method.FullName}");
+                    return _baseCallInvoker.BlockingUnaryCall(WrapMethod(method), host, options, request);
+                }
+
+                public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request)
+                {
+                    //Debug.Log($"Unary: {method.FullName}");
+                    return _baseCallInvoker.AsyncUnaryCall(WrapMethod(method), host, options, request);
+                }
+
+                public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request)
+                {
+                    //Debug.Log($"ServerStreaming: {method.FullName}");
+                    return _baseCallInvoker.AsyncServerStreamingCall(WrapMethod(method), host, options, request);
+                }
+
+                public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options)
+                {
+                    //Debug.Log($"ClientStreaming: {method.FullName}");
+                    return _baseCallInvoker.AsyncClientStreamingCall(WrapMethod(method), host, options);
+                }
+
+                public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options)
+                {
+                    //Debug.Log($"DuplexStreaming: {method.FullName}");
+                    return _baseCallInvoker.AsyncDuplexStreamingCall(WrapMethod(method), host, options);
+                }
+
+                private Method<TRequest, TResponse> WrapMethod<TRequest, TResponse>(Method<TRequest, TResponse> method)
+                {
+                    var wrappedMethod = new Method<TRequest, TResponse>(
+                        method.Type,
+                        method.ServiceName,
+                        method.Name,
+                        new Marshaller<TRequest>(x =>
+                        {
+                            var bytes = method.RequestMarshaller.Serializer(x);
+                            _channelStats.AddSentBytes(bytes.Length);
+                            return bytes;
+                        }, x => method.RequestMarshaller.Deserializer(x)),
+                        new Marshaller<TResponse>(x => method.ResponseMarshaller.Serializer(x), x =>
+                        {
+                            _channelStats.AddReceivedBytes(x.Length);
+                            return method.ResponseMarshaller.Deserializer(x);
+                        })
+                    );
+
+                    return wrappedMethod;
+                }
+            }
+        }
+#endif
+    }
+
+    public interface IMagicOnionAwareGrpcChannel
+    {
+        /// <summary>
+        /// Register the StreamingHub under the management of the channel.
+        /// </summary>
+        void ManageStreamingHubClient(IStreamingHubMarker streamingHub, Func<Task> disposeAsync, Task waitForDisconnect);
+
+        /// <summary>
+        /// Gets all StreamingHubs that depends on the channel.
+        /// </summary>
+        /// <returns></returns>
+        IReadOnlyCollection<IStreamingHubMarker> GetAllManagedStreamingHubs();
+    }
+
+#if UNITY_EDITOR
+    public interface IGrpcChannelxDiagnosticsInfo
+    {
+        string StackTrace { get; }
+
+        GrpcChannelx.ChannelStats Stats { get; }
+
+        IReadOnlyList<ChannelOption> ChannelOptions { get; }
+    }
+#endif
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
@@ -5,6 +5,10 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+#if MAGICONION_UNITASK_SUPPORT
+using Cysharp.Threading.Tasks;
+using Channel = Grpc.Core.Channel;
+#endif
 using Grpc.Core;
 using MagicOnion.Unity;
 using UnityEngine;

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4d7b969df3791346b39bf722c7e6989
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/IGrpcChannelProvider.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/IGrpcChannelProvider.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using Grpc.Core;
+
+namespace MagicOnion.Unity
+{
+    /// <summary>
+    /// Provide and manage gRPC channels for MagicOnion.
+    /// </summary>
+    public interface IGrpcChannelProvider
+    {
+        /// <summary>
+        /// Create a channel to the target and register the channel under the management of the provider.
+        /// </summary>
+        GrpcChannelx CreateChannel(CreateGrpcChannelContext ctx);
+
+        /// <summary>
+        /// Unregister the disposed channel. The method is called when the channel is disposed.
+        /// </summary>
+        /// <param name="channel"></param>
+        void UnregisterChannel(GrpcChannelx channel);
+
+        /// <summary>
+        /// Returns all channels under the management of the provider.
+        /// </summary>
+        /// <returns></returns>
+        IReadOnlyCollection<GrpcChannelx> GetAllChannels();
+
+        /// <summary>
+        ///  Shutdown all channels under the management of the provider.
+        /// </summary>
+        void ShutdownAllChannels();
+    }
+
+    public readonly struct CreateGrpcChannelContext
+    {
+        public IGrpcChannelProvider Provider { get; }
+        public GrpcChannelTarget Target { get; }
+        public ChannelOption[] ChannelOptions { get; }
+
+        public CreateGrpcChannelContext(IGrpcChannelProvider provider, GrpcChannelTarget target, ChannelOption[] channelOptions)
+        {
+            Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            Target = target;
+            ChannelOptions = channelOptions ?? throw new ArgumentNullException(nameof(channelOptions));
+        }
+    }
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/IGrpcChannelProvider.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/IGrpcChannelProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe583cda4dabc974db6b5aae194b307e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/MagicOnion.Unity.asmdef
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/MagicOnion.Unity.asmdef
@@ -2,7 +2,8 @@
     "name": "MagicOnion.Unity",
     "references": [
         "MagicOnion.Abstractions",
-        "MagicOnion.Client"
+        "MagicOnion.Client",
+        "UniTask"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/MagicOnion.Unity.asmdef
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/MagicOnion.Unity.asmdef
@@ -14,5 +14,12 @@
         "Grpc.Core.Api.dll"
     ],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.cysharp.unitask",
+            "expression": "",
+            "define": "MAGICONION_UNITASK_SUPPORT"
+        }
+    ]
 }

--- a/src/MagicOnion.Client/IMagicOnionAwareGrpcChannel.cs
+++ b/src/MagicOnion.Client/IMagicOnionAwareGrpcChannel.cs
@@ -11,18 +11,30 @@ namespace MagicOnion.Client
         /// <summary>
         /// Register the StreamingHub under the management of the channel.
         /// </summary>
-        void ManageStreamingHubClient(IStreamingHubMarker streamingHub, Func<Task> disposeAsync, Task waitForDisconnect);
+        void ManageStreamingHubClient(Type streamingHubInterfaceType, IStreamingHubMarker streamingHub, Func<Task> disposeAsync, Task waitForDisconnect);
 
         /// <summary>
         /// Gets all StreamingHubs that depends on the channel.
         /// </summary>
         /// <returns></returns>
-        IReadOnlyCollection<IStreamingHubMarker> GetAllManagedStreamingHubs();
+        IReadOnlyCollection<ManagedStreamingHubInfo> GetAllManagedStreamingHubs();
 
         /// <summary>
         /// Create a <see cref="Grpc.Core.CallInvoker"/> from the channel.
         /// </summary>
         /// <returns></returns>
         CallInvoker CreateCallInvoker();
+    }
+
+    public readonly struct ManagedStreamingHubInfo
+    {
+        public Type StreamingHubType { get; }
+        public IStreamingHubMarker Client { get; }
+
+        public ManagedStreamingHubInfo(Type streamingHubType, IStreamingHubMarker client)
+        {
+            StreamingHubType = streamingHubType;
+            Client = client;
+        }
     }
 }

--- a/src/MagicOnion.Client/IMagicOnionAwareGrpcChannel.cs
+++ b/src/MagicOnion.Client/IMagicOnionAwareGrpcChannel.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace MagicOnion.Client
+{
+    public interface IMagicOnionAwareGrpcChannel
+    {
+        /// <summary>
+        /// Register the StreamingHub under the management of the channel.
+        /// </summary>
+        void ManageStreamingHubClient(IStreamingHubMarker streamingHub, Func<Task> disposeAsync, Task waitForDisconnect);
+
+        /// <summary>
+        /// Gets all StreamingHubs that depends on the channel.
+        /// </summary>
+        /// <returns></returns>
+        IReadOnlyCollection<IStreamingHubMarker> GetAllManagedStreamingHubs();
+
+        /// <summary>
+        /// Create a <see cref="Grpc.Core.CallInvoker"/> from the channel.
+        /// </summary>
+        /// <returns></returns>
+        CallInvoker CreateCallInvoker();
+    }
+}

--- a/src/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.cs
@@ -13,7 +13,7 @@ namespace MagicOnion.Client
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             var hubClient = Connect<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
-            channel.ManageStreamingHubClient(hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
+            channel.ManageStreamingHubClient(typeof(TStreamingHub), hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
             return hubClient;
         }
 
@@ -21,7 +21,7 @@ namespace MagicOnion.Client
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             var hubClient = await ConnectAsync<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger, cancellationToken);
-            channel.ManageStreamingHubClient(hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
+            channel.ManageStreamingHubClient(typeof(TStreamingHub), hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
             return hubClient;
         }
 

--- a/src/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.cs
@@ -9,6 +9,23 @@ namespace MagicOnion.Client
     public static partial class StreamingHubClient
     {
         [Obsolete("Use ConnectAsync instead.")]
+        public static TStreamingHub Connect<TStreamingHub, TReceiver>(IMagicOnionAwareGrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            var hubClient = Connect<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger);
+            channel.ManageStreamingHubClient(hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
+            return hubClient;
+        }
+
+        public static async Task<TStreamingHub> ConnectAsync<TStreamingHub, TReceiver>(IMagicOnionAwareGrpcChannel channel, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null, CancellationToken cancellationToken = default)
+            where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            var hubClient = await ConnectAsync<TStreamingHub, TReceiver>(channel.CreateCallInvoker(), receiver, host, option, serializerOptions, logger, cancellationToken);
+            channel.ManageStreamingHubClient(hubClient, hubClient.DisposeAsync, hubClient.WaitForDisconnect());
+            return hubClient;
+        }
+
+        [Obsolete("Use ConnectAsync instead.")]
         public static TStreamingHub Connect<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host = null, CallOptions option = default(CallOptions), MessagePackSerializerOptions serializerOptions = null, IMagicOnionClientLogger logger = null)
              where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {


### PR DESCRIPTION
Wraps gRPC channels and provides a mechanism to manage them with Unity's lifecycle.
This prevents your application and the Unity Editor from freezing by releasing channels and StreamingHub in one place.

The editor extension also provides the ability to display the communication status of channels.

![Screen08](https://user-images.githubusercontent.com/9012/111609638-da21a800-881d-11eb-81b2-33abe80ea497.gif)

> **NOTE**: The data rate is calculated only for the message body of methods, and does not include Headers, Trailers, or Keep-alive pings.

## New APIs
### `MagicOnion.GrpcChannelx` class
- `GrpcChannelx.FromTarget(GrpcChannelTarget)` method
- `GrpcChannelx.FromAddress(Uri)` method
### `MagicOnion.Unity.GrpcChannelProviderHost` class
- `GrpcChannelProviderHost.Initialize(IGrpcChannelProvider)` method
### `MagicOnion.Unity.IGrpcChannelProvider` interface
- `DefaultGrpcChannelProvider` class
- `LoggingGrpcChannelProvider` class

## Usages
### 1. Prepare to use `GrpcChannelx` in your Unity project.
Before creating a channel in your application, you need to initialize the provider host to be managed.

```csharp
[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
public static void OnRuntimeInitialize()
{
    // Initialize gRPC channel provider when the application is loaded.
    GrpcChannelProviderHost.Initialize(new DefaultGrpcChannelProvider(new []
    {
        // send keepalive ping every 5 second, default is 2 hours
        new ChannelOption("grpc.keepalive_time_ms", 5000),
        // keepalive ping time out after 5 seconds, default is 20 seconds
        new ChannelOption("grpc.keepalive_timeout_ms", 5 * 1000),
    }));
}
```

GrpcChannelProviderHost will be created as DontDestroyOnLoad and keeps existing while the application is running. DO NOT destory it.

![image](https://user-images.githubusercontent.com/9012/111586444-2eb82980-8804-11eb-8a4f-a898c86e5a60.png)

### 2. Use `GrpcChannelx.FromTarget` or `GrpcChannelx.FromAddress` to create a channel.
Use `GrpcChannelx.FromTarget` or `GrpcChannelx.FromAddress` to create a channel instead of `new Channel(...)`.

```csharp
var channel = GrpcChannelx.FromTarget(new GrpcChannelTarget("localhost", 12345, ChannelCredentials.Insecure));
// or
var channel = GrpcChannelx.FromAddress(new Uri("http://localhost:12345"));
```

### 3. Use the channel instead of `Grpc.Core.Channel`.
```csharp
var channel = GrpcChannelx.FromAddress(new Uri("http://localhost:12345"));

var serviceClient = MagicOnionClient.Create<IGreeterService>(channel);
var hubClient = StreamingHubClient.ConnectAsync<IGreeterHub, IGreeterHubReceiver>(channel, this);
```

## Extensions for Unity Editor (Editor Window & Inspector)
![image](https://user-images.githubusercontent.com/9012/111585700-0d0a7280-8803-11eb-8ce3-3b8f9d968c13.png)
