### PR TITLE
Make the method names like the API of GrpcChannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,8 +1046,9 @@ The editor extension also provides the ability to display the communication stat
 
 #### New APIs
 - `MagicOnion.GrpcChannelx` class
-  - `GrpcChannelx.FromTarget(GrpcChannelTarget)` method
-  - `GrpcChannelx.FromAddress(Uri)` method
+  - `GrpcChannelx.ForTarget(GrpcChannelTarget)` method
+  - `GrpcChannelx.ForAddress(Uri)` method
+  - `GrpcChannelx.ForAddress(string)` method
 - `MagicOnion.Unity.GrpcChannelProviderHost` class
   - `GrpcChannelProviderHost.Initialize(IGrpcChannelProvider)` method
 - `MagicOnion.Unity.IGrpcChannelProvider` interface
@@ -1077,18 +1078,18 @@ GrpcChannelProviderHost will be created as DontDestroyOnLoad and keeps existing 
 
 ![image](https://user-images.githubusercontent.com/9012/111586444-2eb82980-8804-11eb-8a4f-a898c86e5a60.png)
 
-##### 2. Use `GrpcChannelx.FromTarget` or `GrpcChannelx.FromAddress` to create a channel.
-Use `GrpcChannelx.FromTarget` or `GrpcChannelx.FromAddress` to create a channel instead of `new Channel(...)`.
+##### 2. Use `GrpcChannelx.ForTarget` or `GrpcChannelx.ForAddress` to create a channel.
+Use `GrpcChannelx.ForTarget` or `GrpcChannelx.ForAddress` to create a channel instead of `new Channel(...)`.
 
 ```csharp
-var channel = GrpcChannelx.FromTarget(new GrpcChannelTarget("localhost", 12345, ChannelCredentials.Insecure));
+var channel = GrpcChannelx.ForTarget(new GrpcChannelTarget("localhost", 12345, ChannelCredentials.Insecure));
 // or
-var channel = GrpcChannelx.FromAddress(new Uri("http://localhost:12345"));
+var channel = GrpcChannelx.ForAddress("http://localhost:12345");
 ```
 
 ##### 3. Use the channel instead of `Grpc.Core.Channel`.
 ```csharp
-var channel = GrpcChannelx.FromAddress(new Uri("http://localhost:12345"));
+var channel = GrpcChannelx.ForAddress("http://localhost:12345");
 
 var serviceClient = MagicOnionClient.Create<IGreeterService>(channel);
 var hubClient = StreamingHubClient.ConnectAsync<IGreeterHub, IGreeterHubReceiver>(channel, this);
@@ -1284,7 +1285,7 @@ webBuilder
 ```
 
 #### Client-side (.NET Standard 2.1; Grpc.Net.Client)
-When calling `GrpcChannel.FromAddress`, change the URL scheme to HTTP and the port to an unencrypted port.
+When calling `GrpcChannel.ForAddress`, change the URL scheme to HTTP and the port to an unencrypted port.
 
 ```csharp
 var channel = GrpcChannel.ForAddress("http://localhost:5000");

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/ChatComponent.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/ChatComponent.cs
@@ -63,11 +63,11 @@ namespace Assets.Scripts
         private async Task InitializeClientAsync()
         {
             // Initialize the Hub
-            this.channel = GrpcChannelx.FromAddress("http://localhost:5000");
+            this.channel = GrpcChannelx.ForAddress("http://localhost:5000");
             // for SSL/TLS connection
             //var cred = new SslCredentials(File.ReadAllText(Path.Combine(Application.streamingAssetsPath, "server.crt")));
-            //this.channel = GrpcChannelx.FromTarget(new GrpcChannelTarget("dummy.example.com", 5000, cred)); // local tls
-            //this.channel = GrpcChannelx.FromTarget(new GrpcChannelTarget("your-nlb-domain.com", 5000, new SslCredentials())); // aws nlb tls
+            //this.channel = GrpcChannelx.ForTarget(new GrpcChannelTarget("dummy.example.com", 5000, cred)); // local tls
+            //this.channel = GrpcChannelx.ForTarget(new GrpcChannelTarget("your-nlb-domain.com", 5000, new SslCredentials())); // aws nlb tls
 
             while (!shutdownCancellation.IsCancellationRequested)
             {

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
@@ -68,6 +68,8 @@ namespace MagicOnion
         /// </summary>
         /// <param name="target"></param>
         /// <returns></returns>
+        [Obsolete("Use ForTarget instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static GrpcChannelx FromTarget(GrpcChannelTarget target)
             => GrpcChannelProvider.Default.CreateChannel(target);
 
@@ -76,15 +78,33 @@ namespace MagicOnion
         /// </summary>
         /// <param name="target"></param>
         /// <returns></returns>
-        public static GrpcChannelx FromAddress(string target)
-            => FromAddress(new Uri(target));
+        [Obsolete("Use ForAddress instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static GrpcChannelx FromAddress(Uri target)
+            => GrpcChannelProvider.Default.CreateChannel(target.Host, target.Port, (target.Scheme == "http" ? ChannelCredentials.Insecure : new SslCredentials()));
 
         /// <summary>
         /// Create a channel to the specified target.
         /// </summary>
         /// <param name="target"></param>
         /// <returns></returns>
-        public static GrpcChannelx FromAddress(Uri target)
+        public static GrpcChannelx ForTarget(GrpcChannelTarget target)
+            => GrpcChannelProvider.Default.CreateChannel(target);
+
+        /// <summary>
+        /// Create a channel to the specified target.
+        /// </summary>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        public static GrpcChannelx ForAddress(string target)
+            => ForAddress(new Uri(target));
+
+        /// <summary>
+        /// Create a channel to the specified target.
+        /// </summary>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        public static GrpcChannelx ForAddress(Uri target)
             => GrpcChannelProvider.Default.CreateChannel(target.Host, target.Port, (target.Scheme == "http" ? ChannelCredentials.Insecure : new SslCredentials()));
 
         /// <summary>

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
@@ -68,6 +68,8 @@ namespace MagicOnion
         /// </summary>
         /// <param name="target"></param>
         /// <returns></returns>
+        [Obsolete("Use ForTarget instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static GrpcChannelx FromTarget(GrpcChannelTarget target)
             => GrpcChannelProvider.Default.CreateChannel(target);
 
@@ -76,7 +78,33 @@ namespace MagicOnion
         /// </summary>
         /// <param name="target"></param>
         /// <returns></returns>
+        [Obsolete("Use ForAddress instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static GrpcChannelx FromAddress(Uri target)
+            => GrpcChannelProvider.Default.CreateChannel(target.Host, target.Port, (target.Scheme == "http" ? ChannelCredentials.Insecure : new SslCredentials()));
+
+        /// <summary>
+        /// Create a channel to the specified target.
+        /// </summary>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        public static GrpcChannelx ForTarget(GrpcChannelTarget target)
+            => GrpcChannelProvider.Default.CreateChannel(target);
+
+        /// <summary>
+        /// Create a channel to the specified target.
+        /// </summary>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        public static GrpcChannelx ForAddress(string target)
+            => ForAddress(new Uri(target));
+
+        /// <summary>
+        /// Create a channel to the specified target.
+        /// </summary>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        public static GrpcChannelx ForAddress(Uri target)
             => GrpcChannelProvider.Default.CreateChannel(target.Host, target.Port, (target.Scheme == "http" ? ChannelCredentials.Insecure : new SslCredentials()));
 
         /// <summary>


### PR DESCRIPTION
Because GrpcChannel has a method named ForAddress, GrpcChannelx follows it.

## Deprecation
- `GrpcChannelx.FromAddress(Uri)`
- `GrpcChannelx.FromTarget(GrpcChannelTarget)`

Use `GrpcChannelx.ForAddress` or `GrpcChannelx.ForTarget` instead.