### PR TITLE
If a user leaves the room, another user joins the same room, and then the user who leaves the room disconnects, the shared data in the room will be deleted.

### DIFF
--- a/src/MagicOnion.Server/Hubs/Group.ImmutableArray.cs
+++ b/src/MagicOnion.Server/Hubs/Group.ImmutableArray.cs
@@ -111,17 +111,20 @@ namespace MagicOnion.Server.Hubs
         {
             lock (gate)
             {
-                members = members.Remove(context);
-                if (inmemoryStorage != null)
+                if (!members.IsEmpty)
                 {
-                    inmemoryStorage.Remove(context.ContextId);
-                }
-
-                if (members.Length == 0)
-                {
-                    if (parent.TryRemove(GroupName))
+                    members = members.Remove(context);
+                    if (inmemoryStorage != null)
                     {
-                        return new ValueTask<bool>(true);
+                        inmemoryStorage.Remove(context.ContextId);
+                    }
+
+                    if (members.Length == 0)
+                    {
+                        if (parent.TryRemove(GroupName))
+                        {
+                            return new ValueTask<bool>(true);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Steps to reproduce(please use [sample for Unity](https://github.com/Cysharp/MagicOnion#streaminghub))
1. Connect as user "A".
2. Join room name "AA" as user "A".
3. User "A" leaves the room name "AA".
4. Connect as user "B".
5. Join room name "AA" as user "B".
6. Disconnect as user "A"(Client-connection dispose).