### PR TITLE
FIX: codegen system type fix

### DIFF
--- a/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
+++ b/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
@@ -26,7 +26,7 @@ namespace MagicOnion.CodeAnalysis
 
         public ReferenceSymbols(Compilation compilation, Action<string> logger)
         {
-            Void = compilation.GetTypeByMetadataName("System.Void");
+            Void = compilation.GetSpecialType(SpecialType.System_Void);
             if (Void == null)
             {
                 logger("failed to get metadata of System.Void.");

--- a/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
+++ b/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 
@@ -32,13 +33,13 @@ namespace MagicOnion.CodeAnalysis
                 logger("failed to get metadata of System.Void.");
             }
 
-            TaskOfT = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+            TaskOfT = GetWellKnownType(94);
             if (TaskOfT == null)
             {
                 logger("failed to get metadata of System.Threading.Tasks.Task`1.");
             }
 
-            Task = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
+            Task = GetWellKnownType(93);
             if (Task == null)
             {
                 logger("failed to get metadata of System.Threading.Tasks.Task.");
@@ -52,6 +53,12 @@ namespace MagicOnion.CodeAnalysis
                     throw new InvalidOperationException("failed to get metadata of " + name);
                 }
                 return symbol;
+            }
+
+            INamedTypeSymbol GetWellKnownType(int id)
+            {
+                var method = compilation.GetType().GetMethod("CommonGetWellKnownType", BindingFlags.Instance | BindingFlags.NonPublic);
+                return (INamedTypeSymbol)method.Invoke(compilation, new object[] { id });
             }
 
             UnaryResult = GetTypeSymbolOrThrow("MagicOnion.UnaryResult`1");

--- a/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
+++ b/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
@@ -27,19 +27,19 @@ namespace MagicOnion.CodeAnalysis
 
         public ReferenceSymbols(Compilation compilation, Action<string> logger)
         {
-            Void = compilation.GetSpecialType(SpecialType.System_Void);
+            Void = compilation.GetTypeByMetadataName("System.Void") ?? compilation.GetSpecialType(SpecialType.System_Void);
             if (Void == null)
             {
                 logger("failed to get metadata of System.Void.");
             }
 
-            TaskOfT = GetWellKnownType(94);
+            TaskOfT = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1") ?? GetWellKnownType(94);
             if (TaskOfT == null)
             {
                 logger("failed to get metadata of System.Threading.Tasks.Task`1.");
             }
 
-            Task = GetWellKnownType(93);
+            Task = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task") ?? GetWellKnownType(93);
             if (Task == null)
             {
                 logger("failed to get metadata of System.Threading.Tasks.Task.");


### PR DESCRIPTION
Fix provides a way to correctly obtain well known system types in the MethodCollector

Fixes the following errors:

```
failed to get metadata of System.Void.
failed to get metadata of System.Threading.Tasks.Task`1.
failed to get metadata of System.Threading.Tasks.Task.
```