### PR TITLE
Adopt to .NET 7 and drop support for .NET Core 3.1,  .NET 5 on servers

### DIFF
--- a/.github/actions/setup-dotnet/action.yaml
+++ b/.github/actions/setup-dotnet/action.yaml
@@ -4,10 +4,9 @@ runs:
   steps:
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '6.0.x'
+        dotnet-version: |
+          6.0.x
+          7.0.x
     - name: "Prepare Environment Variables (.NET SDK)"
       shell: bash
       run: |

--- a/perf/BenchmarkApp/PerformanceTest.Client/PerformanceTest.Client.csproj
+++ b/perf/BenchmarkApp/PerformanceTest.Client/PerformanceTest.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DefineConstants>CLIENT;$(DefineConstants)</DefineConstants>

--- a/perf/BenchmarkApp/PerformanceTest.Server/PerformanceTest.Server.csproj
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerformanceTest.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DefineConstants>SERVER;$(DefineConstants)</DefineConstants>

--- a/perf/BenchmarkApp/PerformanceTest.Shared/PerformanceTest.Shared.csproj
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/PerformanceTest.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/ChatApp/ChatApp.Server/ChatApp.Server.csproj
+++ b/samples/ChatApp/ChatApp.Server/ChatApp.Server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/ChatApp/ChatApp.Server/Dockerfile
+++ b/samples/ChatApp/ChatApp.Server/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 EXPOSE 12345
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["ChatApp.Server/ChatApp.Server.csproj", "ChatApp.Server/"]
 COPY ["ChatApp.Shared/ChatApp.Shared.csproj", "ChatApp.Shared/"]

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
@@ -287,6 +287,7 @@ namespace ChatApp.Shared.Hubs {
         }
 
 
+        [Ignore]
         class FireAndForgetClient : global::ChatApp.Shared.Hubs.IChatHub
         {
             readonly ChatHubClient __parent;

--- a/samples/JwtAuthentication/JwtAuthApp.Client/JwtAuthApp.Client.csproj
+++ b/samples/JwtAuthentication/JwtAuthApp.Client/JwtAuthApp.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/JwtAuthentication/JwtAuthApp.Server/JwtAuthApp.Server.csproj
+++ b/samples/JwtAuthentication/JwtAuthApp.Server/JwtAuthApp.Server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/sandbox/Sandbox.AspNetCore/Sandbox.AspNetCore.csproj
+++ b/sandbox/Sandbox.AspNetCore/Sandbox.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Abstractions/IgnoreAttribute.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Abstractions/IgnoreAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,7 +9,7 @@ namespace MagicOnion
     /// <summary>
     /// Don't register on MagicOnionEngine.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class,AllowMultiple = false,Inherited = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false,Inherited = false)]
     public class IgnoreAttribute : Attribute
     {
     }

--- a/src/MagicOnion.Client/MagicOnion.Client.csproj
+++ b/src/MagicOnion.Client/MagicOnion.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
 
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\MagicOnion\opensource.snk</AssemblyOriginatorKeyFile>

--- a/src/MagicOnion.Generator/MagicOnion.Generator.csproj
+++ b/src/MagicOnion.Generator/MagicOnion.Generator.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <AssemblyName>moc</AssemblyName>
         <IsPackable>true</IsPackable>

--- a/src/MagicOnion.Server.HttpGateway/MagicOnion.Server.HttpGateway.csproj
+++ b/src/MagicOnion.Server.HttpGateway/MagicOnion.Server.HttpGateway.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <LangVersion>default</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/MagicOnion.Server.OpenTelemetry/MagicOnion.Server.OpenTelemetry.csproj
+++ b/src/MagicOnion.Server.OpenTelemetry/MagicOnion.Server.OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <SignAssembly>true</SignAssembly>

--- a/src/MagicOnion.Server.Redis/MagicOnion.Server.Redis.csproj
+++ b/src/MagicOnion.Server.Redis/MagicOnion.Server.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <LangVersion>default</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/MagicOnion.Server/MagicOnion.Server.csproj
+++ b/src/MagicOnion.Server/MagicOnion.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\MagicOnion\opensource.snk</AssemblyOriginatorKeyFile>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/MagicOnion/MagicOnion.csproj
+++ b/src/MagicOnion/MagicOnion.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- net471 can not ignore for DynamicCodeDumper(.NET Core lacks assembly save) but currently removed(for CI) -->
-        <!--<TargetFrameworks>netcoreapp3.1;net471</TargetFrameworks>-->
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <AssemblyOriginatorKeyFile>opensource.snk</AssemblyOriginatorKeyFile>

--- a/tests/MagicOnion.Client.Tests/MagicOnion.Client.Tests.csproj
+++ b/tests/MagicOnion.Client.Tests/MagicOnion.Client.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/MagicOnion.Generator.Tests/MagicOnion.Generator.Tests.csproj
+++ b/tests/MagicOnion.Generator.Tests/MagicOnion.Generator.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>

--- a/tests/MagicOnion.Integration.Tests/MagicOnion.Integration.Tests.csproj
+++ b/tests/MagicOnion.Integration.Tests/MagicOnion.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/MagicOnion.Server.Tests/MagicOnion.Server.Tests.csproj
+++ b/tests/MagicOnion.Server.Tests/MagicOnion.Server.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/tests/MagicOnion.Shared.Tests/MagicOnion.Shared.Tests.csproj
+++ b/tests/MagicOnion.Shared.Tests/MagicOnion.Shared.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/samples/AuthSample/AuthSample.csproj
+++ b/tests/samples/AuthSample/AuthSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/samples/BasicServerSample/BasicServerSample.csproj
+++ b/tests/samples/BasicServerSample/BasicServerSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/samples/MagicOnionEngineTest/MagicOnionEngineTest.csproj
+++ b/tests/samples/MagicOnionEngineTest/MagicOnionEngineTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/samples/MagicOnionTestServer/MagicOnionTestServer.csproj
+++ b/tests/samples/MagicOnionTestServer/MagicOnionTestServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
MagicOnion now supports .NET 7 and we drop support for .NET Core 3.1 and .NET 5 on servers.

- MagicOnion.Server supports only .NET 7 and .NET 6.
- MagicOnion.Client continues to support .NET Standard 2.x. 
  - If the client application which built/run on .NET 5 or .NET Core 3.1 runtime, it still can depend on the package for .NET Standard.