### PR TITLE
Pass attributes as metadata on binding gRPC method

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>7.3</LangVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <VersionPrefix>4.4.0</VersionPrefix>
 

--- a/MagicOnion.sln
+++ b/MagicOnion.sln
@@ -77,6 +77,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\build-release.yml = .github\workflows\build-release.yml
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{B5617CC1-55FD-4F77-BA75-9450474C6527}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthSample", "tests\samples\AuthSample\AuthSample.csproj", "{4D5E8486-9A0D-444A-922B-1D94FD8A820A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -159,6 +163,10 @@ Global
 		{E3F88CE3-F892-42AB-9D92-178BC9AD46FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E3F88CE3-F892-42AB-9D92-178BC9AD46FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E3F88CE3-F892-42AB-9D92-178BC9AD46FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D5E8486-9A0D-444A-922B-1D94FD8A820A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D5E8486-9A0D-444A-922B-1D94FD8A820A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D5E8486-9A0D-444A-922B-1D94FD8A820A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D5E8486-9A0D-444A-922B-1D94FD8A820A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -186,6 +194,8 @@ Global
 		{34C724ED-7459-4F62-855D-90C276A6F5EA} = {1987061F-8970-4018-8D58-6932961C9EB4}
 		{E3F88CE3-F892-42AB-9D92-178BC9AD46FD} = {7ACC27E8-8FBE-4807-B91F-B89AF3CFF7E0}
 		{A8550C24-2486-49DA-8D1A-DB6BBB2E9905} = {42EBB7E4-52D7-4E57-80AD-79FDD4900E13}
+		{B5617CC1-55FD-4F77-BA75-9450474C6527} = {7ACC27E8-8FBE-4807-B91F-B89AF3CFF7E0}
+		{4D5E8486-9A0D-444A-922B-1D94FD8A820A} = {B5617CC1-55FD-4F77-BA75-9450474C6527}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D5B2E7E3-B727-40A1-BE68-7BAC9B9DE2FE}

--- a/src/MagicOnion.Abstractions/MagicOnion.Abstractions.csproj
+++ b/src/MagicOnion.Abstractions/MagicOnion.Abstractions.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\MagicOnion\opensource.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>NON_UNITY</DefineConstants>

--- a/src/MagicOnion.Client/MagicOnion.Client.csproj
+++ b/src/MagicOnion.Client/MagicOnion.Client.csproj
@@ -5,7 +5,7 @@
 
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\MagicOnion\opensource.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <!--<nullable>enable</nullable>-->
 
     <DefineConstants>TRACE;NON_UNITY</DefineConstants>

--- a/src/MagicOnion.Server.HttpGateway/MagicOnion.Server.HttpGateway.csproj
+++ b/src/MagicOnion.Server.HttpGateway/MagicOnion.Server.HttpGateway.csproj
@@ -11,7 +11,6 @@
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
         <NoWarn>1701;1702;1705;1591</NoWarn>
         <DefineConstants>NON_UNITY</DefineConstants>
-        <LangVersion>latest</LangVersion>
         <!--<nullable>enable</nullable>-->
 
         <!-- NuGet -->

--- a/src/MagicOnion.Server/Glue/MagicOnionGlueServiceBinder.cs
+++ b/src/MagicOnion.Server/Glue/MagicOnionGlueServiceBinder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Grpc.AspNetCore.Server.Model;
 using Grpc.Core;
+using Microsoft.AspNetCore.Routing;
 
 namespace MagicOnion.Server.Glue
 {
@@ -16,24 +17,39 @@ namespace MagicOnion.Server.Glue
             _context = context;
         }
 
+        private IList<object> GetMetadataFromHandler(Delegate handler)
+        {
+            var methodHandler = ((MethodHandler)handler.Target!);
+            var serviceType = methodHandler.ServiceType;
+
+            // NOTE: We need to collect Attributes for Endpoint metadata. ([Authorize], [AllowAnonymous] ...)
+            // https://github.com/grpc/grpc-dotnet/blob/7ef184f3c4cd62fbc3cde55e4bb3e16b58258ca1/src/Grpc.AspNetCore.Server/Model/Internal/ProviderServiceBinder.cs#L89-L98
+            var metadata = new List<object>();
+            metadata.AddRange(serviceType.GetCustomAttributes(inherit: true));
+            metadata.AddRange(methodHandler.MethodInfo.GetCustomAttributes(inherit: true));
+
+            metadata.Add(new HttpMethodMetadata(new[] { "POST" }, acceptCorsPreflight: true));
+            return metadata;
+        }
+
         public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TRequest, TResponse> handler)
         {
-            _context.AddUnaryMethod(method, Array.Empty<object>(), (_, request, context) => handler(request, context));
+            _context.AddUnaryMethod(method, GetMetadataFromHandler(handler), (_, request, context) => handler(request, context));
         }
 
         public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TRequest, TResponse> handler)
         {
-            _context.AddClientStreamingMethod(method, Array.Empty<object>(), (_, request, context) => handler(request, context));
+            _context.AddClientStreamingMethod(method, GetMetadataFromHandler(handler), (_, request, context) => handler(request, context));
         }
 
         public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TRequest, TResponse> handler)
         {
-            _context.AddServerStreamingMethod(method, Array.Empty<object>(), (_, request, stream, context) => handler(request, stream, context));
+            _context.AddServerStreamingMethod(method, GetMetadataFromHandler(handler), (_, request, stream, context) => handler(request, stream, context));
         }
 
         public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TRequest, TResponse> handler)
         {
-            _context.AddDuplexStreamingMethod(method, Array.Empty<object>(), (_, request, stream, context) => handler(request, stream, context));
+            _context.AddDuplexStreamingMethod(method, GetMetadataFromHandler(handler), (_, request, stream, context) => handler(request, stream, context));
         }
     }
 }

--- a/src/MagicOnion.Server/MagicOnion.Server.csproj
+++ b/src/MagicOnion.Server/MagicOnion.Server.csproj
@@ -4,9 +4,9 @@
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\MagicOnion\opensource.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>latest</LangVersion>
     <nullable>enable</nullable>
     <DefineConstants>TRACE;NON_UNITY</DefineConstants>
+    <LangVersion>default</LangVersion>
 
     <!-- NuGet -->
     <PackageId>MagicOnion.Server</PackageId>

--- a/src/MagicOnion.Shared/MagicOnion.Shared.csproj
+++ b/src/MagicOnion.Shared/MagicOnion.Shared.csproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\MagicOnion\opensource.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>latest</LangVersion>
     <!--<nullable>enable</nullable>-->
     <DefineConstants>TRACE;NON_UNITY</DefineConstants>
 

--- a/tests/MagicOnion.Server.Tests/MagicOnion.Server.Tests.csproj
+++ b/tests/MagicOnion.Server.Tests/MagicOnion.Server.Tests.csproj
@@ -3,11 +3,13 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>default</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
@@ -17,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\MagicOnion.Client\MagicOnion.Client.csproj" />
     <ProjectReference Include="..\..\src\MagicOnion.Server\MagicOnion.Server.csproj" />
+    <ProjectReference Include="..\samples\AuthSample\AuthSample.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MagicOnion.Server.Tests/Tests/AuthorizeServiceTest.cs
+++ b/tests/MagicOnion.Server.Tests/Tests/AuthorizeServiceTest.cs
@@ -1,0 +1,73 @@
+using System.Net.Http.Headers;
+using AuthSample;
+using Grpc.Core;
+using Grpc.Net.Client;
+using MagicOnion.Client;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace MagicOnion.Server.Tests.Tests
+{
+    public class AuthorizeServiceTest : IClassFixture<WebApplicationFactory<AuthSample.Startup>>
+    {
+        private readonly WebApplicationFactory<AuthSample.Startup> _factory;
+
+        public AuthorizeServiceTest(WebApplicationFactory<AuthSample.Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task Class_Authorize()
+        {
+            var httpClient = _factory.CreateDefaultClient();
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "Alice");
+            var client = MagicOnionClient.Create<IAuthorizeClassService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
+            var userName = await client.GetUserNameAsync();
+            userName.Should().Be("Alice");
+        }
+
+        [Fact]
+        public async Task Class_Unauthorized()
+        {
+            var httpClient = _factory.CreateDefaultClient();
+            var client = MagicOnionClient.Create<IAuthorizeClassService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
+            var ex = (await Assert.ThrowsAsync<RpcException>(async () => await client.GetUserNameAsync()));
+            ex.StatusCode.Should().Be(StatusCode.Unauthenticated);
+        }
+
+        [Fact]
+        public async Task Class_AllowAnonymous()
+        {
+            var httpClient = _factory.CreateDefaultClient();
+            var client = MagicOnionClient.Create<IAuthorizeClassService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
+            (await client.AddAsync(123, 456)).Should().Be(579);
+        }
+
+        [Fact]
+        public async Task Method_Authorize()
+        {
+            var httpClient = _factory.CreateDefaultClient();
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "Alice");
+            var client = MagicOnionClient.Create<IAuthorizeMethodService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
+            var userName = await client.GetUserNameAsync();
+            userName.Should().Be("Alice");
+        }
+
+        [Fact]
+        public async Task Method_Unauthorized()
+        {
+            var httpClient = _factory.CreateDefaultClient();
+            var client = MagicOnionClient.Create<IAuthorizeMethodService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
+            var ex = (await Assert.ThrowsAsync<RpcException>(async () => await client.GetUserNameAsync()));
+            ex.StatusCode.Should().Be(StatusCode.Unauthenticated);
+        }
+
+        [Fact]
+        public async Task Method_AllowAnonymous()
+        {
+            var httpClient = _factory.CreateDefaultClient();
+            var client = MagicOnionClient.Create<IAuthorizeMethodService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
+            (await client.AddAsync(123, 456)).Should().Be(579);
+        }
+    }
+}

--- a/tests/MagicOnion.Server.Tests/Tests/AuthorizeStreamingHubTest.cs
+++ b/tests/MagicOnion.Server.Tests/Tests/AuthorizeStreamingHubTest.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using AuthSample;
+using Grpc.Core;
+using Grpc.Net.Client;
+using MagicOnion.Client;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace MagicOnion.Server.Tests.Tests
+{
+    public class AuthorizeStreamingHubTest : IClassFixture<WebApplicationFactory<AuthSample.Startup>>, IAuthorizeHubReceiver
+    {
+        private readonly WebApplicationFactory<AuthSample.Startup> _factory;
+
+        public AuthorizeStreamingHubTest(WebApplicationFactory<AuthSample.Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task Authorize_Connect()
+        {
+            var httpClient = _factory.CreateDefaultClient();
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "Alice");
+            var client = await StreamingHubClient.ConnectAsync<IAuthorizeHub, IAuthorizeHubReceiver>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }), this);
+            var userName = await client.GetUserNameAsync();
+            userName.Should().Be("Alice");
+        }
+
+        [Fact]
+        public async Task Unauthenticated_Connect()
+        {
+            var httpClient = _factory.CreateDefaultClient();
+
+            var ex = await Assert.ThrowsAsync<RpcException>(async () =>
+            {
+                var client = await StreamingHubClient.ConnectAsync<IAuthorizeHub, IAuthorizeHubReceiver>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }), this);
+            });
+
+            ex.StatusCode.Should().Be(StatusCode.Unauthenticated);
+        }
+    }
+}

--- a/tests/MagicOnion.Server.Tests/_GlobalUsings.cs
+++ b/tests/MagicOnion.Server.Tests/_GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using FluentAssertions;
+global using Xunit;

--- a/tests/samples/AuthSample/AuthSample.csproj
+++ b/tests/samples/AuthSample/AuthSample.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\MagicOnion.Server\MagicOnion.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/samples/AuthSample/FakeAuthenticationHandler.cs
+++ b/tests/samples/AuthSample/FakeAuthenticationHandler.cs
@@ -1,0 +1,26 @@
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace AuthSample;
+
+public class FakeAuthenticationHandler : AuthenticationHandler<FakeAuthenticationHandlerOptions>
+{
+    public FakeAuthenticationHandler(IOptionsMonitor<FakeAuthenticationHandlerOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock) : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (Context.Request.Headers.TryGetValue("Authorization", out var value) && value == "Bearer Alice")
+        {
+            return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(new GenericIdentity("Alice")), "Fake")));
+        }
+
+        return Task.FromResult(AuthenticateResult.Fail("Unauthorized"));
+    }
+}
+
+public class FakeAuthenticationHandlerOptions : AuthenticationSchemeOptions { }

--- a/tests/samples/AuthSample/Program.cs
+++ b/tests/samples/AuthSample/Program.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Text.Encodings.Web;
+
+namespace AuthSample;
+
+public class Program
+{
+    public static void Main(string[] args) => CreateWebHostBuilder(args).Build().Run();
+
+    // Do not change. This is the pattern our test infrastructure uses to initialize a IWebHostBuilder from
+    // a users app.
+    public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+        new WebHostBuilder()
+            .UseContentRoot(Directory.GetCurrentDirectory())
+            .UseStartup<Startup>()
+            .ConfigureLogging(logging =>
+            {
+                logging.AddDebug();
+            })
+            .UseKestrel()
+            .UseIISIntegration();
+}
+
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddGrpc();
+        services.AddMagicOnion(new [] { typeof(Startup).Assembly });
+
+        services.AddAuthentication("Fake")
+            .AddScheme<FakeAuthenticationHandlerOptions, FakeAuthenticationHandler>("Fake", options => { });
+
+        services.AddAuthorization();
+    }
+
+    public void Configure(IApplicationBuilder app)
+    {
+        app.UseRouting();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapMagicOnionService();
+        });
+    }
+}

--- a/tests/samples/AuthSample/Properties/launchSettings.json
+++ b/tests/samples/AuthSample/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:50379/",
+      "sslPort": 44330
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "AuthSample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}

--- a/tests/samples/AuthSample/ServicesAndHubs.cs
+++ b/tests/samples/AuthSample/ServicesAndHubs.cs
@@ -1,0 +1,52 @@
+using Grpc.Core;
+using MagicOnion;
+using MagicOnion.Server;
+using MagicOnion.Server.Hubs;
+using Microsoft.AspNetCore.Authorization;
+
+namespace AuthSample;
+
+public interface IAuthorizeClassService : IService<IAuthorizeClassService>
+{
+    UnaryResult<string> GetUserNameAsync();
+    UnaryResult<int> AddAsync(int a, int b);
+}
+
+[Authorize]
+public class AuthorizeClassService : ServiceBase<IAuthorizeClassService>, IAuthorizeClassService
+{
+    public UnaryResult<string> GetUserNameAsync() => UnaryResult(Context.CallContext.GetHttpContext().User.Identity?.Name ?? throw new InvalidOperationException("Unauthenticated"));
+
+    [AllowAnonymous]
+    public UnaryResult<int> AddAsync(int a, int b) => UnaryResult(a + b);
+}
+
+public interface IAuthorizeMethodService : IService<IAuthorizeMethodService>
+{
+    UnaryResult<string> GetUserNameAsync();
+    UnaryResult<int> AddAsync(int a, int b);
+}
+
+public class AuthorizeMethodService : ServiceBase<IAuthorizeMethodService>, IAuthorizeMethodService
+{
+    [Authorize]
+    public UnaryResult<string> GetUserNameAsync() => UnaryResult(Context.CallContext.GetHttpContext().User.Identity?.Name ?? throw new InvalidOperationException("Unauthenticated"));
+
+    public UnaryResult<int> AddAsync(int a, int b) => UnaryResult(a + b);
+}
+
+public interface IAuthorizeHubReceiver {}
+
+public interface IAuthorizeHub : IStreamingHub<IAuthorizeHub, IAuthorizeHubReceiver>
+{
+    Task<string> GetUserNameAsync();
+}
+
+[Authorize]
+public class AuthorizeHub : StreamingHubBase<IAuthorizeHub, IAuthorizeHubReceiver>, IAuthorizeHub
+{
+    public Task<string> GetUserNameAsync()
+    {
+        return Task.FromResult(Context.CallContext.GetHttpContext().User.Identity?.Name ?? throw new InvalidOperationException("Unauthenticated"));
+    }
+}

--- a/tests/samples/AuthSample/appsettings.Development.json
+++ b/tests/samples/AuthSample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/tests/samples/AuthSample/appsettings.json
+++ b/tests/samples/AuthSample/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
+}


### PR DESCRIPTION
Pass attributes as metadata on binding gRPC method.
Metadata/Attributes are processed by the middleware in ASP.NET Core. For example, `Authorize` and `AllowAnonymous`.