### PR TITLE
Remove ChangeSerializer from ServiceContext

### DIFF
--- a/src/MagicOnion.Server/ServiceContext.cs
+++ b/src/MagicOnion.Server/ServiceContext.cs
@@ -73,7 +73,7 @@ public class ServiceContext : IServiceContext
     /// <summary>Raw gRPC Context.</summary>
     public ServerCallContext CallContext { get; }
 
-    public IMagicOnionMessageSerializer MessageSerializer { get; private set; }
+    public IMagicOnionMessageSerializer MessageSerializer { get; }
 
     public IServiceProvider ServiceProvider { get; }
 
@@ -129,13 +129,5 @@ public class ServiceContext : IServiceContext
     public void SetRawResponse(object? response)
     {
         Result = response;
-    }
-
-    /// <summary>
-    /// modify request/response options in this context.
-    /// </summary>
-    public void ChangeSerializer(IMagicOnionMessageSerializer messageSerializer)
-    {
-        this.MessageSerializer = messageSerializer;
     }
 }


### PR DESCRIPTION
This PR removes `ChangeSerializer` method from `ServiceContext`.

In the current MethodHandler implementation, `Marshaller` encapsulates the message serializer, so it is no longer to change the serializer on a per request basis.