### PR TITLE
Use ModuleInitializer for automatic registration on .NET 5+

### DIFF
--- a/src/MagicOnion.Generator/Program.cs
+++ b/src/MagicOnion.Generator/Program.cs
@@ -16,7 +16,8 @@ public class Program
         ConsoleAppContext ctx,
         [Option("i", "The path to the project (.csproj) to generate the client.")]string input,
         [Option("o", "The generated file path (single file) or the directory path to generate the files (multiple files).")]string output,
-        [Option("u", "Do not use UnityEngine's RuntimeInitializeOnLoadMethodAttribute on MagicOnionInitializer.")]bool noUseUnityAttr = false,
+        [Option("u", "Do not use UnityEngine's RuntimeInitializeOnLoadMethodAttribute on MagicOnionInitializer. (Same as --disable-auto-register)")]bool noUseUnityAttr = false,
+        [Option("d", "Do not automatically call MagicOnionInitializer during start-up. (Automatic registration requires .NET 5+ or Unity)")]bool disableAutoRegister = false,
         [Option("n", "The namespace of clients to generate.")]string @namespace = "MagicOnion",
         [Option("m", "The namespace of pre-generated MessagePackFormatters.")]string messagepackFormatterNamespace = "MessagePack.Formatters",
         [Option("c", "The conditional compiler symbols used during code analysis. The value is split by ','.")]string conditionalSymbol = null,
@@ -27,7 +28,7 @@ public class Program
             .GenerateFileAsync(
                 input,
                 output,
-                noUseUnityAttr,
+                disableAutoRegister,
                 @namespace,
                 conditionalSymbol,
                 messagepackFormatterNamespace);

--- a/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.cs
+++ b/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.cs
@@ -53,9 +53,10 @@ namespace ");
         static bool isRegistered = false;
 
 ");
- if (!OmitUnityAttribute) { 
-            this.Write("        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeL" +
-                    "oadType.BeforeSceneLoad)]\r\n");
+ if (!DisableAutoRegisterOnInitialize) { 
+            this.Write("#if UNITY_2019_4_OR_NEWER\r\n        [UnityEngine.RuntimeInitializeOnLoadMethod(Uni" +
+                    "tyEngine.RuntimeInitializeLoadType.BeforeSceneLoad)]\r\n#elif NET5_0_OR_GREATER\r\n " +
+                    "       [System.Runtime.CompilerServices.ModuleInitializer]\r\n#endif\r\n");
  } 
             this.Write("        public static void Register()\r\n        {\r\n            if(isRegistered) re" +
                     "turn;\r\n            isRegistered = true;\r\n\r\n");

--- a/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.tt
+++ b/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.tt
@@ -28,8 +28,12 @@ namespace <#= Namespace #>
     {
         static bool isRegistered = false;
 
-<# if (!OmitUnityAttribute) { #>
+<# if (!DisableAutoRegisterOnInitialize) { #>
+#if UNITY_2019_4_OR_NEWER
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.BeforeSceneLoad)]
+#elif NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+#endif
 <# } #>
         public static void Register()
         {

--- a/src/MagicOnion.GeneratorCore/CodeGen/TemplatePartials.cs
+++ b/src/MagicOnion.GeneratorCore/CodeGen/TemplatePartials.cs
@@ -11,7 +11,7 @@ public partial class HubTemplate
 public partial class RegisterTemplate
 {
     public string Namespace { get; set; }
-    public bool OmitUnityAttribute { get; set; }
+    public bool DisableAutoRegisterOnInitialize { get; set; }
     public IReadOnlyList<MagicOnionServiceInfo> Services { get; set; }
     public IReadOnlyList<MagicOnionStreamingHubInfo> Hubs { get; set; }
 }

--- a/src/MagicOnion.GeneratorCore/MagicOnionCompiler.cs
+++ b/src/MagicOnion.GeneratorCore/MagicOnionCompiler.cs
@@ -28,7 +28,7 @@ public class MagicOnionCompiler
     public async Task GenerateFileAsync(
         string input,
         string output,
-        bool omitUnityAttribute,
+        bool disableAutoRegister,
         string @namespace,
         string conditionalSymbol,
         string userDefinedMessagePackFormattersNamespace)
@@ -40,7 +40,7 @@ public class MagicOnionCompiler
         // Generator Start...
         logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:Input: {input}");
         logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:Output: {output}");
-        logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:OmitUnityAttribute: {omitUnityAttribute}");
+        logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:DisableAutoRegister: {disableAutoRegister}");
         logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:Namespace: {@namespace}");
         logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:ConditionalSymbol: {conditionalSymbol}");
         logger.Trace($"[{nameof(MagicOnionCompiler)}] Option:UserDefinedMessagePackFormattersNamespace: {userDefinedMessagePackFormattersNamespace}");
@@ -82,7 +82,7 @@ public class MagicOnionCompiler
             Namespace = @namespace,
             Services = serviceCollection.Services,
             Hubs = serviceCollection.Hubs,
-            OmitUnityAttribute = omitUnityAttribute,
+            DisableAutoRegisterOnInitialize = disableAutoRegister,
         };
 
         if (Path.GetExtension(output) == ".cs")

--- a/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
+++ b/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
@@ -23,6 +23,11 @@ namespace MagicOnion.Integration.Tests.Generated
     {
         static bool isRegistered = false;
 
+#if UNITY_2019_4_OR_NEWER
+        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.BeforeSceneLoad)]
+#elif NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+#endif
         public static void Register()
         {
             if(isRegistered) return;


### PR DESCRIPTION
This PR allow to use ModuleInitializer for automatic registration on .NET 5+.
When an application running on .NET 5+ uses a generated client, `MagicOnionInitializer.Register()` is automatically called.

## Notable changes
Option `--no-use-unity-attr` is obsoleted, please use `--disable-auto-register` instead.