### PR TITLE
Add manual dependency resolver client for inject service with depende…

### DIFF
--- a/src/MagicOnion.Client/MagicOnion.Client.csproj
+++ b/src/MagicOnion.Client/MagicOnion.Client.csproj
@@ -38,6 +38,9 @@
   <ItemGroup>
     <TargetFiles Include="$(ProjectDir)**\*.cs" Exclude="**\bin\**\*.*;**\obj\**\*.*" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
+  </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Copy SourceFiles="@(TargetFiles)" DestinationFiles="$(DestinationRoot)\%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />
   </Target>

--- a/src/MagicOnion.Client/MagicOnionClient.cs
+++ b/src/MagicOnion.Client/MagicOnionClient.cs
@@ -1,6 +1,7 @@
 using Grpc.Core;
 using MessagePack;
 using System;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MagicOnion.Client
 {
@@ -63,6 +64,13 @@ namespace MagicOnion.Client
             {
                 return ctor(invoker, serializerOptions, clientFilters);
             }
+        }
+        
+        public static IServiceCollection AddMagicOnionClient<T>(this IServiceCollection serviceCollection, ChannelBase channel) 
+            where T : IService<T>
+        {
+            Create<T>(channel.CreateCallInvoker(), MessagePackSerializer.DefaultOptions, emptyFilters);
+            return serviceCollection;
         }
     }
 


### PR DESCRIPTION
Injection client with dependency injection to handle mocking gRPC service with dependency injection in test purpose and easy inject services in constructor.

> We have something like this [gRPC client factory integration in .NET](https://docs.microsoft.com/en-us/aspnet/core/grpc/clientfactory?view=aspnetcore-6.0) in gRPC .net.

Like this in Program.cs:
```csharp
var builder = WebApplication.CreateBuilder(args);
    //...
builder.Services.AddMagicOnionClient<IPassengerGrpcService>(GrpcChannel.ForAddress("https://localhost:5001"));
    //...
```
and inject this service in our services, our handlers:
```csharp
public class CreateBookingCommandHandler : IRequestHandler<CreateBookingCommand, ulong>
{
    private readonly IPassengerGrpcService _passengerGrpcService;

    // inject grpc clients in constructor
    public CreateBookingCommandHandler(IPassengerGrpcService passengerGrpcService)
    {
        _passengerGrpcService = passengerGrpcService;
    }
    //...
         var result = await _passengerGrpcService.GetById(100);
    //...
}
```