### PR TITLE
SynchronizationContext should not be restored when the stream is completed in WebGL

### DIFF
--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClient.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClient.cs
@@ -44,7 +44,7 @@ namespace MagicOnion.Client
                 var task = client.__ConnectAndSubscribeAsync(receiver, CancellationToken.None);
                 try
                 {
-                    await task;
+                    await task.ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -64,7 +64,7 @@ namespace MagicOnion.Client
             await client.__ConnectAndSubscribeAsync(receiver, cancellationToken).ConfigureAwait(false);
             return (TStreamingHub)(object)client;
         }
-        
+
         private static StreamingHubClientBase<TStreamingHub, TReceiver> CreateClient<TStreamingHub, TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host, CallOptions option, MessagePackSerializerOptions serializerOptions, IMagicOnionClientLogger logger)
             where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientBase.cs
@@ -162,12 +162,15 @@ namespace MagicOnion.Client
             {
                 try
                 {
+#if !UNITY_WEBGL
                     // set syncContext before await
+                    // NOTE: If restore SynchronizationContext in WebGL environment, a continuation will not be executed inline and will be stuck.
                     if (syncContext != null && SynchronizationContext.Current == null)
                     {
                         SynchronizationContext.SetSynchronizationContext(syncContext);
                     }
-                    await DisposeAsyncCore(false);
+#endif
+                    await DisposeAsyncCore(false).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -268,7 +271,7 @@ namespace MagicOnion.Client
             }
 
             var v = BuildMessage();
-            using (await asyncLock.LockAsync())
+            using (await asyncLock.LockAsync().ConfigureAwait(false))
             {
                 await connection.RawStreamingCall.RequestStream.WriteAsync(v).ConfigureAwait(false);
             }
@@ -310,7 +313,7 @@ namespace MagicOnion.Client
                 await connection.RawStreamingCall.RequestStream.WriteAsync(v).ConfigureAwait(false);
             }
 
-            return await tcs.Task; // wait until server return response(or error). if connection was closed, throws cancellation from DisposeAsyncCore.
+            return await tcs.Task.ConfigureAwait(false); // wait until server return response(or error). if connection was closed, throws cancellation from DisposeAsyncCore.
         }
 
         void ThrowIfDisposed()
@@ -340,7 +343,7 @@ namespace MagicOnion.Client
 
             try
             {
-                await connection.RequestStream.CompleteAsync();
+                await connection.RequestStream.CompleteAsync().ConfigureAwait(false);
             }
             catch { } // ignore error?
             finally
@@ -353,7 +356,7 @@ namespace MagicOnion.Client
                     {
                         if (subscription != null)
                         {
-                            await subscription;
+                            await subscription.ConfigureAwait(false);
                         }
                     }
 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClient.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClient.cs
@@ -53,7 +53,7 @@ namespace MagicOnion.Client
             if (ctor == null)
             {
 #if ((ENABLE_IL2CPP && !UNITY_EDITOR) || NET_STANDARD_2_0)
-                throw new InvalidOperationException("Does not registered client factory, dynamic code generation is not supported on IL2CPP. Please use code generator(moc).");
+                throw new InvalidOperationException($"Unable to find a client factory of type '{typeof(T)}'. If the application is running on IL2CPP or AOT, dynamic code generation is not supported. Please use the code generator (moc).");
 #else
                 var t = DynamicClientBuilder<T>.ClientType;
                 return (T)Activator.CreateInstance(t, invoker, serializerOptions, clientFilters);

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClient.cs
@@ -44,7 +44,7 @@ namespace MagicOnion.Client
                 var task = client.__ConnectAndSubscribeAsync(receiver, CancellationToken.None);
                 try
                 {
-                    await task;
+                    await task.ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientBase.cs
@@ -162,12 +162,15 @@ namespace MagicOnion.Client
             {
                 try
                 {
+#if !UNITY_WEBGL
                     // set syncContext before await
+                    // NOTE: If restore SynchronizationContext in WebGL environment, a continuation will not be executed inline and will be stuck.
                     if (syncContext != null && SynchronizationContext.Current == null)
                     {
                         SynchronizationContext.SetSynchronizationContext(syncContext);
                     }
-                    await DisposeAsyncCore(false);
+#endif
+                    await DisposeAsyncCore(false).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -268,7 +271,7 @@ namespace MagicOnion.Client
             }
 
             var v = BuildMessage();
-            using (await asyncLock.LockAsync())
+            using (await asyncLock.LockAsync().ConfigureAwait(false))
             {
                 await connection.RawStreamingCall.RequestStream.WriteAsync(v).ConfigureAwait(false);
             }
@@ -310,7 +313,7 @@ namespace MagicOnion.Client
                 await connection.RawStreamingCall.RequestStream.WriteAsync(v).ConfigureAwait(false);
             }
 
-            return await tcs.Task; // wait until server return response(or error). if connection was closed, throws cancellation from DisposeAsyncCore.
+            return await tcs.Task.ConfigureAwait(false); // wait until server return response(or error). if connection was closed, throws cancellation from DisposeAsyncCore.
         }
 
         void ThrowIfDisposed()
@@ -340,7 +343,7 @@ namespace MagicOnion.Client
 
             try
             {
-                await connection.RequestStream.CompleteAsync();
+                await connection.RequestStream.CompleteAsync().ConfigureAwait(false);
             }
             catch { } // ignore error?
             finally
@@ -353,7 +356,7 @@ namespace MagicOnion.Client
                     {
                         if (subscription != null)
                         {
-                            await subscription;
+                            await subscription.ConfigureAwait(false);
                         }
                     }
 

--- a/src/MagicOnion.Client/StreamingHubClient.cs
+++ b/src/MagicOnion.Client/StreamingHubClient.cs
@@ -44,7 +44,7 @@ namespace MagicOnion.Client
                 var task = client.__ConnectAndSubscribeAsync(receiver, CancellationToken.None);
                 try
                 {
-                    await task;
+                    await task.ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {

--- a/src/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/src/MagicOnion.Client/StreamingHubClientBase.cs
@@ -162,12 +162,15 @@ namespace MagicOnion.Client
             {
                 try
                 {
+#if !UNITY_WEBGL
                     // set syncContext before await
+                    // NOTE: If restore SynchronizationContext in WebGL environment, a continuation will not be executed inline and will be stuck.
                     if (syncContext != null && SynchronizationContext.Current == null)
                     {
                         SynchronizationContext.SetSynchronizationContext(syncContext);
                     }
-                    await DisposeAsyncCore(false);
+#endif
+                    await DisposeAsyncCore(false).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -268,7 +271,7 @@ namespace MagicOnion.Client
             }
 
             var v = BuildMessage();
-            using (await asyncLock.LockAsync())
+            using (await asyncLock.LockAsync().ConfigureAwait(false))
             {
                 await connection.RawStreamingCall.RequestStream.WriteAsync(v).ConfigureAwait(false);
             }
@@ -310,7 +313,7 @@ namespace MagicOnion.Client
                 await connection.RawStreamingCall.RequestStream.WriteAsync(v).ConfigureAwait(false);
             }
 
-            return await tcs.Task; // wait until server return response(or error). if connection was closed, throws cancellation from DisposeAsyncCore.
+            return await tcs.Task.ConfigureAwait(false); // wait until server return response(or error). if connection was closed, throws cancellation from DisposeAsyncCore.
         }
 
         void ThrowIfDisposed()
@@ -340,7 +343,7 @@ namespace MagicOnion.Client
 
             try
             {
-                await connection.RequestStream.CompleteAsync();
+                await connection.RequestStream.CompleteAsync().ConfigureAwait(false);
             }
             catch { } // ignore error?
             finally
@@ -353,7 +356,7 @@ namespace MagicOnion.Client
                     {
                         if (subscription != null)
                         {
-                            await subscription;
+                            await subscription.ConfigureAwait(false);
                         }
                     }
 


### PR DESCRIPTION
If restore SynchronizationContext in WebGL environment, a continuation will not be executed inline and will be stuck.