### PR TITLE
Read and write directly to the buffer using IBufferWriter when calling Unary

### DIFF
--- a/src/MagicOnion.Server.OpenTelemetry/MagicOnionOpenTelemetryTracerFilterAttributes.cs
+++ b/src/MagicOnion.Server.OpenTelemetry/MagicOnionOpenTelemetryTracerFilterAttributes.cs
@@ -55,7 +55,6 @@ namespace MagicOnion.Server.OpenTelemetry
                 { SemanticConventions.AttributeHttpUrl, context.CallContext.Host + context.CallContext.Method },
                 { SemanticConventions.AttributeHttpUserAgent, context.CallContext.RequestHeaders.GetValue("user-agent")},
                 { SemanticConventions.AttributeMessageId, context.ContextId.ToString()},
-                { SemanticConventions.AttributeMessageUncompressedSize, context.GetRawRequest()?.LongLength.ToString() ?? "0"},
                 { SemanticConventions.AttributeMagicOnionPeerName, context.CallContext.Peer},
                 { SemanticConventions.AttributeMagicOnionAuthEnabled, (!string.IsNullOrEmpty(context.CallContext.AuthContext.PeerIdentityPropertyName)).ToString()},
                 { SemanticConventions.AttributeMagicOnionAuthPeerAuthenticated, context.CallContext.AuthContext.IsPeerAuthenticated.ToString()},

--- a/src/MagicOnion.Server/IMagicOnionLogger.cs
+++ b/src/MagicOnion.Server/IMagicOnionLogger.cs
@@ -13,8 +13,8 @@ namespace MagicOnion.Server
         void BeginBuildServiceDefinition();
         void EndBuildServiceDefinition(double elapsed);
 
-        void BeginInvokeMethod(ServiceContext context, byte[] request, Type type);
-        void EndInvokeMethod(ServiceContext context, byte[] response, Type type, double elapsed, bool isErrorOrInterrupted);
+        void BeginInvokeMethod(ServiceContext context, Type type);
+        void EndInvokeMethod(ServiceContext context, Type type, double elapsed, bool isErrorOrInterrupted);
 
         void BeginInvokeHubMethod(StreamingHubContext context, ReadOnlyMemory<byte> request, Type type);
         void EndInvokeHubMethod(StreamingHubContext context, int responseSize, Type? type, double elapsed, bool isErrorOrInterrupted);
@@ -33,7 +33,7 @@ namespace MagicOnion.Server
         {
         }
 
-        public void BeginInvokeMethod(ServiceContext context, byte[] request, Type type)
+        public void BeginInvokeMethod(ServiceContext context, Type type)
         {
         }
 
@@ -49,7 +49,7 @@ namespace MagicOnion.Server
         {
         }
 
-        public void EndInvokeMethod(ServiceContext context, byte[] response, Type type, double elapsed, bool isErrorOrInterrupted)
+        public void EndInvokeMethod(ServiceContext context, Type type, double elapsed, bool isErrorOrInterrupted)
         {
         }
 
@@ -92,15 +92,15 @@ namespace MagicOnion.Server
             _logger.LogDebug($"{nameof(EndBuildServiceDefinition)} elapsed:{elapsed}");
         }
 
-        public void BeginInvokeMethod(ServiceContext context, byte[] request, Type type)
+        public void BeginInvokeMethod(ServiceContext context, Type type)
         {
-            _logger.LogDebug($"{nameof(BeginInvokeMethod)} type:{MethodTypeToString(context.MethodType)} method:{context.CallContext.Method} size:{request.Length}");
+            _logger.LogDebug($"{nameof(BeginInvokeMethod)} type:{MethodTypeToString(context.MethodType)} method:{context.CallContext.Method}");
         }
 
-        public void EndInvokeMethod(ServiceContext context, byte[] response, Type type, double elapsed, bool isErrorOrInterrupted)
+        public void EndInvokeMethod(ServiceContext context, Type type, double elapsed, bool isErrorOrInterrupted)
         {
             var msg = isErrorOrInterrupted ? "error" : "";
-            _logger.LogDebug($"{nameof(EndInvokeMethod)} type:{MethodTypeToString(context.MethodType)}  method:{context.CallContext.Method} size:{response.Length} elapsed:{elapsed} {msg}");
+            _logger.LogDebug($"{nameof(EndInvokeMethod)} type:{MethodTypeToString(context.MethodType)}  method:{context.CallContext.Method} elapsed:{elapsed} {msg}");
         }
 
         public void WriteToStream(ServiceContext context, byte[] writeData, Type type)
@@ -155,224 +155,6 @@ namespace MagicOnion.Server
         public void Error(Exception ex, StreamingHubContext context)
         {
             _logger.LogError(ex, "Hub Method Handler throws exception occured in " + context.Path);
-        }
-    }
-
-    /// <summary>
-    /// Data dump is slightly heavy, recommended to only use debugging.
-    /// </summary>
-    public class MagicOnionLogToLoggerWithDataDump : IMagicOnionLogger
-    {
-        readonly ILogger _logger;
-
-        public MagicOnionLogToLoggerWithDataDump(ILogger<MagicOnionLogToLoggerWithDataDump> logger)
-        {
-            _logger = logger;
-        }
-
-        public void BeginBuildServiceDefinition()
-        {
-            _logger.LogDebug(nameof(BeginBuildServiceDefinition));
-        }
-
-        public void EndBuildServiceDefinition(double elapsed)
-        {
-            _logger.LogDebug($"{nameof(EndBuildServiceDefinition)} elapsed:{elapsed}");
-        }
-
-        public void BeginInvokeMethod(ServiceContext context, byte[] request, Type type)
-        {
-            _logger.LogDebug($"{nameof(BeginInvokeMethod)} type:{MethodTypeToString(context.MethodType)} method:{context.CallContext.Method} size:{request.Length} {ToJson(request, context.SerializerOptions)}");
-        }
-
-        public void EndInvokeMethod(ServiceContext context, byte[] response, Type type, double elapsed, bool isErrorOrInterrupted)
-        {
-            var msg = isErrorOrInterrupted ? "error" : "";
-            _logger.LogDebug($"{nameof(EndInvokeMethod)} type:{MethodTypeToString(context.MethodType)}  method:{context.CallContext.Method} size:{response.Length} elapsed:{elapsed} {msg} {ToJson(response, context.SerializerOptions)}");
-        }
-
-        public void WriteToStream(ServiceContext context, byte[] writeData, Type type)
-        {
-            _logger.LogDebug($"{nameof(WriteToStream)} type:{MethodTypeToString(context.MethodType)}  method:{context.CallContext.Method} size:{writeData.Length} {ToJson(writeData, context.SerializerOptions)}");
-        }
-
-        public void ReadFromStream(ServiceContext context, byte[] readData, Type type, bool complete)
-        {
-            _logger.LogDebug($"{nameof(ReadFromStream)} type:{MethodTypeToString(context.MethodType)}  method:{context.CallContext.Method} size:{readData.Length} complete:{complete} {ToJson(readData, context.SerializerOptions)}");
-        }
-
-        string ToJson(byte[] bytes, MessagePackSerializerOptions serializerOptions)
-        {
-            if (bytes == null || bytes.Length == 0) return "";
-            if (bytes.Length >= 5000) return "log is too large.";
-
-            return "dump:" + MessagePackSerializer.ConvertToJson(bytes, serializerOptions);
-        }
-
-        string ToJson(ReadOnlyMemory<byte> bytes, MessagePackSerializerOptions serializerOptions)
-        {
-            if (bytes.Length == 0) return "";
-            if (bytes.Length >= 5000) return "log is too large.";
-
-            return "dump:" + MessagePackSerializer.ConvertToJson(bytes, serializerOptions);
-        }
-
-        // enum.ToString is slow.
-        string MethodTypeToString(MethodType type)
-        {
-            switch (type)
-            {
-                case MethodType.Unary:
-                    return "Unary";
-                case MethodType.ClientStreaming:
-                    return "ClientStreaming";
-                case MethodType.ServerStreaming:
-                    return "ServerStreaming";
-                case MethodType.DuplexStreaming:
-                    return "DuplexStreaming";
-                default:
-                    return ((int)type).ToString();
-            }
-        }
-
-        public void BeginInvokeHubMethod(StreamingHubContext context, ReadOnlyMemory<byte> request, Type type)
-        {
-            _logger.LogDebug($"{nameof(BeginInvokeHubMethod)} method:{context.Path} size:{request.Length} {ToJson(request, context.SerializerOptions)}");
-        }
-
-        public void EndInvokeHubMethod(StreamingHubContext context, int responseSize, Type? type, double elapsed, bool isErrorOrInterrupted)
-        {
-            var msg = isErrorOrInterrupted ? "error" : "";
-            _logger.LogDebug($"{nameof(EndInvokeHubMethod)} method:{context.Path} size:{responseSize} elapsed:{elapsed} {msg}");
-        }
-
-        public void InvokeHubBroadcast(string groupName, int responseSize, int broadcastGroupCount)
-        {
-            _logger.LogDebug($"{nameof(InvokeHubBroadcast)} size:{responseSize} broadcastGroupCount:{broadcastGroupCount}");
-        }
-
-        public void Error(Exception ex, ServerCallContext context)
-        {
-            _logger.LogError(ex, "MagicOnionHandler throws exception occured in " + context.Method);
-        }
-        public void Error(Exception ex, StreamingHubContext context)
-        {
-            _logger.LogError(ex, "Hub Method Handler throws exception occured in " + context.Path);
-        }
-    }
-
-    /// <summary>
-    /// Named data dump is most heavy, recommended to only use debugging.
-    /// </summary>
-    public class MagicOnionLogToLoggerWithNamedDataDump : IMagicOnionLogger
-    {
-        readonly MessagePackSerializerOptions dumpResolverOptions;
-        readonly ILogger logger;
-
-        public MagicOnionLogToLoggerWithNamedDataDump(ILogger<MagicOnionLogToLoggerWithNamedDataDump> logger)
-            : this(logger, ContractlessFirstStandardResolver.Instance)
-        {
-        }
-
-        public MagicOnionLogToLoggerWithNamedDataDump(ILogger<MagicOnionLogToLoggerWithNamedDataDump> logger, IFormatterResolver dumpResolver)
-        {
-            this.logger = logger;
-            this.dumpResolverOptions = MessagePackSerializerOptions.Standard.WithResolver(dumpResolver);
-        }
-
-        public void BeginBuildServiceDefinition()
-        {
-            logger.LogDebug(nameof(BeginBuildServiceDefinition));
-        }
-
-        public void EndBuildServiceDefinition(double elapsed)
-        {
-            logger.LogDebug($"{nameof(EndBuildServiceDefinition)} elapsed:{elapsed}");
-        }
-
-        public void BeginInvokeMethod(ServiceContext context, byte[] request, Type type)
-        {
-            logger.LogDebug($"{nameof(BeginInvokeMethod)} type:{MethodTypeToString(context.MethodType)} method:{context.CallContext.Method} size:{request.Length} {ToJson(request, type, context)}");
-        }
-
-        public void EndInvokeMethod(ServiceContext context, byte[] response, Type type, double elapsed, bool isErrorOrInterrupted)
-        {
-            var msg = isErrorOrInterrupted ? "error" : "";
-            logger.LogDebug($"{nameof(EndInvokeMethod)} type:{MethodTypeToString(context.MethodType)}  method:{context.CallContext.Method} size:{response.Length} elapsed:{elapsed} {msg} {ToJson(response, type, context)}");
-        }
-
-        public void WriteToStream(ServiceContext context, byte[] writeData, Type type)
-        {
-            logger.LogDebug($"{nameof(WriteToStream)} type:{MethodTypeToString(context.MethodType)}  method:{context.CallContext.Method} size:{writeData.Length} {ToJson(writeData, type, context)}");
-        }
-
-        public void ReadFromStream(ServiceContext context, byte[] readData, Type type, bool complete)
-        {
-            logger.LogDebug($"{nameof(ReadFromStream)} type:{MethodTypeToString(context.MethodType)}  method:{context.CallContext.Method} size:{readData.Length} complete:{complete} {ToJson(readData, type, context)}");
-        }
-
-        string ToJson(byte[] bytes, Type type, ServiceContext context)
-        {
-            if (bytes == null || bytes.Length == 0) return "";
-            if (bytes.Length >= 5000) return "log is too large.";
-
-            var reData = MessagePackSerializer.Deserialize(type, bytes, context.SerializerOptions);
-            var reSerialized = MessagePackSerializer.Serialize(type, reData, dumpResolverOptions);
-
-            return "dump:" + MessagePackSerializer.ConvertToJson(reSerialized);
-        }
-
-        string ToJson(ReadOnlyMemory<byte> bytes, Type type, MessagePackSerializerOptions serializerOptions)
-        {
-            if (bytes.Length == 0) return "";
-            if (bytes.Length >= 5000) return "log is too large.";
-
-            var reData = MessagePackSerializer.Deserialize(type, bytes, serializerOptions);
-            var reSerialized = MessagePackSerializer.Serialize(type, reData, dumpResolverOptions);
-
-            return "dump:" + MessagePackSerializer.ConvertToJson(reSerialized);
-        }
-
-        // enum.ToString is slow.
-        string MethodTypeToString(MethodType type)
-        {
-            switch (type)
-            {
-                case MethodType.Unary:
-                    return "Unary";
-                case MethodType.ClientStreaming:
-                    return "ClientStreaming";
-                case MethodType.ServerStreaming:
-                    return "ServerStreaming";
-                case MethodType.DuplexStreaming:
-                    return "DuplexStreaming";
-                default:
-                    return ((int)type).ToString();
-            }
-        }
-        public void BeginInvokeHubMethod(StreamingHubContext context, ReadOnlyMemory<byte> request, Type type)
-        {
-            logger.LogDebug($"{nameof(BeginInvokeHubMethod)} method:{context.Path} size:{request.Length} {ToJson(request, type, context.SerializerOptions)}");
-        }
-
-        public void EndInvokeHubMethod(StreamingHubContext context, int responseSize, Type? type, double elapsed, bool isErrorOrInterrupted)
-        {
-            var msg = isErrorOrInterrupted ? "error" : "";
-            logger.LogDebug($"{nameof(EndInvokeHubMethod)} method:{context.Path} size:{responseSize} elapsed:{elapsed} {msg}");
-        }
-
-        public void InvokeHubBroadcast(string groupName, int responseSize, int broadcastGroupCount)
-        {
-            logger.LogDebug($"{nameof(InvokeHubBroadcast)} size:{responseSize} broadcastGroupCount:{broadcastGroupCount}");
-        }
-
-        public void Error(Exception ex, ServerCallContext context)
-        {
-            logger.LogError(ex, "MagicOnionHandler throws exception occured in " + context.Method);
-        }
-        public void Error(Exception ex, StreamingHubContext context)
-        {
-            logger.LogError(ex, "Hub Method Handler throws exception occured in " + context.Path);
         }
     }
 

--- a/src/MagicOnion.Server/MethodHandler.cs
+++ b/src/MagicOnion.Server/MethodHandler.cs
@@ -345,14 +345,14 @@ namespace MagicOnion.Server
                     .MakeGenericMethod(RequestType, UnwrappedResponseType);
                 bind = (Action<ServiceBinderBase>)methodBindUnaryHandler_Box_Box.CreateDelegate(typeof(Action<ServiceBinderBase>), this);
             }
-            else if (isRequestTypeValueType)
+            else if (isRequestTypeValueType && !isResponseTypeValueType)
             {
                 var methodBindUnaryHandler_Box_Class = this.GetType()
                     .GetMethod(nameof(BindUnaryHandler_Box_Class), BindingFlags.Instance | BindingFlags.NonPublic)!
                     .MakeGenericMethod(RequestType, UnwrappedResponseType);
                 bind = (Action<ServiceBinderBase>)methodBindUnaryHandler_Box_Class.CreateDelegate(typeof(Action<ServiceBinderBase>), this);
             }
-            else if (isResponseTypeValueType)
+            else if (!isRequestTypeValueType && isResponseTypeValueType)
             {
                 var methodBindUnaryHandler_Class_Box = this.GetType()
                     .GetMethod(nameof(BindUnaryHandler_Class_Box), BindingFlags.Instance | BindingFlags.NonPublic)!

--- a/src/MagicOnion.Server/MethodHandler.cs
+++ b/src/MagicOnion.Server/MethodHandler.cs
@@ -332,7 +332,7 @@ namespace MagicOnion.Server
             return next;
         }
 
-        internal void BindUnaryHandler(ServiceBinderBase binder)
+        void BindUnaryHandler(ServiceBinderBase binder)
         {
             // NOTE: ServiceBinderBase.AddMethod has `class` generic constraint.
             //       We need to box an instance of the value type.
@@ -372,7 +372,7 @@ namespace MagicOnion.Server
             bind(binder);
         }
 
-        internal void BindUnaryHandler_ValueType_ValueType<TRequest, TResponse>(ServiceBinderBase binder)
+        void BindUnaryHandler_ValueType_ValueType<TRequest, TResponse>(ServiceBinderBase binder)
         {
             var requestMarshaller = new Marshaller<Box<TRequest>>(
                 serializer: (obj, ctx) =>
@@ -394,7 +394,7 @@ namespace MagicOnion.Server
             binder.AddMethod(method, async (request, context) => new Box<TResponse>(await UnaryServerMethod<TRequest, TResponse>(request.Value!, context)));
         }
 
-        internal void BindUnaryHandler_RefType_ValueType<TRequest, TResponse>(ServiceBinderBase binder)
+        void BindUnaryHandler_RefType_ValueType<TRequest, TResponse>(ServiceBinderBase binder)
             where TRequest : class
         {
             var requestMarshaller = new Marshaller<TRequest>(
@@ -417,7 +417,7 @@ namespace MagicOnion.Server
             binder.AddMethod(method, async (request, context) => new Box<TResponse>(await UnaryServerMethod<TRequest, TResponse>(request, context)));
         }
 
-        internal void BindUnaryHandler_ValueType_RefType<TRequest, TResponse>(ServiceBinderBase binder)
+        void BindUnaryHandler_ValueType_RefType<TRequest, TResponse>(ServiceBinderBase binder)
             where TResponse : class
         {
             var requestMarshaller = new Marshaller<Box<TRequest>>(
@@ -442,7 +442,7 @@ namespace MagicOnion.Server
 #pragma warning restore CS8603
         }
 
-        internal void BindUnaryHandler_RefType_RefType<TRequest, TResponse>(ServiceBinderBase binder)
+        void BindUnaryHandler_RefType_RefType<TRequest, TResponse>(ServiceBinderBase binder)
             where TRequest : class
             where TResponse : class
         {

--- a/src/MagicOnion.Server/MethodHandler.cs
+++ b/src/MagicOnion.Server/MethodHandler.cs
@@ -536,7 +536,10 @@ namespace MagicOnion.Server
                     ServiceContext.currentServiceContext.Value = serviceContext;
                 }
                 await this.methodBody(serviceContext).ConfigureAwait(false);
-                response = (TResponse?)serviceContext.Result;
+                if (serviceContext.Result is not null)
+                {
+                    response = (TResponse?)serviceContext.Result;
+                }
             }
             catch (ReturnStatusException ex)
             {

--- a/src/MagicOnion.Server/MethodHandler.cs
+++ b/src/MagicOnion.Server/MethodHandler.cs
@@ -334,43 +334,45 @@ namespace MagicOnion.Server
 
         internal void BindUnaryHandler(ServiceBinderBase binder)
         {
+            // NOTE: ServiceBinderBase.AddMethod has `class` generic constraint.
+            //       We need to box an instance of the value type.
             var isRequestTypeValueType = RequestType.IsValueType;
             var isResponseTypeValueType = UnwrappedResponseType.IsValueType;
 
             Action<ServiceBinderBase> bind;
             if (isRequestTypeValueType && isResponseTypeValueType)
             {
-                var methodBindUnaryHandler_Box_Box = this.GetType()
-                    .GetMethod(nameof(BindUnaryHandler_Box_Box), BindingFlags.Instance | BindingFlags.NonPublic)!
+                var methodBindUnaryHandler_ValueType_ValueType = this.GetType()
+                    .GetMethod(nameof(BindUnaryHandler_ValueType_ValueType), BindingFlags.Instance | BindingFlags.NonPublic)!
                     .MakeGenericMethod(RequestType, UnwrappedResponseType);
-                bind = (Action<ServiceBinderBase>)methodBindUnaryHandler_Box_Box.CreateDelegate(typeof(Action<ServiceBinderBase>), this);
+                bind = (Action<ServiceBinderBase>)methodBindUnaryHandler_ValueType_ValueType.CreateDelegate(typeof(Action<ServiceBinderBase>), this);
             }
             else if (isRequestTypeValueType && !isResponseTypeValueType)
             {
-                var methodBindUnaryHandler_Box_Class = this.GetType()
-                    .GetMethod(nameof(BindUnaryHandler_Box_Class), BindingFlags.Instance | BindingFlags.NonPublic)!
+                var methodBindUnaryHandler_ValueType_RefType = this.GetType()
+                    .GetMethod(nameof(BindUnaryHandler_ValueType_RefType), BindingFlags.Instance | BindingFlags.NonPublic)!
                     .MakeGenericMethod(RequestType, UnwrappedResponseType);
-                bind = (Action<ServiceBinderBase>)methodBindUnaryHandler_Box_Class.CreateDelegate(typeof(Action<ServiceBinderBase>), this);
+                bind = (Action<ServiceBinderBase>)methodBindUnaryHandler_ValueType_RefType.CreateDelegate(typeof(Action<ServiceBinderBase>), this);
             }
             else if (!isRequestTypeValueType && isResponseTypeValueType)
             {
-                var methodBindUnaryHandler_Class_Box = this.GetType()
-                    .GetMethod(nameof(BindUnaryHandler_Class_Box), BindingFlags.Instance | BindingFlags.NonPublic)!
+                var methodBindUnaryHandler_RefType_ValueType = this.GetType()
+                    .GetMethod(nameof(BindUnaryHandler_RefType_ValueType), BindingFlags.Instance | BindingFlags.NonPublic)!
                     .MakeGenericMethod(RequestType, UnwrappedResponseType);
-                bind = (Action<ServiceBinderBase>)methodBindUnaryHandler_Class_Box.CreateDelegate(typeof(Action<ServiceBinderBase>), this);
+                bind = (Action<ServiceBinderBase>)methodBindUnaryHandler_RefType_ValueType.CreateDelegate(typeof(Action<ServiceBinderBase>), this);
             }
             else
             {
-                var methodBindUnaryHandler_Class_Class = this.GetType()
-                    .GetMethod(nameof(BindUnaryHandler_Class_Class), BindingFlags.Instance | BindingFlags.NonPublic)!
+                var methodBindUnaryHandler_RefType_RefType = this.GetType()
+                    .GetMethod(nameof(BindUnaryHandler_RefType_RefType), BindingFlags.Instance | BindingFlags.NonPublic)!
                     .MakeGenericMethod(RequestType, UnwrappedResponseType);
-                bind = (Action<ServiceBinderBase>)methodBindUnaryHandler_Class_Class.CreateDelegate(typeof(Action<ServiceBinderBase>), this);
+                bind = (Action<ServiceBinderBase>)methodBindUnaryHandler_RefType_RefType.CreateDelegate(typeof(Action<ServiceBinderBase>), this);
             }
 
             bind(binder);
         }
 
-        internal void BindUnaryHandler_Box_Box<TRequest, TResponse>(ServiceBinderBase binder)
+        internal void BindUnaryHandler_ValueType_ValueType<TRequest, TResponse>(ServiceBinderBase binder)
         {
             var requestMarshaller = new Marshaller<Box<TRequest>>(
                 serializer: (obj, ctx) =>
@@ -392,7 +394,7 @@ namespace MagicOnion.Server
             binder.AddMethod(method, async (request, context) => new Box<TResponse>(await UnaryServerMethod<TRequest, TResponse>(request.Value!, context)));
         }
 
-        internal void BindUnaryHandler_Class_Box<TRequest, TResponse>(ServiceBinderBase binder)
+        internal void BindUnaryHandler_RefType_ValueType<TRequest, TResponse>(ServiceBinderBase binder)
             where TRequest : class
         {
             var requestMarshaller = new Marshaller<TRequest>(
@@ -415,7 +417,7 @@ namespace MagicOnion.Server
             binder.AddMethod(method, async (request, context) => new Box<TResponse>(await UnaryServerMethod<TRequest, TResponse>(request, context)));
         }
 
-        internal void BindUnaryHandler_Box_Class<TRequest, TResponse>(ServiceBinderBase binder)
+        internal void BindUnaryHandler_ValueType_RefType<TRequest, TResponse>(ServiceBinderBase binder)
             where TResponse : class
         {
             var requestMarshaller = new Marshaller<Box<TRequest>>(
@@ -440,7 +442,7 @@ namespace MagicOnion.Server
 #pragma warning restore CS8603
         }
 
-        internal void BindUnaryHandler_Class_Class<TRequest, TResponse>(ServiceBinderBase binder)
+        internal void BindUnaryHandler_RefType_RefType<TRequest, TResponse>(ServiceBinderBase binder)
             where TRequest : class
             where TResponse : class
         {

--- a/src/MagicOnion.Server/MethodHandler.cs
+++ b/src/MagicOnion.Server/MethodHandler.cs
@@ -608,6 +608,7 @@ namespace MagicOnion.Server
                         ServiceContext.currentServiceContext.Value = serviceContext;
                     }
                     await this.methodBody(serviceContext).ConfigureAwait(false);
+                    response = serviceContext.Result as byte[] ?? emptyBytes;
                 }
             }
             catch (ReturnStatusException ex)

--- a/src/MagicOnion.Server/ServiceContext.cs
+++ b/src/MagicOnion.Server/ServiceContext.cs
@@ -59,13 +59,11 @@ namespace MagicOnion.Server
 
         public IServiceProvider ServiceProvider { get; private set; }
 
-        // internal, used from there methods.
-        internal bool IsIgnoreSerialization { get; set; }
-        byte[]? request;
-        internal ReadOnlyMemory<byte> Request => request;
+        object? request;
+        internal object? Request => request;
         internal IAsyncStreamReader<byte[]>? RequestStream { get; set; }
         internal IAsyncStreamWriter<byte[]>? ResponseStream { get; set; }
-        internal byte[]? Result { get; set; }
+        internal object? Result { get; set; }
         internal IMagicOnionLogger MagicOnionLogger { get; private set; }
         internal MethodHandler MethodHandler { get; private set; }
 
@@ -90,25 +88,25 @@ namespace MagicOnion.Server
         }
 
         /// <summary>Get Raw Request.</summary>
-        public byte[]? GetRawRequest()
+        public object? GetRawRequest()
         {
             return request;
         }
 
         /// <summary>Set Raw Request, you can set before method body was called.</summary>
-        public void SetRawRequest(byte[] request)
+        public void SetRawRequest(object? request)
         {
             this.request = request;
         }
 
         /// <summary>Can get after method body was finished.</summary>
-        public byte[]? GetRawResponse()
+        public object? GetRawResponse()
         {
             return Result;
         }
 
         /// <summary>Can set after method body was finished.</summary>
-        public void SetRawResponse(byte[] response)
+        public void SetRawResponse(object? response)
         {
             Result = response;
         }
@@ -154,15 +152,6 @@ namespace MagicOnion.Server
         public void ChangeSerializerOptions(MessagePackSerializerOptions serializerOptions)
         {
             this.SerializerOptions = serializerOptions;
-        }
-
-        /// <summary>
-        /// Unsafe optimize option, ignore serialization process of MessagePackSerializer. This is useful for cache result.
-        /// </summary>
-        public void ForceSetRawUnaryResult(byte[] result)
-        {
-            this.IsIgnoreSerialization = true;
-            this.Result = result;
         }
     }
 


### PR DESCRIPTION
This PR changes to read and write directly to the buffer using IBufferWriter when calling Unary.
Unary requests can be processed up to 5-10% more efficiently.

## Breaking changes
- Remove `request`/`response` parameter from `IMagicOnionLogger`
- Remove `MagicOnionLogToLoggerWithDataDump`, `MagicOnionLogToLoggerWithNamedDataDump`
- Change the signature of `SetRawRequest` / `GetRawRequest` from `byte[]` to `object`