### PR TITLE
Excludes non-public services and hubs when collecting types.

### DIFF
--- a/MagicOnion.sln
+++ b/MagicOnion.sln
@@ -91,11 +91,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "perf", "perf", "{A0CED9FB-5
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BenchmarkApp", "BenchmarkApp", "{2FF12B46-BA5C-4B6C-BD94-3556C3F25722}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerformanceTest.Server", "perf\BenchmarkApp\PerformanceTest.Server\PerformanceTest.Server.csproj", "{D00774F4-6817-4768-8043-4BAAE88B3AE5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerformanceTest.Server", "perf\BenchmarkApp\PerformanceTest.Server\PerformanceTest.Server.csproj", "{D00774F4-6817-4768-8043-4BAAE88B3AE5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerformanceTest.Client", "perf\BenchmarkApp\PerformanceTest.Client\PerformanceTest.Client.csproj", "{3C67CF21-CDAD-4F77-9416-078924700CF8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerformanceTest.Client", "perf\BenchmarkApp\PerformanceTest.Client\PerformanceTest.Client.csproj", "{3C67CF21-CDAD-4F77-9416-078924700CF8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerformanceTest.Shared", "perf\BenchmarkApp\PerformanceTest.Shared\PerformanceTest.Shared.csproj", "{E7D60CFB-0B20-4582-94C9-5398B2049201}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerformanceTest.Shared", "perf\BenchmarkApp\PerformanceTest.Shared\PerformanceTest.Shared.csproj", "{E7D60CFB-0B20-4582-94C9-5398B2049201}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MagicOnionEngineTest", "tests\samples\MagicOnionEngineTest\MagicOnionEngineTest.csproj", "{5EB62B20-75D1-4945-B7D4-F9466FE67BA5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -211,6 +213,10 @@ Global
 		{E7D60CFB-0B20-4582-94C9-5398B2049201}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E7D60CFB-0B20-4582-94C9-5398B2049201}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E7D60CFB-0B20-4582-94C9-5398B2049201}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5EB62B20-75D1-4945-B7D4-F9466FE67BA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5EB62B20-75D1-4945-B7D4-F9466FE67BA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5EB62B20-75D1-4945-B7D4-F9466FE67BA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5EB62B20-75D1-4945-B7D4-F9466FE67BA5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -248,6 +254,7 @@ Global
 		{D00774F4-6817-4768-8043-4BAAE88B3AE5} = {2FF12B46-BA5C-4B6C-BD94-3556C3F25722}
 		{3C67CF21-CDAD-4F77-9416-078924700CF8} = {2FF12B46-BA5C-4B6C-BD94-3556C3F25722}
 		{E7D60CFB-0B20-4582-94C9-5398B2049201} = {2FF12B46-BA5C-4B6C-BD94-3556C3F25722}
+		{5EB62B20-75D1-4945-B7D4-F9466FE67BA5} = {B5617CC1-55FD-4F77-BA75-9450474C6527}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D5B2E7E3-B727-40A1-BE68-7BAC9B9DE2FE}

--- a/src/MagicOnion.Server/Extensions/MagicOnionServicesExtensions.cs
+++ b/src/MagicOnion.Server/Extensions/MagicOnionServicesExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using Grpc.AspNetCore.Server.Model;
 using MagicOnion.Server;
@@ -14,21 +15,21 @@ public static class MagicOnionServicesExtensions
     public static IMagicOnionServerBuilder AddMagicOnion(this IServiceCollection services, Action<MagicOnionOptions>? configureOptions = null)
     {
         var configName = Options.Options.DefaultName;
-        services.AddSingleton<MagicOnionServiceDefinition>(sp => MagicOnionEngine.BuildServerServiceDefinition(sp, sp.GetRequiredService<IOptionsMonitor<MagicOnionOptions>>().Get(configName)));
+        services.AddSingleton<MagicOnionServiceDefinition>(sp => MagicOnionEngine.BuildServerServiceDefinition(sp, sp.GetRequiredService<IOptionsMonitor<MagicOnionOptions>>().Get(configName), sp.GetRequiredService<IMagicOnionLogger>()));
         return services.AddMagicOnionCore(configureOptions);
     }
 
     public static IMagicOnionServerBuilder AddMagicOnion(this IServiceCollection services, Assembly[] searchAssemblies, Action<MagicOnionOptions>? configureOptions = null)
     {
         var configName = Options.Options.DefaultName;
-        services.AddSingleton<MagicOnionServiceDefinition>(sp => MagicOnionEngine.BuildServerServiceDefinition(sp, searchAssemblies, sp.GetRequiredService<IOptionsMonitor<MagicOnionOptions>>().Get(configName)));
+        services.AddSingleton<MagicOnionServiceDefinition>(sp => MagicOnionEngine.BuildServerServiceDefinition(sp, searchAssemblies, sp.GetRequiredService<IOptionsMonitor<MagicOnionOptions>>().Get(configName), sp.GetRequiredService<IMagicOnionLogger>()));
         return services.AddMagicOnionCore(configureOptions);
     }
 
     public static IMagicOnionServerBuilder AddMagicOnion(this IServiceCollection services, IEnumerable<Type> searchTypes, Action<MagicOnionOptions>? configureOptions = null)
     {
         var configName = Options.Options.DefaultName;
-        services.AddSingleton<MagicOnionServiceDefinition>(sp => MagicOnionEngine.BuildServerServiceDefinition(sp, searchTypes, sp.GetRequiredService<IOptionsMonitor<MagicOnionOptions>>().Get(configName)));
+        services.AddSingleton<MagicOnionServiceDefinition>(sp => MagicOnionEngine.BuildServerServiceDefinition(sp, searchTypes, sp.GetRequiredService<IOptionsMonitor<MagicOnionOptions>>().Get(configName), sp.GetRequiredService<IMagicOnionLogger>()));
         return services.AddMagicOnionCore(configureOptions);
     }
 

--- a/src/MagicOnion.Server/MagicOnionEngine.cs
+++ b/src/MagicOnion.Server/MagicOnionEngine.cs
@@ -121,12 +121,6 @@ public static class MagicOnionEngine
                 VerifyServiceType(classType);
 
                 var className = classType.Name;
-                if (!classType.GetConstructors().Any(x => x.GetParameters().Length == 0))
-                {
-                    // supports paramaterless constructor after v2.1(DI support).
-                    // throw new InvalidOperationException(string.Format("Type needs parameterless constructor, class:{0}", classType.FullName));
-                }
-
                 var isStreamingHub = typeof(IStreamingHubMarker).IsAssignableFrom(classType);
                 HashSet<StreamingHubHandler>? tempStreamingHubHandlers = null;
                 if (isStreamingHub)

--- a/src/MagicOnion.Server/MethodHandler.cs
+++ b/src/MagicOnion.Server/MethodHandler.cs
@@ -46,7 +46,7 @@ public class MethodHandler : IEquatable<MethodHandler>
         .First(x => x.Name == "Deserialize" && x.GetParameters().Length == 3 && x.GetParameters()[0].ParameterType == typeof(ReadOnlyMemory<byte>) && x.GetParameters()[1].ParameterType == typeof(MessagePackSerializerOptions));
     static readonly MethodInfo createService = typeof(ServiceProviderHelper).GetMethod(nameof(ServiceProviderHelper.CreateService), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
 
-    public MethodHandler(Type classType, MethodInfo methodInfo, string methodName, MethodHandlerOptions handlerOptions, IServiceProvider serviceProvider)
+    public MethodHandler(Type classType, MethodInfo methodInfo, string methodName, MethodHandlerOptions handlerOptions, IServiceProvider serviceProvider, IMagicOnionLogger logger)
     {
         this.methodHandlerId = Interlocked.Increment(ref methodHandlerIdBuild);
 
@@ -80,7 +80,7 @@ public class MethodHandler : IEquatable<MethodHandler>
 
         // options
         this.isReturnExceptionStackTraceInErrorDetail = handlerOptions.IsReturnExceptionStackTraceInErrorDetail;
-        this.logger = serviceProvider.GetRequiredService<IMagicOnionLogger>();
+        this.logger = logger;
         this.enableCurrentContext = handlerOptions.EnableCurrentContext;
 
         // prepare lambda parameters

--- a/tests/MagicOnion.Server.Tests/MagicOnion.Server.Tests.csproj
+++ b/tests/MagicOnion.Server.Tests/MagicOnion.Server.Tests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\src\MagicOnion.Server\MagicOnion.Server.csproj" />
     <ProjectReference Include="..\samples\AuthSample\AuthSample.csproj" />
     <ProjectReference Include="..\samples\BasicServerSample\BasicServerSample.csproj" />
+    <ProjectReference Include="..\samples\MagicOnionEngineTest\MagicOnionEngineTest.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MagicOnion.Server.Tests/MagicOnionEngineTest.cs
+++ b/tests/MagicOnion.Server.Tests/MagicOnionEngineTest.cs
@@ -1,0 +1,133 @@
+﻿using System.Reflection;
+using MagicOnion.Server.Hubs;
+using MagicOnionEngineTest;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MagicOnion.Server.Tests;
+
+public class MagicOnionEngineTest
+{
+    [Fact]
+    public void CollectFromTypes_Empty()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var serviceProvider = services.BuildServiceProvider();
+        var types = new Type[]{};
+        var options = new MagicOnionOptions();
+
+        // Act
+        var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, types, options, new NullMagicOnionLogger());
+
+        // Assert
+        def.MethodHandlers.Should().BeEmpty();
+        def.StreamingHubHandlers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CollectFromTypes_Service()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var serviceProvider = services.BuildServiceProvider();
+        var types = new Type[]{ typeof(MyService) };
+        var options = new MagicOnionOptions();
+
+        // Act
+        var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, types, options, new NullMagicOnionLogger());
+
+        // Assert
+        def.MethodHandlers.Should().HaveCount(2);
+        def.StreamingHubHandlers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CollectFromTypes_StreamingHub()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<IGroupRepositoryFactory, ConcurrentDictionaryGroupRepositoryFactory>();
+        var serviceProvider = services.BuildServiceProvider();
+        var types = new Type[]{ typeof(MyHub) };
+        var options = new MagicOnionOptions();
+
+        // Act
+        var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, types, options, new NullMagicOnionLogger());
+
+        // Assert
+        def.MethodHandlers.Should().HaveCount(1); // Connect
+        def.StreamingHubHandlers.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void CollectFromAssembly()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<IGroupRepositoryFactory, ConcurrentDictionaryGroupRepositoryFactory>();
+        var serviceProvider = services.BuildServiceProvider();
+        var assemblies = new Assembly[]{ typeof(IMyService).Assembly };
+        var options = new MagicOnionOptions();
+
+        // Act
+        var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, assemblies, options, new NullMagicOnionLogger());
+
+        // Assert
+        def.MethodHandlers.Should().HaveCount(3); // MyHub.Connect, MyService.MethodA, MyService.MethodB
+        def.StreamingHubHandlers.Should().HaveCount(2); // MyHub.MethodA, MyHub.MethodB
+    }
+    
+    [Fact]
+    public void CollectFromAssembly_Ignore()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<IGroupRepositoryFactory, ConcurrentDictionaryGroupRepositoryFactory>();
+        var serviceProvider = services.BuildServiceProvider();
+        var assemblies = new Assembly[]{ typeof(IMyIgnoredService).Assembly };
+        var options = new MagicOnionOptions();
+
+        // Act
+        var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, assemblies, options, new NullMagicOnionLogger());
+
+        // Assert
+        def.MethodHandlers.Should().NotContain(x => x.ServiceName.Contains("Ignored"));
+        def.StreamingHubHandlers.Should().NotContain(x => x.HubName.Contains("Ignored"));
+    }
+  
+    [Fact]
+    public void CollectFromAssembly_NonPublic()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<IGroupRepositoryFactory, ConcurrentDictionaryGroupRepositoryFactory>();
+        var serviceProvider = services.BuildServiceProvider();
+        var assemblies = new Assembly[]{ typeof(IMyNonPublicService).Assembly };
+        var options = new MagicOnionOptions();
+
+        // Act
+        var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, assemblies, options, new NullMagicOnionLogger());
+
+        // Assert
+        def.MethodHandlers.Should().NotContain(x => x.ServiceName.Contains("NonPublic"));
+        def.StreamingHubHandlers.Should().NotContain(x => x.HubName.Contains("NonPublic"));
+    }
+ 
+    [Fact]
+    public void CollectFromAssembly_Abstract()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<IGroupRepositoryFactory, ConcurrentDictionaryGroupRepositoryFactory>();
+        var serviceProvider = services.BuildServiceProvider();
+        var assemblies = new Assembly[]{ typeof(IMyAbstractService).Assembly };
+        var options = new MagicOnionOptions();
+
+        // Act
+        var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, assemblies, options, new NullMagicOnionLogger());
+
+        // Assert
+        def.MethodHandlers.Should().NotContain(x => x.ServiceName.Contains("Abstract"));
+        def.StreamingHubHandlers.Should().NotContain(x => x.HubName.Contains("Abstract"));
+    }
+}

--- a/tests/samples/MagicOnionEngineTest/Abstract.cs
+++ b/tests/samples/MagicOnionEngineTest/Abstract.cs
@@ -1,0 +1,34 @@
+﻿using MagicOnion;
+using MagicOnion.Server;
+using MagicOnion.Server.Hubs;
+using MessagePack;
+
+namespace MagicOnionEngineTest;
+
+public interface IMyAbstractService : IService<IMyAbstractService>
+{
+    UnaryResult<Nil> MethodA();
+    UnaryResult<Nil> MethodB();
+}
+
+public interface IMyAbstractHub : IStreamingHub<IMyAbstractHub, IMyAbstractHubReceiver>
+{
+    Task MethodA();
+    Task MethodB();
+}
+
+public interface IMyAbstractHubReceiver
+{}
+
+public abstract class MyAbstractService : ServiceBase<IMyAbstractService>, IMyAbstractService
+{
+    public UnaryResult<Nil> MethodA() => default;
+    public UnaryResult<Nil> MethodB() => default;
+    public UnaryResult<Nil> MethodC() => default; // Non-Service method
+}
+
+public abstract class MyAbstractHub : StreamingHubBase<IMyAbstractHub, IMyAbstractHubReceiver>, IMyAbstractHub
+{
+    public Task MethodA() => Task.CompletedTask;
+    public Task MethodB() => Task.CompletedTask;
+}

--- a/tests/samples/MagicOnionEngineTest/Ignored.cs
+++ b/tests/samples/MagicOnionEngineTest/Ignored.cs
@@ -1,0 +1,36 @@
+﻿using MagicOnion;
+using MagicOnion.Server;
+using MagicOnion.Server.Hubs;
+using MessagePack;
+
+namespace MagicOnionEngineTest;
+
+public interface IMyIgnoredService : IService<IMyIgnoredService>
+{
+    UnaryResult<Nil> MethodA();
+    UnaryResult<Nil> MethodB();
+}
+
+public interface IMyIgnoredHub : IStreamingHub<IMyIgnoredHub, IMyIgnoredHubReceiver>
+{
+    Task MethodA();
+    Task MethodB();
+}
+
+public interface IMyIgnoredHubReceiver
+{}
+
+[Ignore]
+public class MyIgnoredService : ServiceBase<IMyIgnoredService>, IMyIgnoredService
+{
+    public UnaryResult<Nil> MethodA() => default;
+    public UnaryResult<Nil> MethodB() => default;
+    public UnaryResult<Nil> MethodC() => default; // Non-Service method
+}
+
+[Ignore]
+public class MyIgnoredHub : StreamingHubBase<IMyIgnoredHub, IMyIgnoredHubReceiver>, IMyIgnoredHub
+{
+    public Task MethodA() => Task.CompletedTask;
+    public Task MethodB() => Task.CompletedTask;
+}

--- a/tests/samples/MagicOnionEngineTest/MagicOnionEngineTest.csproj
+++ b/tests/samples/MagicOnionEngineTest/MagicOnionEngineTest.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\MagicOnion.Server\MagicOnion.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/samples/MagicOnionEngineTest/Non-Public.cs
+++ b/tests/samples/MagicOnionEngineTest/Non-Public.cs
@@ -1,0 +1,38 @@
+﻿using MagicOnion;
+using MagicOnion.Server;
+using MagicOnion.Server.Hubs;
+using MessagePack;
+
+namespace MagicOnionEngineTest;
+
+public interface IMyNonPublicService : IService<IMyNonPublicService>
+{
+    UnaryResult<Nil> MethodA();
+    UnaryResult<Nil> MethodB();
+}
+
+public interface IMyNonPublicHub : IStreamingHub<IMyNonPublicHub, IMyNonPublicHubReceiver>
+{
+    Task MethodA();
+    Task MethodB();
+}
+
+public interface IMyNonPublicHubReceiver
+{}
+
+
+internal class MyNonPublicService : ServiceBase<IMyNonPublicService>, IMyNonPublicService
+{
+    public UnaryResult<Nil> MethodA() => default;
+    public UnaryResult<Nil> MethodB() => default;
+    public UnaryResult<Nil> MethodC() => default; // Non-Service method
+    UnaryResult<Nil> MethodD() => default; // Non-Service method
+}
+
+internal class MyNonPublicHub : StreamingHubBase<IMyNonPublicHub, IMyNonPublicHubReceiver>, IMyNonPublicHub
+{
+    public Task MethodA() => Task.CompletedTask;
+    public Task MethodB() => Task.CompletedTask;
+    public Task MethodC() => Task.CompletedTask; // Non-Service method
+    Task MethodD() => Task.CompletedTask; // Non-Service method
+}

--- a/tests/samples/MagicOnionEngineTest/Program.cs
+++ b/tests/samples/MagicOnionEngineTest/Program.cs
@@ -1,0 +1,16 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Additional configuration is required to successfully run gRPC on macOS.
+// For instructions on how to configure Kestrel and gRPC clients on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
+
+// Add services to the container.
+builder.Services.AddGrpc();
+builder.Services.AddMagicOnion();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+app.MapMagicOnionService();
+app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
+
+app.Run();

--- a/tests/samples/MagicOnionEngineTest/Properties/launchSettings.json
+++ b/tests/samples/MagicOnionEngineTest/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+﻿{
+  "profiles": {
+    "MagicOnionEngineTest": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5028;https://localhost:7028",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/tests/samples/MagicOnionEngineTest/Public.cs
+++ b/tests/samples/MagicOnionEngineTest/Public.cs
@@ -1,0 +1,38 @@
+﻿using MagicOnion;
+using MagicOnion.Server;
+using MagicOnion.Server.Hubs;
+using MessagePack;
+
+namespace MagicOnionEngineTest;
+
+public interface IMyService : IService<IMyService>
+{
+    UnaryResult<Nil> MethodA();
+    UnaryResult<Nil> MethodB();
+}
+
+public interface IMyHub : IStreamingHub<IMyHub, IMyHubReceiver>
+{
+    Task MethodA();
+    Task MethodB();
+}
+
+public interface IMyHubReceiver
+{}
+
+
+public class MyService : ServiceBase<IMyService>, IMyService
+{
+    public UnaryResult<Nil> MethodA() => default;
+    public UnaryResult<Nil> MethodB() => default;
+    public UnaryResult<Nil> MethodC() => default; // Non-Service method
+    UnaryResult<Nil> MethodD() => default; // Non-Service method
+}
+
+public class MyHub : StreamingHubBase<IMyHub, IMyHubReceiver>, IMyHub
+{
+    public Task MethodA() => Task.CompletedTask;
+    public Task MethodB() => Task.CompletedTask;
+    public Task MethodC() => Task.CompletedTask; // Non-Service method
+    Task MethodD() => Task.CompletedTask; // Non-Service method
+}

--- a/tests/samples/MagicOnionEngineTest/README.md
+++ b/tests/samples/MagicOnionEngineTest/README.md
@@ -1,0 +1,3 @@
+﻿# MagicOnionEngineTest
+
+⚠ This project is for use in MagicOnion.Server.Tests (MagicOnionEngineTest.cs).

--- a/tests/samples/MagicOnionEngineTest/appsettings.Development.json
+++ b/tests/samples/MagicOnionEngineTest/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/tests/samples/MagicOnionEngineTest/appsettings.json
+++ b/tests/samples/MagicOnionEngineTest/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
+}


### PR DESCRIPTION
Excludes non-public services and hubs when collecting types from an assembly.

MagicOnion collects following types:
- Type is `public` accessible (if a type accessiblity is `private`, `protected` or `internal`, the engine will ignore it).
- Type is not marked as `[Ignore]`
- Type is not `abstract`