### PR TITLE
Fix of #472

### DIFF
--- a/src/MagicOnion.Server.HttpGateway/MagicOnionHttpGatewayMiddleware.cs
+++ b/src/MagicOnion.Server.HttpGateway/MagicOnionHttpGatewayMiddleware.cs
@@ -132,7 +132,7 @@ namespace MagicOnion.Server.HttpGateway
                 // JSON to C# Object to MessagePack
                 var requestObject = handler.BoxedSerialize(deserializedObject);
 
-                var method = new Method<byte[], byte[]>(MethodType.Unary, handler.ServiceName, handler.MethodInfo.Name, MagicOnionMarshallers.ThroughMarshaller, MagicOnionMarshallers.ThroughMarshaller);
+                var method = new Method<byte[], byte[]>(MethodType.Unary, handler.ServiceName, handler.MethodName, MagicOnionMarshallers.ThroughMarshaller, MagicOnionMarshallers.ThroughMarshaller);
 
                 // create header
                 var metadata = new Metadata();

--- a/src/MagicOnion.Server/MethodHandler.cs
+++ b/src/MagicOnion.Server/MethodHandler.cs
@@ -560,7 +560,7 @@ namespace MagicOnion.Server
 
         public override string ToString()
         {
-            return ServiceName + "/" + MethodInfo.Name;
+            return ServiceName + "/" + MethodName;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Fix #472 (HttpGateway breaks if explicit interface implementation used)

Change usages of MethodHandler.MethodInfo.Name to MethodHandler.MethodName

- In ToString()
Affects `MagicOnionHttpGatewayMiddleware.handlers` dictionary keys, which are just `MethodHandler.ToString()` values. Also, it will produce more precise Swagger spec. If not change this method, the HttpGateway might still work, but requests to HttpGateway should be done with paths, different to normal requests through gRPC (`/IMyService/MyNamespace.IMyService.MyMethod` instead of `/IMyService/MyMethod`).
- In gRPC `Method` constructor call when proxying call through HttpGateway
Necessary because gRPC can not route call with fully qualified method name (actually,  it finds the interface declaration, and throws an error with status "Unimplemented").

It is difficult for me to write tests for this case, but the issue is very easy to reproduce.