### PR TITLE
Add verbose logging option to Generator

### DIFF
--- a/src/MagicOnion.Generator/Program.cs
+++ b/src/MagicOnion.Generator/Program.cs
@@ -2,6 +2,7 @@ using MagicOnion.Generator;
 using System;
 using System.Threading.Tasks;
 using ConsoleAppFramework;
+using MagicOnion.Generator.Internal;
 using Microsoft.Extensions.Hosting;
 
 namespace MagicOnion.Generator
@@ -25,9 +26,10 @@ namespace MagicOnion.Generator
             [Option("u", "Unuse UnityEngine's RuntimeInitializeOnLoadMethodAttribute on MagicOnionInitializer.")]bool unuseUnityAttr = false,
             [Option("n", "Set namespace root name.")]string @namespace = "MagicOnion",
             [Option("m", "Set generated MessagePackFormatter namespace.")]string messagePackGeneratedNamespace = "MessagePack.Formatters",
-            [Option("c", "Conditional compiler symbols, split with ','.")]string conditionalSymbol = null)
+            [Option("c", "Conditional compiler symbols, split with ','.")]string conditionalSymbol = null,
+            [Option("v", "Enable verbose logging")]bool verbose = false)
         {
-            await new MagicOnionCompiler(x => Console.WriteLine(x), this.Context.CancellationToken)
+            await new MagicOnionCompiler(new MagicOnionGeneratorConsoleLogger(verbose), this.Context.CancellationToken)
                 .GenerateFileAsync(
                     input,
                     output,

--- a/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
+++ b/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
@@ -79,7 +79,7 @@ namespace MagicOnion.Generator.CodeAnalysis
                     throw new InvalidOperationException($"StreamingHub method '{interfaceType.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.Namespace)}.{methodSymbol.Name}' has unsupported return type '{methodReturnType.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.Namespace)}'.");
             }
 
-            logger.Trace($"[{nameof(MethodCollectorContext)}] Found StreamingHub method '{methodSymbol.Name}' in type '{interfaceType.FullName}'");
+            logger.Trace($"[{nameof(MethodCollectorContext)}] StreamingHub method '{methodSymbol.Name}' in type '{interfaceType.FullName}'");
             return new MagicOnionStreamingHubInfo.MagicOnionHubMethodInfo(
                 hubId,
                 methodSymbol.Name,

--- a/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
+++ b/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
@@ -12,11 +12,11 @@ namespace MagicOnion.Generator.CodeAnalysis
     /// </summary>
     public class MethodCollector
     {
-        readonly Action<string> logger;
+        readonly IMagicOnionGeneratorLogger logger;
 
-        public MethodCollector(Action<string> logger = null)
+        public MethodCollector(IMagicOnionGeneratorLogger logger = null)
         {
-            this.logger = logger ?? (_ => {});
+            this.logger = logger ?? MagicOnionGeneratorNullLogger.Instance;
         }
 
         public MagicOnionServiceCollection Collect(Compilation compilation)
@@ -32,6 +32,9 @@ namespace MagicOnion.Generator.CodeAnalysis
                 .Select(x =>
                 {
                     var serviceType = MagicOnionTypeInfo.CreateFromSymbol(x);
+                    var ifDirective = x.GetDefinedGenerateIfCondition();
+                    logger.Trace($"[{nameof(MethodCollectorContext)}] StreamingHub type '{serviceType.FullName}' (IfDirective={ifDirective})");
+
                     var methods = x.GetMembers()
                         .OfType<IMethodSymbol>()
                         .Select(y => CreateHubMethodInfoFromMethodSymbol(serviceType, y))
@@ -44,8 +47,10 @@ namespace MagicOnion.Generator.CodeAnalysis
                         .Select(y => CreateHubReceiverMethodInfoFromMethodSymbol(serviceType, y))
                         .ToArray();
 
+                    logger.Trace($"[{nameof(MethodCollectorContext)}] StreamingHub Receiver type '{receiverType.FullName}'");
                     var receiver = new MagicOnionStreamingHubInfo.MagicOnionStreamingHubReceiverInfo(receiverType, receiverMethods, receiverInterfaceSymbol.GetDefinedGenerateIfCondition());
-                    return new MagicOnionStreamingHubInfo(serviceType, methods, receiver, x.GetDefinedGenerateIfCondition());
+
+                    return new MagicOnionStreamingHubInfo(serviceType, methods, receiver, ifDirective);
                 })
                 .OrderBy(x => x.ServiceType.FullName)
                 .ToArray();
@@ -74,6 +79,7 @@ namespace MagicOnion.Generator.CodeAnalysis
                     throw new InvalidOperationException($"StreamingHub method '{interfaceType.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.Namespace)}.{methodSymbol.Name}' has unsupported return type '{methodReturnType.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.Namespace)}'.");
             }
 
+            logger.Trace($"[{nameof(MethodCollectorContext)}] Found StreamingHub method '{methodSymbol.Name}' in type '{interfaceType.FullName}'");
             return new MagicOnionStreamingHubInfo.MagicOnionHubMethodInfo(
                 hubId,
                 methodSymbol.Name,
@@ -97,6 +103,7 @@ namespace MagicOnion.Generator.CodeAnalysis
                 throw new InvalidOperationException($"StreamingHub receiver method '{interfaceType.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.Namespace)}.{methodSymbol.Name}' has unsupported return type '{methodReturnType.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.Namespace)}'.");
             }
 
+            logger.Trace($"[{nameof(MethodCollectorContext)}] StreamingHub receiver method '{methodSymbol.Name}' in type '{interfaceType.FullName}'");
             return new MagicOnionStreamingHubInfo.MagicOnionHubMethodInfo(
                 hubId,
                 methodSymbol.Name,
@@ -114,12 +121,15 @@ namespace MagicOnion.Generator.CodeAnalysis
                 .Select(x =>
                 {
                     var serviceType = MagicOnionTypeInfo.CreateFromSymbol(x);
+                    var ifDirective = x.GetDefinedGenerateIfCondition();
+                    logger.Trace($"[{nameof(MethodCollectorContext)}] Service type '{serviceType.FullName}' (IfDirective={ifDirective})");
+
                     var methods = x.GetMembers()
                         .OfType<IMethodSymbol>()
                         .Select(y => CreateServiceMethodInfoFromMethodSymbol(serviceType, y))
                         .ToArray();
 
-                    return new MagicOnionServiceInfo(serviceType, methods, x.GetDefinedGenerateIfCondition());
+                    return new MagicOnionServiceInfo(serviceType, methods, ifDirective);
                 })
                 .OrderBy(x => x.ServiceType.FullName)
                 .ToArray();
@@ -177,6 +187,7 @@ namespace MagicOnion.Generator.CodeAnalysis
                 throw new InvalidOperationException($"ClientStreaming and DuplexStreaming must have no parameters. ({serviceType.FullName}.{methodSymbol.Name})");
             }
 
+            logger.Trace($"[{nameof(MethodCollectorContext)}] Service method '{methodSymbol.Name}' ({methodType}) in type '{serviceType.FullName}' (IfDirective={ifDirective})");
             return new MagicOnionServiceInfo.MagicOnionServiceMethodInfo(
                 methodType,
                 serviceType.Name,
@@ -200,34 +211,47 @@ namespace MagicOnion.Generator.CodeAnalysis
                     ? parameters[0].Type
                     : MagicOnionTypeInfo.CreateValueType("MagicOnion", "DynamicArgumentTuple", parameters.Select(x => x.Type).ToArray());
 
-        public class MethodCollectorContext
+        class MethodCollectorContext
         {
             public ReferenceSymbols ReferenceSymbols { get; }
             public IReadOnlyList<INamedTypeSymbol> ServiceAndHubInterfaces { get; }
             public IReadOnlyList<INamedTypeSymbol> ServiceInterfaces { get; }
             public IReadOnlyList<INamedTypeSymbol> HubInterfaces { get; }
-            public Action<string> Logger { get; }
+            public IMagicOnionGeneratorLogger Logger { get; }
 
-            public MethodCollectorContext(ReferenceSymbols referenceSymbols, IReadOnlyList<INamedTypeSymbol> serviceAndHubInterfaces, Action<string> logger)
+            public MethodCollectorContext(ReferenceSymbols referenceSymbols, IReadOnlyList<INamedTypeSymbol> serviceAndHubInterfaces, IMagicOnionGeneratorLogger logger)
             {
                 ReferenceSymbols = referenceSymbols;
                 ServiceAndHubInterfaces = serviceAndHubInterfaces;
-                Logger = logger ?? (_ => { });
+                Logger = logger;
 
-                ServiceInterfaces = serviceAndHubInterfaces
-                    .Where(x => x.AllInterfaces.Any(y => y.ApproximatelyEqual(referenceSymbols.IServiceMarker)) && x.AllInterfaces.All(y => !y.ApproximatelyEqual(referenceSymbols.IStreamingHubMarker)))
-                    .Where(x => !x.ConstructedFrom.ApproximatelyEqual(referenceSymbols.IService))
-                    .Distinct()
-                    .ToArray();
+                var serviceInterfaces = new HashSet<INamedTypeSymbol>();
+                var hubInterfaces = new HashSet<INamedTypeSymbol>();
+                foreach (var type in serviceAndHubInterfaces)
+                {
+                    if (type.AllInterfaces.Any(y => y.ApproximatelyEqual(referenceSymbols.IStreamingHubMarker)))
+                    {
+                        // StreamingHub
+                        if (!type.ConstructedFrom.ApproximatelyEqual(referenceSymbols.IStreamingHub))
+                        {
+                            hubInterfaces.Add(type);
+                        }
+                    }
+                    else if (type.AllInterfaces.Any(y => y.ApproximatelyEqual(referenceSymbols.IServiceMarker)))
+                    {
+                        // Service
+                        if (!type.ConstructedFrom.ApproximatelyEqual(referenceSymbols.IService))
+                        {
+                            serviceInterfaces.Add(type);
+                        }
+                    }
+                }
 
-                HubInterfaces = serviceAndHubInterfaces
-                    .Where(x => x.AllInterfaces.Any(y => y.ApproximatelyEqual(referenceSymbols.IStreamingHubMarker)))
-                    .Where(x => !x.ConstructedFrom.ApproximatelyEqual(referenceSymbols.IStreamingHub))
-                    .Distinct()
-                    .ToArray();
+                ServiceInterfaces = serviceInterfaces.ToArray();
+                HubInterfaces = hubInterfaces.ToArray();
             }
 
-            public static MethodCollectorContext CreateFromCompilation(Compilation compilation, Action<string> logger = null)
+            public static MethodCollectorContext CreateFromCompilation(Compilation compilation, IMagicOnionGeneratorLogger logger)
             {
                 var typeReferences = new ReferenceSymbols(compilation, logger);
                 var serviceAndHubInterfaces = compilation.GetNamedTypeSymbols()

--- a/src/MagicOnion.GeneratorCore/Internal/IMagicOnionGeneratorLogger.cs
+++ b/src/MagicOnion.GeneratorCore/Internal/IMagicOnionGeneratorLogger.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace MagicOnion.Generator.Internal
+{
+    public interface IMagicOnionGeneratorLogger
+    {
+        void Trace(string message);
+        void Information(string message);
+        void Error(string message, Exception exception = null);
+    }
+
+    public class MagicOnionGeneratorNullLogger : IMagicOnionGeneratorLogger
+    {
+        public static IMagicOnionGeneratorLogger Instance { get; } = new MagicOnionGeneratorNullLogger();
+
+        public void Trace(string message)
+        {
+        }
+
+        public void Information(string message)
+        {
+        }
+
+        public void Error(string message, Exception exception = null)
+        {
+        }
+    }
+
+    public class MagicOnionGeneratorConsoleLogger : IMagicOnionGeneratorLogger
+    {
+        readonly bool verbose;
+
+        public MagicOnionGeneratorConsoleLogger(bool verbose)
+        {
+            this.verbose = verbose;
+        }
+        
+        public void Trace(string message)
+        {
+            if (verbose)
+            {
+                Console.WriteLine(message);
+            }
+        }
+
+        public void Information(string message)
+        {
+            Console.WriteLine(message);
+        }
+
+        public void Error(string message, Exception exception = null)
+        {
+            Console.Error.WriteLine(message);
+        }
+    }
+}

--- a/src/MagicOnion.GeneratorCore/MagicOnionCompiler.cs
+++ b/src/MagicOnion.GeneratorCore/MagicOnionCompiler.cs
@@ -43,6 +43,12 @@ namespace MagicOnion.Generator
             var conditionalSymbols = conditionalSymbol?.Split(',') ?? Array.Empty<string>();
 
             // Generator Start...
+            logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:Input: {input}");
+            logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:Output: {output}");
+            logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:OmitUnityAttribute: {omitUnityAttribute}");
+            logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:Namespace: {@namespace}");
+            logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:ConditionalSymbol: {conditionalSymbol}");
+            logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:UserDefinedMessagePackFormattersNamespace: {userDefinedMessagePackFormattersNamespace}");
             logger.Trace($"[{nameof(MagicOnionCompiler)}] Assembly version: {typeof(MagicOnionCompiler).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion}");
             logger.Trace($"[{nameof(MagicOnionCompiler)}] RuntimeInformation.OSDescription: {RuntimeInformation.OSDescription}");
             logger.Trace($"[{nameof(MagicOnionCompiler)}] RuntimeInformation.ProcessArchitecture: {RuntimeInformation.ProcessArchitecture}");

--- a/src/MagicOnion.GeneratorCore/Utils/PseudoCompilation.cs
+++ b/src/MagicOnion.GeneratorCore/Utils/PseudoCompilation.cs
@@ -72,7 +72,7 @@ namespace MagicOnion.Generator.Utils
             {
                 foreach (var diagnostic in diagnostics.Where(x => x.Severity == DiagnosticSeverity.Error))
                 {
-                    logger.Trace($"[{nameof(PseudoCompilation)}] {diagnostic.ToString()}");
+                    logger.Trace($"[{nameof(PseudoCompilation)}] CompilationDiagnostic: {diagnostic.ToString()}");
                 }
             }
 
@@ -298,6 +298,7 @@ namespace MagicOnion.Generator.Utils
                 void CollectNugetPackages(string id, string packageVersion, string originalTargetFramework)
                 {
                     logger.Trace($"[{nameof(PseudoCompilation)}] NuGet Package '{id} {packageVersion}'");
+                    var packageAssemblyResolved = false;
                     foreach (var targetFramework in NetstandardFallBack(originalTargetFramework).Distinct())
                     {
                         var pathpath = Path.Combine(nugetPackagesPath, id, packageVersion, "lib", targetFramework);
@@ -317,8 +318,14 @@ namespace MagicOnion.Generator.Utils
                                 }
                             }
 
+                            packageAssemblyResolved = true;
                             break;
                         }
+                    }
+
+                    if (!packageAssemblyResolved)
+                    {
+                        logger.Trace($"[{nameof(PseudoCompilation)}] Could not find package assembly for '{id} {packageVersion}'");
                     }
                 }
 

--- a/tests/MagicOnion.Generator.Tests/Collector/MethodCollectorServicesTest.cs
+++ b/tests/MagicOnion.Generator.Tests/Collector/MethodCollectorServicesTest.cs
@@ -1,11 +1,19 @@
 using System;
 using System.Threading.Tasks;
 using MagicOnion.Generator.CodeAnalysis;
+using Xunit.Abstractions;
 
 namespace MagicOnion.Generator.Tests.Collector;
 
 public class MethodCollectorServicesTest
 {
+    readonly ITestOutputHelper _testOutputHelper;
+
+    public MethodCollectorServicesTest(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
     [Fact]
     public void FileScopedNamespace()
     {
@@ -28,7 +36,7 @@ public interface IMyService : IService<IMyService>
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -76,7 +84,7 @@ public interface IMyService : IService<IMyService>
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -116,7 +124,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -148,7 +156,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -180,7 +188,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -223,7 +231,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -265,7 +273,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -308,7 +316,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -352,7 +360,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -396,7 +404,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -431,7 +439,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act & Assert
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         Assert.Throws<InvalidOperationException>(() => collector.Collect(compilation));
     }
     
@@ -458,7 +466,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act & Assert
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         Assert.Throws<InvalidOperationException>(() => collector.Collect(compilation));
     }
         
@@ -485,7 +493,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act & Assert
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         Assert.Throws<InvalidOperationException>(() => collector.Collect(compilation));
     }
            
@@ -512,7 +520,7 @@ namespace MyNamespace
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act & Assert
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         Assert.Throws<InvalidOperationException>(() => collector.Collect(compilation));
     }
 
@@ -538,7 +546,7 @@ public interface IMyService : IService<IMyService>
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -579,7 +587,7 @@ public interface IMyService : IService<IMyService>
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -621,7 +629,7 @@ public interface IMyService : IService<IMyService>
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -665,7 +673,7 @@ public interface IMyService : IService<IMyService>
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act & Assert
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         Assert.Throws<InvalidOperationException>(() => collector.Collect(compilation));
     }
 
@@ -692,7 +700,7 @@ public interface IMyService : IService<IMyService>
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -733,7 +741,7 @@ public interface IMyService : IService<IMyService>
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act & Assert
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         Assert.Throws<InvalidOperationException>(() => collector.Collect(compilation));
     }
 
@@ -759,7 +767,7 @@ public interface IMyService : IService<IMyService>
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var serviceCollection = collector.Collect(compilation);
 
         // Assert
@@ -800,7 +808,7 @@ public interface IMyService : IService<IMyService>
         var compilation = tempWorkspace.GetOutputCompilation().Compilation;
 
         // Act & Assert
-        var collector = new MethodCollector();
+        var collector = new MethodCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         Assert.Throws<InvalidOperationException>(() => collector.Collect(compilation));
     }
 

--- a/tests/MagicOnion.Generator.Tests/Collector/SerializationInfoCollectorTest.cs
+++ b/tests/MagicOnion.Generator.Tests/Collector/SerializationInfoCollectorTest.cs
@@ -4,16 +4,24 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using MagicOnion.Generator.CodeAnalysis;
+using Xunit.Abstractions;
 
 namespace MagicOnion.Generator.Tests.Collector;
 
 public class SerializationInfoCollectorTest
 {
+    readonly ITestOutputHelper _testOutputHelper;
+
+    public SerializationInfoCollectorTest(ITestOutputHelper testOutputHelper)
+    {
+        this._testOutputHelper = testOutputHelper;
+    }
+
     [Fact]
     public void NonGenerics()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.CreateFromType<int>(), new string[] { }),
@@ -36,7 +44,7 @@ public class SerializationInfoCollectorTest
     public void Nullable()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.Create("System", "Nullable", MagicOnionTypeInfo.Create("MyNamespace", "MyGenericObject")), new string[] { }),
@@ -58,7 +66,7 @@ public class SerializationInfoCollectorTest
     public void Generics_MergeIfDirectives()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.CreateFromType<int>(), new string[] { }),
@@ -86,7 +94,7 @@ public class SerializationInfoCollectorTest
     public void Generics_ManyTypeArguments()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.Create("MyNamespace", "MyGenericObject", MagicOnionTypeInfo.CreateFromType<string>(), MagicOnionTypeInfo.CreateFromType<long>()), new string[] { }),
@@ -107,7 +115,7 @@ public class SerializationInfoCollectorTest
     public void Enum()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.CreateEnum("MyNamespace", "MyEnum", MagicOnionTypeInfo.CreateFromType<int>()), new string[] { }),
@@ -142,7 +150,7 @@ public class SerializationInfoCollectorTest
     public void KnownTypes_SkipBuiltInGenericTypes()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.CreateFromType<ArraySegment<byte>>(), new string[] {}),
@@ -162,7 +170,7 @@ public class SerializationInfoCollectorTest
     public void KnownTypes_Array_SkipBuiltInTypes()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.CreateFromType<byte[]>(), new string[] {}),
@@ -202,7 +210,7 @@ public class SerializationInfoCollectorTest
     public void KnownTypes_Array_NonBuiltIn()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.CreateArray(MagicOnionTypeInfo.Create("MyNamespace", "MyObject")), new string[] { "CONST_1" }),
@@ -227,7 +235,7 @@ public class SerializationInfoCollectorTest
     public void KnownTypes_Generics()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.Create("System.Collections.Generic", "List",MagicOnionTypeInfo.Create("MyNamespace", "MyObject")), new string[] { "CONST_1" }),
@@ -266,7 +274,7 @@ public class SerializationInfoCollectorTest
     public void KnownTypes_Nullable()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.CreateFromType<short?>(), new string[] { }),
@@ -297,7 +305,7 @@ public class SerializationInfoCollectorTest
     public void DynamicArgumentTuple()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.Create("MagicOnion", "DynamicArgumentTuple", MagicOnionTypeInfo.CreateFromType<string>(), MagicOnionTypeInfo.CreateFromType<long>()), new string[] { }),
@@ -318,7 +326,7 @@ public class SerializationInfoCollectorTest
     public void UserDefinedMessagePackSerializerFormattersNamespace()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.Create("System", "Nullable", MagicOnionTypeInfo.Create("MyNamespace", "MyGenericObject")), new string[] { }),
@@ -343,7 +351,7 @@ public class SerializationInfoCollectorTest
     public void UserDefinedMessagePackSerializerFormattersNamespace_NotSpecified()
     {
         // Arrange
-        var collector = new SerializationInfoCollector();
+        var collector = new SerializationInfoCollector(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper));
         var types = new[]
         {
             new SerializationInfoCollector.TypeWithIfDirectives(MagicOnionTypeInfo.Create("System", "Nullable", MagicOnionTypeInfo.Create("MyNamespace", "MyGenericObject")), new string[] { }),

--- a/tests/MagicOnion.Generator.Tests/GenerateEnumFormatterTest.cs
+++ b/tests/MagicOnion.Generator.Tests/GenerateEnumFormatterTest.cs
@@ -42,7 +42,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -82,7 +82,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -121,7 +121,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -160,7 +160,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,

--- a/tests/MagicOnion.Generator.Tests/GenerateGenericsStreamingHubTest.cs
+++ b/tests/MagicOnion.Generator.Tests/GenerateGenericsStreamingHubTest.cs
@@ -61,7 +61,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -121,7 +121,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -182,7 +182,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -245,7 +245,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -305,7 +305,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -347,7 +347,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -391,7 +391,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -434,7 +434,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -474,7 +474,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -534,7 +534,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -595,7 +595,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -658,7 +658,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -717,7 +717,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -778,7 +778,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -838,7 +838,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -880,7 +880,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -924,7 +924,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -967,7 +967,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -1007,7 +1007,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -1070,7 +1070,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -1133,7 +1133,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -1198,7 +1198,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -1259,7 +1259,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -1322,7 +1322,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -1384,7 +1384,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -1428,7 +1428,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -1474,7 +1474,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -1519,7 +1519,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -1561,7 +1561,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,

--- a/tests/MagicOnion.Generator.Tests/GenerateGenericsTest.cs
+++ b/tests/MagicOnion.Generator.Tests/GenerateGenericsTest.cs
@@ -50,7 +50,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -97,7 +97,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -145,7 +145,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -195,7 +195,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -243,7 +243,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -283,7 +283,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -325,7 +325,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -366,7 +366,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -405,7 +405,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -463,7 +463,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -522,7 +522,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -583,7 +583,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -640,7 +640,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -699,7 +699,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -758,7 +758,7 @@ namespace MessagePack.Formatters.TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -799,7 +799,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -842,7 +842,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -884,7 +884,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -923,7 +923,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,
@@ -980,7 +980,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 tempWorkspace.OutputDirectory,

--- a/tests/MagicOnion.Generator.Tests/GenerateRawStreamingTest.cs
+++ b/tests/MagicOnion.Generator.Tests/GenerateRawStreamingTest.cs
@@ -39,7 +39,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),

--- a/tests/MagicOnion.Generator.Tests/GenerateServiceTest.cs
+++ b/tests/MagicOnion.Generator.Tests/GenerateServiceTest.cs
@@ -38,7 +38,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -71,7 +71,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -104,7 +104,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -137,7 +137,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -173,7 +173,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -206,7 +206,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 await compiler.GenerateFileAsync(
@@ -239,7 +239,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 await compiler.GenerateFileAsync(
@@ -274,7 +274,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 await compiler.GenerateFileAsync(

--- a/tests/MagicOnion.Generator.Tests/GenerateStreamingHub.cs
+++ b/tests/MagicOnion.Generator.Tests/GenerateStreamingHub.cs
@@ -47,7 +47,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -86,7 +86,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -125,7 +125,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),

--- a/tests/MagicOnion.Generator.Tests/GenerateTest.cs
+++ b/tests/MagicOnion.Generator.Tests/GenerateTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -51,7 +50,7 @@ namespace TempProject
             using var tempWorkspace = TemporaryProjectWorkarea.Create(options);
             tempWorkspace.AddFileToProject("IMyService.cs", MyServiceSourceCode);
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -79,7 +78,7 @@ namespace TempProject
             using var tempWorkspace = TemporaryProjectWorkarea.Create(options);
             tempWorkspace.AddFileToProject("IMyService.cs", MyServiceSourceCode);
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -107,7 +106,7 @@ namespace TempProject
             using var tempWorkspace = TemporaryProjectWorkarea.Create(options);
             tempWorkspace.AddFileToProject("IMyService.cs", MyServiceSourceCode);
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -131,7 +130,7 @@ namespace TempProject
             using var tempWorkspace = TemporaryProjectWorkarea.Create(options);
             tempWorkspace.AddFileToProject("IMyService.cs", MyServiceSourceCode);
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),

--- a/tests/MagicOnion.Generator.Tests/GenerateWithIfDirectiveTest.cs
+++ b/tests/MagicOnion.Generator.Tests/GenerateWithIfDirectiveTest.cs
@@ -49,7 +49,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -100,7 +100,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -152,7 +152,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -239,7 +239,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -323,7 +323,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -380,7 +380,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
@@ -454,7 +454,7 @@ namespace TempProject
 }
             ");
 
-            var compiler = new MagicOnionCompiler(_testOutputHelper.WriteLine, CancellationToken.None);
+            var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(_testOutputHelper), CancellationToken.None);
             await compiler.GenerateFileAsync(
                 tempWorkspace.CsProjectPath,
                 Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),

--- a/tests/MagicOnion.Generator.Tests/MagicOnionGeneratorTestOutputLogger.cs
+++ b/tests/MagicOnion.Generator.Tests/MagicOnionGeneratorTestOutputLogger.cs
@@ -1,0 +1,23 @@
+using System;
+using MagicOnion.Generator.Internal;
+using Xunit.Abstractions;
+
+namespace MagicOnion.Generator.Tests;
+
+public class MagicOnionGeneratorTestOutputLogger : IMagicOnionGeneratorLogger
+{
+    readonly ITestOutputHelper outputHelper;
+
+    public MagicOnionGeneratorTestOutputLogger(ITestOutputHelper outputHelper)
+    {
+        this.outputHelper = outputHelper;
+    }
+
+#if FALSE
+    public void Trace(string message) => outputHelper.WriteLine(message);
+#else
+    public void Trace(string message) {}
+#endif
+    public void Information(string message) => outputHelper.WriteLine(message);
+    public void Error(string message, Exception exception = null) => outputHelper.WriteLine(message);
+}


### PR DESCRIPTION
This PR adds verbose logging option `-v` to Generator.

<details>
<summary>Output example</summary>

```
>dotnet moc -i Shared\Shared.csproj -o Client\MagicOnion.g.cs -v
[MagicOnionCompiler] Option:Input: Shared\Shared.csproj
[MagicOnionCompiler] Option:Output: Client\MagicOnion.g.cs
[MagicOnionCompiler] Option:OmitUnityAttribute: False
[MagicOnionCompiler] Option:Namespace: MagicOnion
[MagicOnionCompiler] Option:ConditionalSymbol:
[MagicOnionCompiler] Option:UserDefinedMessagePackFormattersNamespace: MessagePack.Formatters
[MagicOnionCompiler] Assembly version: 5.0.0+2ebbe5db758490e0ce861dacc49cf1697b00bccb
[MagicOnionCompiler] RuntimeInformation.OSDescription: Microsoft Windows 10.0.19044
[MagicOnionCompiler] RuntimeInformation.ProcessArchitecture: X64
[MagicOnionCompiler] RuntimeInformation.FrameworkDescription: .NET 6.0.5
Project Compilation Start:Shared\Shared.csproj
[PseudoCompilation] Creating compilation from project(s). (PreprocessorSymbolNames=)
[PseudoCompilation] Open project 'Shared\Shared.csproj'
[PseudoCompilation] NuGet Package 'magiconion.abstractions 4.5.1'
[PseudoCompilation] Could not find package assembly for 'magiconion.abstractions 4.5.1'
[PseudoCompilation] NuGet Package 'messagepack 2.4.35'
[PseudoCompilation] Resolved assembly 'C:\Users\UserName\.nuget\packages\messagepack\2.4.35\lib\net6.0' (targetFramework=net6.0)
[PseudoCompilation] NuGet Package 'MessagePack.Annotations 2.4.35'
[PseudoCompilation] Resolved assembly 'C:\Users\UserName\.nuget\packages\MessagePack.Annotations\2.4.35\lib\netstandard2.0' (targetFramework=netstandard2.0)
[PseudoCompilation] NuGet Package 'Microsoft.NET.StringTools 1.0.0'
[PseudoCompilation] Resolved assembly 'C:\Users\UserName\.nuget\packages\Microsoft.NET.StringTools\1.0.0\lib\netstandard2.0' (targetFramework=netstandard2.0)
[PseudoCompilation] NuGet Package 'System.Memory 4.5.4'
[PseudoCompilation] Resolved assembly 'C:\Users\UserName\.nuget\packages\System.Memory\4.5.4\lib\netstandard2.0' (targetFramework=netstandard2.0)
[PseudoCompilation] NuGet Package 'System.Buffers 4.5.1'
[PseudoCompilation] Resolved assembly 'C:\Users\UserName\.nuget\packages\System.Buffers\4.5.1\lib\netstandard2.0' (targetFramework=netstandard2.0)
[PseudoCompilation] NuGet Package 'System.Numerics.Vectors 4.4.0'
[PseudoCompilation] Resolved assembly 'C:\Users\UserName\.nuget\packages\System.Numerics.Vectors\4.4.0\lib\netstandard2.0' (targetFramework=netstandard2.0)
[PseudoCompilation] NuGet Package 'System.Runtime.CompilerServices.Unsafe 4.5.3'
[PseudoCompilation] Resolved assembly 'C:\Users\UserName\.nuget\packages\System.Runtime.CompilerServices.Unsafe\4.5.3\lib\netstandard2.0' (targetFramework=netstandard2.0)
[PseudoCompilation] NuGet Package 'System.Runtime.CompilerServices.Unsafe 5.0.0'
[PseudoCompilation] Resolved assembly 'C:\Users\UserName\.nuget\packages\System.Runtime.CompilerServices.Unsafe\5.0.0\lib\netstandard2.0' (targetFramework=netstandard2.0)
[PseudoCompilation] NuGet Package 'messagepackanalyzer 2.4.35'
[PseudoCompilation] Could not find package assembly for 'messagepackanalyzer 2.4.35'
[PseudoCompilation] NuGet Package 'newtonsoft.json 13.0.1'
[PseudoCompilation] Resolved assembly 'C:\Users\UserName\.nuget\packages\newtonsoft.json\13.0.1\lib\netstandard2.0' (targetFramework=netstandard2.0)
[PseudoCompilation] Source 'C:\Users\UserName\Downloads\New folder (5)\Shared\Class1.cs'
[PseudoCompilation] Loading Metadata 'C:\Users\UserName\.nuget\packages\messagepack\2.4.35\lib\net6.0\MessagePack.dll'
[PseudoCompilation] Loading Metadata 'C:\Users\UserName\.nuget\packages\MessagePack.Annotations\2.4.35\lib\netstandard2.0\MessagePack.Annotations.dll'
[PseudoCompilation] Loading Metadata 'C:\Users\UserName\.nuget\packages\Microsoft.NET.StringTools\1.0.0\lib\netstandard2.0\Microsoft.NET.StringTools.dll'
[PseudoCompilation] Loading Metadata 'C:\Users\UserName\.nuget\packages\System.Memory\4.5.4\lib\netstandard2.0\System.Memory.dll'
[PseudoCompilation] Loading Metadata 'C:\Users\UserName\.nuget\packages\System.Buffers\4.5.1\lib\netstandard2.0\System.Buffers.dll'
[PseudoCompilation] Loading Metadata 'C:\Users\UserName\.nuget\packages\System.Numerics.Vectors\4.4.0\lib\netstandard2.0\System.Numerics.Vectors.dll'
[PseudoCompilation] Loading Metadata 'C:\Users\UserName\.nuget\packages\System.Runtime.CompilerServices.Unsafe\4.5.3\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll'
[PseudoCompilation] Loading Metadata 'C:\Users\UserName\.nuget\packages\System.Runtime.CompilerServices.Unsafe\5.0.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll'
[PseudoCompilation] Loading Metadata 'C:\Users\UserName\.nuget\packages\newtonsoft.json\13.0.1\lib\netstandard2.0\Newtonsoft.Json.dll'
[PseudoCompilation] Loading Metadata 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.5\System.Private.CoreLib.dll'
[PseudoCompilation] Loading Metadata 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.5\System.Linq.dll'
[PseudoCompilation] Loading Metadata 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.5\System.Runtime.Serialization.Primitives.dll'
[PseudoCompilation] Loading Metadata 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.5\System.Collections.Immutable.dll'
[PseudoCompilation] Loading Metadata 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.5\System.Collections.Concurrent.dll'
[PseudoCompilation] Loading Metadata 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.5\System.ObjectModel.dll'
[PseudoCompilation] Loading Metadata 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.5\netstandard.dll'
[PseudoCompilation] Loading Metadata 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.5\System.Runtime.dll'
[PseudoCompilation] CompilationDiagnostic: C:\Users\UserName\Downloads\New folder (5)\Shared\Class1.cs(1,17): error CS1514: { expected
[PseudoCompilation] CompilationDiagnostic: C:\Users\UserName\Downloads\New folder (5)\Shared\Class1.cs(5,2): error CS1513: } expected
Project Compilation Complete:00:00:00.7060694
Collect services and methods Start
[ReferenceSymbols] Resolving well-known reference symbols...
[ReferenceSymbols] GetTypeSymbolOrThrow: System.Void; type=System_Void; required=True
[ReferenceSymbols] GetTypeByMetadataName: System.Void; Symbol=void
[ReferenceSymbols] GetTypeSymbolOrThrow: System.Threading.Tasks.Task; type=None; required=False
[ReferenceSymbols] GetTypeByMetadataName: System.Threading.Tasks.Task; Symbol=System.Threading.Tasks.Task
[ReferenceSymbols] GetTypeSymbolOrThrow: System.Threading.Tasks.Task`1; type=None; required=False
[ReferenceSymbols] GetTypeByMetadataName: System.Threading.Tasks.Task`1; Symbol=System.Threading.Tasks.Task<TResult>
[ReferenceSymbols] GetTypeSymbolOrThrow: MagicOnion.UnaryResult`1; type=None; required=True
[ReferenceSymbols] GetTypeByMetadataName: MagicOnion.UnaryResult`1; Symbol=
[ReferenceSymbols] GetWellKnownType: MagicOnion.UnaryResult`1; Symbol=
[ReferenceSymbols] GetSpecialType: MagicOnion.UnaryResult`1; Symbol=
Unable to get metadata of MagicOnion.UnaryResult`1. Please check that there is a reference to MagicOnion.Abstractions or try to run `dotnet restore`.
Fail in console app running on Program.RunAsync
System.InvalidOperationException: Unable to get metadata of MagicOnion.UnaryResult`1. Please check that there is a reference to MagicOnion.Abstractions or try to run `dotnet restore`.
   at MagicOnion.Generator.CodeAnalysis.ReferenceSymbols.<.ctor>g__GetTypeSymbolOrThrow|12_0(String name, SpecialType type, Boolean required, <>c__DisplayClass12_0& , <>c__DisplayClass12_1& ) in C:\Users\UserName\source\repos\GitHub\MagicOnion\src\MagicOnion.GeneratorCore\CodeAnalysis\ReferenceSymbols.cs:line 46
   at MagicOnion.Generator.CodeAnalysis.ReferenceSymbols..ctor(Compilation compilation, IMagicOnionGeneratorLogger logger) in C:\Users\UserName\source\repos\GitHub\MagicOnion\src\MagicOnion.GeneratorCore\CodeAnalysis\ReferenceSymbols.cs:line 82
   at MagicOnion.Generator.CodeAnalysis.MethodCollector.MethodCollectorContext.CreateFromCompilation(Compilation compilation, IMagicOnionGeneratorLogger logger) in C:\Users\UserName\source\repos\GitHub\MagicOnion\src\MagicOnion.GeneratorCore\CodeAnalysis\MethodCollector.cs:line 256
   at MagicOnion.Generator.CodeAnalysis.MethodCollector.Collect(Compilation compilation) in C:\Users\UserName\source\repos\GitHub\MagicOnion\src\MagicOnion.GeneratorCore\CodeAnalysis\MethodCollector.cs:line 24
   at MagicOnion.Generator.MagicOnionCompiler.GenerateFileAsync(String input, String output, Boolean omitUnityAttribute, String namespace, String conditionalSymbol, String userDefinedMessagePackFormattersNamespace) in C:\Users\UserName\source\repos\GitHub\MagicOnion\src\MagicOnion.GeneratorCore\MagicOnionCompiler.cs:line 65
   at MagicOnion.Generator.Program.RunAsync(String input, String output, Boolean unuseUnityAttr, String namespace, String messagePackGeneratedNamespace, String conditionalSymbol, Boolean verbose) in C:\Users\UserName\source\repos\GitHub\MagicOnion\src\MagicOnion.Generator\Program.cs:line 32
   at ConsoleAppFramework.ConsoleAppEngine.RunCore(ConsoleAppContext ctx, Type type, MethodInfo methodInfo, String[] args, Int32 argsOffset)
```
</details>