### PR TITLE
Annotate nullable properties not required in Swagger, fixes #456

### DIFF
--- a/sandbox/Sandbox.AspNetCore/Services/UnaryService.cs
+++ b/sandbox/Sandbox.AspNetCore/Services/UnaryService.cs
@@ -72,7 +72,7 @@ namespace Sandbox.AspNetCore.Services
         /// <param name="x">多分X。</param>
         /// <param name="y">多分Y。</param>
         /// <returns>何故かString。</returns>
-        UnaryResult<string> SumAsync(int x, int y);
+        UnaryResult<string> SumAsync(int x, int? y);
     }
 
     public class UnaryService : ServiceBase<ICalcSerivce>, ICalcSerivce
@@ -98,9 +98,9 @@ namespace Sandbox.AspNetCore.Services
         }
 
         [MyFirstFilter]
-        public async UnaryResult<string> SumAsync(int x, int y)
+        public async UnaryResult<string> SumAsync(int x, int? y)
         {
-            return (x + y).ToString();
+            return (x + (y ?? 0)).ToString();
         }
     }
 

--- a/src/MagicOnion.Server.HttpGateway/Swagger/SwaggerDefinitionBuilder.cs
+++ b/src/MagicOnion.Server.HttpGateway/Swagger/SwaggerDefinitionBuilder.cs
@@ -182,7 +182,7 @@ namespace MagicOnion.Server.HttpGateway.Swagger
                         @in = "formData",
                         type = swaggerDataType,
                         description = parameterXmlComment,
-                        required = !x.IsOptional,
+                        required = !x.IsOptional && !x.ParameterType.IsNullable(), // OpenAPI 3 has a separate definition for nullable, but for OpenAPI 2, there is only required.
                         @default = defaultObjectExample ?? ((x.IsOptional) ? defaultValue : null),
                         items = items,
                         @enum = enums,


### PR DESCRIPTION
If you are open to a tiny PR, this will resolve #456 by making nullable property types not required in swagger. I also modified the sandbox to make one parameter nullable, to exercise this.