### PR TITLE
MagicOnion.Unity: Grpc.Net.Client

### DIFF
--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/ChatComponent.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/ChatComponent.cs
@@ -63,11 +63,8 @@ namespace Assets.Scripts
         private async Task InitializeClientAsync()
         {
             // Initialize the Hub
+            // NOTE: If you want to use SSL/TLS connection, see InitialSettings.OnRuntimeInitialize method.
             this.channel = GrpcChannelx.ForAddress("http://localhost:5000");
-            // for SSL/TLS connection
-            //var cred = new SslCredentials(File.ReadAllText(Path.Combine(Application.streamingAssetsPath, "server.crt")));
-            //this.channel = GrpcChannelx.ForTarget(new GrpcChannelTarget("dummy.example.com", 5000, cred)); // local tls
-            //this.channel = GrpcChannelx.ForTarget(new GrpcChannelTarget("your-nlb-domain.com", 5000, new SslCredentials())); // aws nlb tls
 
             while (!shutdownCancellation.IsCancellationRequested)
             {

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/InitialSettings.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/InitialSettings.cs
@@ -31,7 +31,13 @@ namespace Assets.Scripts
         public static void OnRuntimeInitialize()
         {
             // Initialize gRPC channel provider when the application is loaded.
-            GrpcChannelProviderHost.Initialize(new DefaultGrpcChannelProvider(new GrpcCCoreChannelOptions()));
+            GrpcChannelProviderHost.Initialize(new DefaultGrpcChannelProvider(new GrpcCCoreChannelOptions(new[]
+            {
+                // send keepalive ping every 5 second, default is 2 hours
+                new ChannelOption("grpc.keepalive_time_ms", 5000),
+                // keepalive ping time out after 5 seconds, default is 20 seconds
+                new ChannelOption("grpc.keepalive_timeout_ms", 5 * 1000),
+            })));
 
             // NOTE: If you want to use self-signed certificate for SSL/TLS connection
             //var cred = new SslCredentials(File.ReadAllText(Path.Combine(Application.streamingAssetsPath, "server.crt")));

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/InitialSettings.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/InitialSettings.cs
@@ -1,4 +1,8 @@
+using System.IO;
 using Grpc.Core;
+#if USE_GRPC_NET_CLIENT
+using Grpc.Net.Client;
+#endif
 using MagicOnion.Unity;
 using MessagePack;
 using MessagePack.Resolvers;
@@ -27,13 +31,14 @@ namespace Assets.Scripts
         public static void OnRuntimeInitialize()
         {
             // Initialize gRPC channel provider when the application is loaded.
-            GrpcChannelProviderHost.Initialize(new DefaultGrpcChannelProvider(new[]
-            {
-                // send keepalive ping every 5 second, default is 2 hours
-                new ChannelOption("grpc.keepalive_time_ms", 5000),
-                // keepalive ping time out after 5 seconds, default is 20 seconds
-                new ChannelOption("grpc.keepalive_timeout_ms", 5 * 1000),
-            }));
+            GrpcChannelProviderHost.Initialize(new DefaultGrpcChannelProvider(new GrpcCCoreChannelOptions()));
+
+            // NOTE: If you want to use self-signed certificate for SSL/TLS connection
+            //var cred = new SslCredentials(File.ReadAllText(Path.Combine(Application.streamingAssetsPath, "server.crt")));
+            //GrpcChannelProviderHost.Initialize(new DefaultGrpcChannelProvider(new GrpcCCoreChannelOptions(channelCredentials: cred)));
+
+            // Use Grpc.Net.Client instead of C-core gRPC library.
+            //GrpcChannelProviderHost.Initialize(new GrpcNetClientGrpcChannelProvider(new GrpcChannelOptions() { HttpHandler = ... }));
         }
     }
 }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/ChannelExtensions.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/ChannelExtensions.cs
@@ -1,4 +1,4 @@
-#if !USE_GRPC_NET_CLIENT
+#if !USE_GRPC_NET_CLIENT_ONLY
 using Grpc.Core;
 using System;
 using System.Collections.Generic;

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/ChannelExtensions.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/ChannelExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Grpc.Core;
+#if !USE_GRPC_NET_CLIENT
+using Grpc.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,3 +18,4 @@ namespace MagicOnion
         }
     }
 }
+#endif

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/Editor/GrpcChannelProviderMonitor.cs
@@ -142,36 +142,22 @@ namespace MagicOnion.Unity.Editor
                             var prevLabelWidth = EditorGUIUtility.labelWidth;
                             EditorGUIUtility.labelWidth = 350;
 
-#if USE_GRPC_NET_CLIENT
+                            foreach (var keyValue in diagInfo.ChannelOptions.GetValues())
                             {
-                                if (diagInfo.ChannelOptions.TryGet<GrpcChannelOptions>(out var channelOptions))
+                                if (keyValue.Value is int intValue)
                                 {
-                                    EditorGUILayout.IntField(nameof(channelOptions.MaxReceiveMessageSize), channelOptions.MaxReceiveMessageSize ?? -1);
-                                    EditorGUILayout.IntField(nameof(channelOptions.MaxRetryAttempts), channelOptions.MaxRetryAttempts ?? -1);
-                                    EditorGUILayout.LongField(nameof(channelOptions.MaxRetryBufferPerCallSize), channelOptions.MaxRetryBufferPerCallSize ?? -1);
-                                    EditorGUILayout.LongField(nameof(channelOptions.MaxRetryBufferSize), channelOptions.MaxRetryBufferSize ?? -1);
-                                    EditorGUILayout.LongField(nameof(channelOptions.MaxSendMessageSize), channelOptions.MaxSendMessageSize ?? -1);
+                                    EditorGUILayout.IntField(keyValue.Key, intValue);
+                                }
+                                else if (keyValue.Value is long longValue)
+                                {
+                                    EditorGUILayout.LongField(keyValue.Key, longValue);
+                                }
+                                else
+                                {
+                                    EditorGUILayout.TextField(keyValue.Key, keyValue.Value?.ToString() ?? "");
                                 }
                             }
-#endif
-#if !USE_GRPC_NET_CLIENT_ONLY
-                            {
-                                if (diagInfo.ChannelOptions.TryGet<IReadOnlyList<ChannelOption>>(out var channelOptions))
-                                {
-                                    foreach (var option in diagInfo.ChannelOptions.Get<IReadOnlyList<ChannelOption>>())
-                                    {
-                                        if (option.Type == ChannelOption.OptionType.Integer)
-                                        {
-                                            EditorGUILayout.IntField(option.Name, option.IntValue);
-                                        }
-                                        else
-                                        {
-                                            EditorGUILayout.TextField(option.Name, option.StringValue);
-                                        }
-                                    }
-                                }
-                            }
-#endif
+
                             EditorGUIUtility.labelWidth = prevLabelWidth;
                         }
                     }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProvider.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProvider.cs
@@ -129,7 +129,7 @@ namespace MagicOnion.Unity
             return channelHolder;
         }
 
-        protected void RegisterChannel(GrpcChannelx channel)
+        private void RegisterChannel(GrpcChannelx channel)
         {
             lock (_channels)
             {
@@ -264,8 +264,6 @@ namespace MagicOnion.Unity
                 new Uri((context.Target.ChannelCredentials == ChannelCredentials.Insecure ? "http" : "https") + $"://{context.Target.Host}:{context.Target.Port}"),
                 new GrpcChannelOptionsBag(channelOptions)
             );
-
-            RegisterChannel(channelHolder);
 
             return channelHolder;
         }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProvider.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProvider.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Grpc.Core;
+#if USE_GRPC_NET_CLIENT
+using Grpc.Net.Client;
+#endif
 using UnityEngine;
 
 namespace MagicOnion.Unity
@@ -13,14 +16,41 @@ namespace MagicOnion.Unity
         /// <summary>
         /// Create a channel to the target and register the channel under the management of the provider.
         /// </summary>
-        public static GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, GrpcChannelTarget target, ChannelOption[] channelOptions = null)
+        public static GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, GrpcChannelTarget target)
+            => provider.CreateChannel(new CreateGrpcChannelContext(provider, target));
+
+        /// <summary>
+        /// Create a channel to the target and register the channel under the management of the provider.
+        /// </summary>
+        public static GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, string host, int port, ChannelCredentials channelCredentials)
+            => provider.CreateChannel(new GrpcChannelTarget(host, port, channelCredentials));
+
+#if USE_GRPC_NET_CLIENT
+        /// <summary>
+        /// Create a channel to the target and register the channel under the management of the provider.
+        /// </summary>
+        public static GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, GrpcChannelTarget target, GrpcChannelOptions channelOptions)
+            => provider.CreateChannel(new CreateGrpcChannelContext(provider, target, channelOptions));
+
+        /// <summary>
+        /// Create a channel to the target and register the channel under the management of the provider.
+        /// </summary>
+        public static GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, string host, int port, ChannelCredentials channelCredentials, GrpcChannelOptions channelOptions)
+            => provider.CreateChannel(new GrpcChannelTarget(host, port, channelCredentials), channelOptions);
+#endif
+#if !USE_GRPC_NET_CLIENT_ONLY
+        /// <summary>
+        /// Create a channel to the target and register the channel under the management of the provider.
+        /// </summary>
+        public static GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, GrpcChannelTarget target, IReadOnlyList<ChannelOption> channelOptions)
             => provider.CreateChannel(new CreateGrpcChannelContext(provider, target, channelOptions ?? Array.Empty<ChannelOption>()));
 
         /// <summary>
         /// Create a channel to the target and register the channel under the management of the provider.
         /// </summary>
-        public static GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, string host, int port, ChannelCredentials channelCredentials, ChannelOption[] channelOptions = null)
+        public static GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, string host, int port, ChannelCredentials channelCredentials, ChannelOption[] channelOptions)
             => provider.CreateChannel(new GrpcChannelTarget(host, port, channelCredentials), channelOptions ?? Array.Empty<ChannelOption>());
+#endif
     }
 
     /// <summary>
@@ -81,51 +111,30 @@ namespace MagicOnion.Unity
     /// <summary>
     /// Provide and manage gRPC channels for MagicOnion.
     /// </summary>
-    public sealed class DefaultGrpcChannelProvider : IGrpcChannelProvider
+    public abstract class GrpcChannelProviderBase : IGrpcChannelProvider
     {
         private readonly List<GrpcChannelx> _channels = new List<GrpcChannelx>();
-        private readonly ChannelOption[] _defaultChannelOptions;
         private int _seq;
 
-        public DefaultGrpcChannelProvider()
-            : this(Array.Empty<ChannelOption>())
-        {
-        }
-
-        public DefaultGrpcChannelProvider(ChannelOption[] channelOptions)
-        {
-            _defaultChannelOptions = channelOptions ?? throw new ArgumentNullException(nameof(channelOptions));
-        }
+        protected abstract GrpcChannelx CreateChannelCore(int id, CreateGrpcChannelContext context);
 
         /// <summary>
         /// Create a channel to the target and register the channel under the management of the provider.
         /// </summary>
         public GrpcChannelx CreateChannel(CreateGrpcChannelContext context)
         {
-            var channelOptions = CreateGrpcChannelOptions(context.ChannelOptions);
-            var id = Interlocked.Increment(ref _seq);
-            var channel = new Channel(context.Target.Host, context.Target.Port, context.Target.ChannelCredentials, channelOptions);
-            var channelHolder = new GrpcChannelx(
-                id,
-                context.Provider.UnregisterChannel /* Root provider may be wrapped outside this provider class. */,
-                channel,
-                new Uri((context.Target.ChannelCredentials == ChannelCredentials.Insecure ? "http" : "https") + $"://{context.Target.Host}:{context.Target.Port}"),
-                channelOptions
-            );
-
-            lock (_channels)
-            {
-                _channels.Add(channelHolder);
-            }
+            var channelHolder = CreateChannelCore(Interlocked.Increment(ref _seq), context);
+            RegisterChannel(channelHolder);
 
             return channelHolder;
         }
 
-        private ChannelOption[] CreateGrpcChannelOptions(ChannelOption[] channelOptions)
+        protected void RegisterChannel(GrpcChannelx channel)
         {
-            if (channelOptions == null || channelOptions.Length == 0) return _defaultChannelOptions;
-
-            return _defaultChannelOptions.Concat(channelOptions).ToArray();
+            lock (_channels)
+            {
+                _channels.Add(channel);
+            }
         }
 
         public void UnregisterChannel(GrpcChannelx channel)
@@ -169,4 +178,104 @@ namespace MagicOnion.Unity
             }
         }
     }
+
+    /// <summary>
+    /// Provide and manage gRPC channels for MagicOnion.
+    /// </summary>
+#if USE_GRPC_NET_CLIENT && USE_GRPC_NET_CLIENT_ONLY
+    public class DefaultGrpcChannelProvider : GrpcNetClientGrpcChannelProvider
+    {
+        public DefaultGrpcChannelProvider() : base() {}
+        public DefaultGrpcChannelProvider(GrpcChannelOptions channelOptions) : base(channelOptions) {}
+    }
+#else
+    public class DefaultGrpcChannelProvider : GrpcCCoreGrpcChannelProvider
+    {
+        public DefaultGrpcChannelProvider() : base() { }
+        public DefaultGrpcChannelProvider(ChannelOption[] channelOptions) : base(channelOptions) { }
+    }
+#endif
+
+#if USE_GRPC_NET_CLIENT
+    /// <summary>
+    /// Provide and manage gRPC channels using Grpc.Net.Client for MagicOnion.
+    /// </summary>
+    public class GrpcNetClientGrpcChannelProvider : GrpcChannelProviderBase
+    {
+        private readonly GrpcChannelOptions _defaultChannelOptions;
+        public GrpcNetClientGrpcChannelProvider()
+            : this(new GrpcChannelOptions())
+        {
+        }
+
+        public GrpcNetClientGrpcChannelProvider(GrpcChannelOptions options)
+        {
+            _defaultChannelOptions = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        /// <summary>
+        /// Create a channel to the target and register the channel under the management of the provider.
+        /// </summary>
+        protected override GrpcChannelx CreateChannelCore(int id, CreateGrpcChannelContext context)
+        {
+            var address = new Uri((context.Target.ChannelCredentials == ChannelCredentials.Insecure ? "http" : "https") + $"://{context.Target.Host}:{context.Target.Port}");
+            var channel = GrpcChannel.ForAddress(address, context.ChannelOptions.Get<GrpcChannelOptions>() ?? _defaultChannelOptions);
+            var channelHolder = new GrpcChannelx(
+                id,
+                context.Provider.UnregisterChannel /* Root provider may be wrapped outside this provider class. */,
+                channel,
+                address,
+                new GrpcChannelOptionsBag(context.ChannelOptions.Get<GrpcChannelOptions>() ?? _defaultChannelOptions)
+            );
+
+            return channelHolder;
+        }
+    }
+#endif
+
+#if !USE_GRPC_NET_CLIENT_ONLY
+    /// <summary>
+    /// Provide and manage gRPC channels using gRPC C-core for MagicOnion.
+    /// </summary>
+    public class GrpcCCoreGrpcChannelProvider : GrpcChannelProviderBase
+    {
+        private readonly ChannelOption[] _defaultChannelOptions;
+        public GrpcCCoreGrpcChannelProvider()
+            : this(Array.Empty<ChannelOption>())
+        {
+        }
+
+        public GrpcCCoreGrpcChannelProvider(ChannelOption[] channelOptions)
+        {
+            _defaultChannelOptions = channelOptions ?? throw new ArgumentNullException(nameof(channelOptions));
+        }
+
+        /// <summary>
+        /// Create a channel to the target and register the channel under the management of the provider.
+        /// </summary>
+        protected override GrpcChannelx CreateChannelCore(int id, CreateGrpcChannelContext context)
+        {
+            var channelOptions = CreateGrpcChannelOptions(context.ChannelOptions.Get<IReadOnlyList<ChannelOption>>());
+            var channel = new Channel(context.Target.Host, context.Target.Port, context.Target.ChannelCredentials, channelOptions);
+            var channelHolder = new GrpcChannelx(
+                id,
+                context.Provider.UnregisterChannel /* Root provider may be wrapped outside this provider class. */,
+                channel,
+                new Uri((context.Target.ChannelCredentials == ChannelCredentials.Insecure ? "http" : "https") + $"://{context.Target.Host}:{context.Target.Port}"),
+                new GrpcChannelOptionsBag(channelOptions)
+            );
+
+            RegisterChannel(channelHolder);
+
+            return channelHolder;
+        }
+
+        private ChannelOption[] CreateGrpcChannelOptions(IReadOnlyList<ChannelOption> channelOptions)
+        {
+            if (channelOptions == null || channelOptions.Count == 0) return _defaultChannelOptions;
+
+            return _defaultChannelOptions.Concat(channelOptions).ToArray();
+        }
+    }
+#endif
 }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProvider.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProvider.cs
@@ -168,7 +168,7 @@ namespace MagicOnion.Unity
     public class DefaultGrpcChannelProvider : GrpcNetClientGrpcChannelProvider
     {
         public DefaultGrpcChannelProvider() : base() {}
-        public DefaultGrpcChannelProvider(Func<GrpcChannelOptions> channelOptionsFactory) : base(channelOptions) {}
+        public DefaultGrpcChannelProvider(GrpcChannelOptions channelOptions) : base(channelOptions) {}
     }
 #else
     public class DefaultGrpcChannelProvider : GrpcCCoreGrpcChannelProvider

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProviderHost.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelProviderHost.cs
@@ -50,7 +50,7 @@ namespace MagicOnion.Unity
 
         private void InitializeCore(IGrpcChannelProvider provider)
         {
-            Provider = provider ?? new DefaultGrpcChannelProvider(Array.Empty<ChannelOption>());
+            Provider = provider ?? new DefaultGrpcChannelProvider();
             GrpcChannelProvider.SetDefaultProvider(Provider);
         }
 

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelTarget.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelTarget.cs
@@ -11,13 +11,13 @@ namespace MagicOnion.Unity
     {
         public string Host { get; }
         public int Port { get; }
-        public ChannelCredentials ChannelCredentials { get; }
+        public bool IsInsecure { get; }
 
-        public GrpcChannelTarget(string host, int port, ChannelCredentials channelCredentials)
+        public GrpcChannelTarget(string host, int port, bool isInsecure)
         {
             Host = host;
             Port = port;
-            ChannelCredentials = channelCredentials;
+            IsInsecure = isInsecure;
         }
     }
 }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
@@ -10,6 +10,9 @@ using Cysharp.Threading.Tasks;
 using Channel = Grpc.Core.Channel;
 #endif
 using Grpc.Core;
+#if USE_GRPC_NET_CLIENT
+using Grpc.Net.Client;
+#endif
 using MagicOnion.Client;
 using MagicOnion.Unity;
 using UnityEngine;
@@ -29,25 +32,25 @@ namespace MagicOnion
     {
         private readonly Action<GrpcChannelx> _onDispose;
         private readonly Dictionary<IStreamingHubMarker, (Func<Task> DisposeAsync, ManagedStreamingHubInfo StreamingHubInfo)> _streamingHubs = new Dictionary<IStreamingHubMarker, (Func<Task>, ManagedStreamingHubInfo)>();
-        private readonly Channel _channel;
+        private readonly ChannelBase _channel;
         private bool _disposed;
 
         public Uri TargetUri { get; }
         public int Id { get; }
 
-        public ChannelState ChannelState => _channel.State;
 
 #if UNITY_EDITOR || MAGICONION_ENABLE_CHANNEL_DIAGNOSTICS
         private readonly string _stackTrace;
-        private readonly IReadOnlyList<ChannelOption> _channelOptions;
         private readonly ChannelStats _channelStats;
+        private readonly GrpcChannelOptionsBag _channelOptions;
 
         string IGrpcChannelxDiagnosticsInfo.StackTrace => _stackTrace;
         ChannelStats IGrpcChannelxDiagnosticsInfo.Stats => _channelStats;
-        IReadOnlyList<ChannelOption> IGrpcChannelxDiagnosticsInfo.ChannelOptions => _channelOptions;
+        GrpcChannelOptionsBag IGrpcChannelxDiagnosticsInfo.ChannelOptions => _channelOptions;
+        ChannelBase IGrpcChannelxDiagnosticsInfo.UnderlyingChannel => _channel;
 #endif
 
-        public GrpcChannelx(int id, Action<GrpcChannelx> onDispose, Channel channel, Uri targetUri, IReadOnlyList<ChannelOption> channelOptions)
+        public GrpcChannelx(int id, Action<GrpcChannelx> onDispose, ChannelBase channel, Uri targetUri, GrpcChannelOptionsBag channelOptions)
             : base(targetUri.ToString())
         {
             Id = id;
@@ -135,6 +138,7 @@ namespace MagicOnion
         /// </summary>
         /// <param name="deadline"></param>
         /// <returns></returns>
+        [Obsolete]
 #if MAGICONION_UNITASK_SUPPORT
         public async UniTask ConnectAsync(DateTime? deadline = null)
 #else
@@ -142,9 +146,13 @@ namespace MagicOnion
 #endif
         {
             ThrowIfDisposed();
-            await _channel.ConnectAsync(deadline);
+#if !USE_GRPC_NET_CLIENT_ONLY
+            if (_channel is Channel grpcCChannel)
+            {
+                await grpcCChannel.ConnectAsync(deadline);
+            }
+#endif
         }
-
 
         /// <inheritdoc />
         IReadOnlyCollection<ManagedStreamingHubInfo> IMagicOnionAwareGrpcChannel.GetAllManagedStreamingHubs()
@@ -434,7 +442,9 @@ namespace MagicOnion
 
         GrpcChannelx.ChannelStats Stats { get; }
 
-        IReadOnlyList<ChannelOption> ChannelOptions { get; }
+        GrpcChannelOptionsBag ChannelOptions { get; }
+
+        ChannelBase UnderlyingChannel { get; }
     }
 #endif
 }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
@@ -84,7 +84,7 @@ namespace MagicOnion
         [Obsolete("Use ForAddress instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static GrpcChannelx FromAddress(Uri target)
-            => GrpcChannelProvider.Default.CreateChannel(target.Host, target.Port, (target.Scheme == "http" ? ChannelCredentials.Insecure : new SslCredentials()));
+            => GrpcChannelProvider.Default.CreateChannel(new GrpcChannelTarget(target.Host, target.Port, target.Scheme == "http"));
 
         /// <summary>
         /// Create a channel to the specified target.
@@ -108,7 +108,7 @@ namespace MagicOnion
         /// <param name="target"></param>
         /// <returns></returns>
         public static GrpcChannelx ForAddress(Uri target)
-            => GrpcChannelProvider.Default.CreateChannel(target.Host, target.Port, (target.Scheme == "http" ? ChannelCredentials.Insecure : new SslCredentials()));
+            => GrpcChannelProvider.Default.CreateChannel(new GrpcChannelTarget(target.Host, target.Port, target.Scheme == "http"));
 
         /// <summary>
         /// Create a <see cref="CallInvoker"/>.

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/IGrpcChannelProvider.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/IGrpcChannelProvider.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using Grpc.Core;
+#if USE_GRPC_NET_CLIENT
+using Grpc.Net.Client;
+#endif
 
 namespace MagicOnion.Unity
 {
@@ -32,17 +35,68 @@ namespace MagicOnion.Unity
         void ShutdownAllChannels();
     }
 
-    public readonly struct CreateGrpcChannelContext
+    public class CreateGrpcChannelContext
     {
         public IGrpcChannelProvider Provider { get; }
         public GrpcChannelTarget Target { get; }
-        public ChannelOption[] ChannelOptions { get; }
+        public GrpcChannelOptionsBag ChannelOptions { get; }
 
-        public CreateGrpcChannelContext(IGrpcChannelProvider provider, GrpcChannelTarget target, ChannelOption[] channelOptions)
+        public CreateGrpcChannelContext(IGrpcChannelProvider provider, GrpcChannelTarget target, object channelOptions = null)
         {
             Provider = provider ?? throw new ArgumentNullException(nameof(provider));
             Target = target;
-            ChannelOptions = channelOptions ?? throw new ArgumentNullException(nameof(channelOptions));
+            ChannelOptions = new GrpcChannelOptionsBag(channelOptions);
+        }
+    }
+
+    public class GrpcChannelOptionsBag
+    {
+#if USE_GRPC_NET_CLIENT
+        private readonly GrpcChannelOptions _grpcChannelOptions;
+#endif
+#if !USE_GRPC_NET_CLIENT_ONLY
+        private readonly IReadOnlyList<ChannelOption> _grpcCChanelOptions;
+#endif
+
+        public GrpcChannelOptionsBag(object options)
+        {
+#if USE_GRPC_NET_CLIENT
+            if (options is GrpcChannelOptions)
+            {
+                _grpcChannelOptions = (GrpcChannelOptions)options;
+            }
+#endif
+#if !USE_GRPC_NET_CLIENT_ONLY
+            if (options is IReadOnlyList<ChannelOption>)
+            {
+                _grpcCChanelOptions = (IReadOnlyList<ChannelOption>)options;
+            }
+#endif
+        }
+
+        public T Get<T>()
+        {
+            return TryGet<T>(out var value) ? value : default;
+        }
+
+        public bool TryGet<T>(out T value)
+        {
+#if USE_GRPC_NET_CLIENT
+            if (typeof(T) == typeof(GrpcChannelOptions) && _grpcChannelOptions != null)
+            {
+                value = (T)(object)_grpcChannelOptions;
+                return true;
+            }
+#endif
+#if !USE_GRPC_NET_CLIENT_ONLY
+            if (typeof(T) == typeof(IReadOnlyList<ChannelOption>) && _grpcCChanelOptions != null)
+            {
+                value = (T)(object)_grpcCChanelOptions;
+                return true;
+            }
+#endif
+            value = default;
+            return false;
         }
     }
 }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/IGrpcChannelProvider.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/IGrpcChannelProvider.cs
@@ -88,9 +88,9 @@ namespace MagicOnion.Unity
             }
 #endif
 #if !USE_GRPC_NET_CLIENT_ONLY
-            if (TryGet<IReadOnlyList<ChannelOption>>(out var channelOptionsForCCore))
+            if (TryGet<GrpcCCoreChannelOptions>(out var channelOptionsForCCore))
             {
-                foreach (var channelOption in channelOptionsForCCore)
+                foreach (var channelOption in channelOptionsForCCore.ChannelOptions)
                 {
                     yield return new KeyValuePair<string, object>(channelOption.Name, channelOption.Type == ChannelOption.OptionType.Integer ? (object)channelOption.IntValue : channelOption.StringValue);
                 }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/UnityDebugLogger.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/UnityDebugLogger.cs
@@ -1,4 +1,4 @@
-#if !USE_GRPC_NET_CLIENT
+#if !USE_GRPC_NET_CLIENT_ONLY
 using Grpc.Core.Logging;
 using System;
 

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/UnityDebugLogger.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/UnityDebugLogger.cs
@@ -1,4 +1,5 @@
-﻿using Grpc.Core.Logging;
+#if !USE_GRPC_NET_CLIENT
+using Grpc.Core.Logging;
 using System;
 
 namespace MagicOnion
@@ -155,3 +156,4 @@ namespace MagicOnion
         }
     }
 }
+#endif


### PR DESCRIPTION
If you want to use MagicOnion with Grpc.Net.Client, define the constant `USE_GRPC_NET_CLIENT` to `Project Settings/Player/Scripting Define Symbols`.

If you want to remove C-core in your project, add the constant `USE_GRPC_NET_CLIENT_ONLY` to the player setting.

## API Changes
### Removed
- `GrpcChannelProviderExtensions` class
    - `GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, GrpcChannelTarget target, ChannelOption[] channelOptions = null)`
    - `CreateChannel(this IGrpcChannelProvider provider, string host, int port, ChannelCredentials channelCredentials, ChannelOption[] channelOptions = null)`
- `GrpcChannelTarget` struct
    - `ChannelCredentials` property

### Added
- `USE_GRPC_NET_CLIENT` and `USE_GRPC_NET_CLIENT_ONLY` define constants
- `GrpcNetClientGrpcChannelProvider` class (for Grpc.Net.Client)
- `GrpcCCoreGrpcChannelProvider` class (for C-core)
- `GrpcChannelProviderExtensions` class
    - `GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, GrpcChannelTarget target)`
    - `GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, GrpcChannelTarget target, GrpcChannelOptions channelOptions)`  (for Grpc.Net.Client)
    - `GrpcChannelx CreateChannel(this IGrpcChannelProvider provider, GrpcChannelTarget target, ChannelCredentials channelCredentials, IReadOnlyList<ChannelOption> channelOptions)` (for C-core)
- `GrpcChannelTarget` struct
    - `IsInsecure` property
- `GrpcChannelOptionsBag` class
- `GrpcCCoreChannelOptions` class (for C-core)