### PR TITLE
Allow ValueTask as a return type of the hub method.

### DIFF
--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnion.Shared/GrpcMethodHelper.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnion.Shared/GrpcMethodHelper.cs
@@ -113,7 +113,6 @@ namespace MagicOnion
             }
         }
 
-
         // WORKAROUND: Prior to MagicOnion 5.0, the request type for the parameter-less method was byte[].
         //             DynamicClient sends byte[], but GeneratedClient sends Nil, which is incompatible,
         //             so as a special case we do not serialize/deserialize and always convert to a fixed values.
@@ -124,7 +123,7 @@ namespace MagicOnion
 
                     var writer = ctx.GetBufferWriter();
                     var buffer = writer.GetSpan(unsafeNilBytes.Length); // Write `Nil` as `byte[]` to the buffer.
-                    MagicOnionMarshallers.UnsafeNilBytes.CopyTo(buffer);
+                    unsafeNilBytes.CopyTo(buffer);
                     writer.Advance(unsafeNilBytes.Length);
 
                     ctx.Complete();

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnion.Shared/MagicOnionMarshallers.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnion.Shared/MagicOnionMarshallers.cs
@@ -24,8 +24,6 @@ namespace MagicOnion
             .OrderBy(x => x.GetGenericArguments().Length)
             .ToArray();
 
-        public static readonly byte[] UnsafeNilBytes = new byte[] { MessagePackCode.Nil };
-
         public static readonly Marshaller<byte[]> ThroughMarshaller = new Marshaller<byte[]>(x => x, x => x);
 
         internal static Type CreateRequestType(ParameterInfo[] parameters)

--- a/src/MagicOnion.GeneratorCore/CodeAnalysis/MagicOnionTypeInfo.cs
+++ b/src/MagicOnion.GeneratorCore/CodeAnalysis/MagicOnionTypeInfo.cs
@@ -14,6 +14,7 @@ public class MagicOnionTypeInfo : IEquatable<MagicOnionTypeInfo>
         public static MagicOnionTypeInfo System_Boolean { get; } = new MagicOnionTypeInfo("System", "Boolean", SubType.ValueType);
         public static MagicOnionTypeInfo MessagePack_Nil { get; } = new MagicOnionTypeInfo("MessagePack", "Nil", SubType.ValueType);
         public static MagicOnionTypeInfo System_Threading_Tasks_Task { get; } = new MagicOnionTypeInfo("System.Threading.Tasks", "Task");
+        public static MagicOnionTypeInfo System_Threading_Tasks_ValueTask { get; } = new MagicOnionTypeInfo("System.Threading.Tasks", "ValueTask", SubType.ValueType);
         public static MagicOnionTypeInfo MagicOnion_UnaryResult { get; } = new MagicOnionTypeInfo("MagicOnion", "UnaryResult", SubType.ValueType);
         // ReSharper restore InconsistentNaming
     }
@@ -25,6 +26,12 @@ public class MagicOnionTypeInfo : IEquatable<MagicOnionTypeInfo>
 
     public IReadOnlyList<MagicOnionTypeInfo> GenericArguments { get; }
     public bool HasGenericArguments => GenericArguments.Any();
+
+    public MagicOnionTypeInfo GetGenericTypeDefinition()
+    {
+        if (!HasGenericArguments) throw new InvalidOperationException("The type is not constructed generic type.");
+        return MagicOnionTypeInfo.Create(Namespace, Name, Array.Empty<MagicOnionTypeInfo>(), IsValueType);
+    }
 
     public bool IsArray => _subType == SubType.Array;
     public int ArrayRank { get; }
@@ -120,6 +127,7 @@ public class MagicOnionTypeInfo : IEquatable<MagicOnionTypeInfo>
         if (@namespace == "System" && name == "String") return KnownTypes.System_String;
         if (@namespace == "System" && name == "Boolean") return KnownTypes.System_Boolean;
         if (@namespace == "System.Threading.Tasks" && name == "Task" && genericArguments.Length == 0) return KnownTypes.System_Threading_Tasks_Task;
+        if (@namespace == "System.Threading.Tasks" && name == "ValueTask" && genericArguments.Length == 0) return KnownTypes.System_Threading_Tasks_ValueTask;
         if (@namespace == "MagicOnion" && name == "UnaryResult" && genericArguments.Length == 0) return KnownTypes.MagicOnion_UnaryResult;
 
         return new MagicOnionTypeInfo(@namespace, name, isValueType ? SubType.ValueType : SubType.None, arrayRank:0, genericArguments);

--- a/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
+++ b/src/MagicOnion.GeneratorCore/CodeAnalysis/MethodCollector.cs
@@ -85,9 +85,11 @@ public class MethodCollector
         switch (methodReturnType.FullNameOpenType)
         {
             case "global::System.Threading.Tasks.Task":
+            case "global::System.Threading.Tasks.ValueTask":
                 //responseType = MagicOnionTypeInfo.KnownTypes.MessagePack_Nil;
                 break;
             case "global::System.Threading.Tasks.Task<>":
+            case "global::System.Threading.Tasks.ValueTask<>":
                 responseType = methodReturnType.GenericArguments[0];
                 break;
             default:

--- a/src/MagicOnion.Server/Hubs/StreamingHubContext.cs
+++ b/src/MagicOnion.Server/Hubs/StreamingHubContext.cs
@@ -39,7 +39,7 @@ public class StreamingHubContext
     internal Type? responseType;
 
     // helper for reflection
-    internal async ValueTask WriteResponseMessageNil(Task value)
+    internal async ValueTask WriteResponseMessageNil(ValueTask value)
     {
         if (MessageId == -1) // don't write.
         {
@@ -70,7 +70,7 @@ public class StreamingHubContext
         responseType = typeof(Nil);
     }
 
-    internal async ValueTask WriteResponseMessage<T>(Task<T> value)
+    internal async ValueTask WriteResponseMessage<T>(ValueTask<T> value)
     {
         if (MessageId == -1) // don't write.
         {

--- a/src/MagicOnion.Server/Internal/MethodHandlerMetadata.cs
+++ b/src/MagicOnion.Server/Internal/MethodHandlerMetadata.cs
@@ -95,7 +95,7 @@ internal class MethodHandlerMetadataFactory
     {
         var hubInterface = serviceClass.GetInterfaces().First(x => x.GetTypeInfo().IsGenericType && x.GetGenericTypeDefinition() == typeof(IStreamingHub<,>)).GetGenericArguments()[0];
         var parameters = methodInfo.GetParameters();
-        var responseType = UnwrapStreamingHubResponseType(methodInfo, out var responseIsTask);
+        var responseType = UnwrapStreamingHubResponseType(methodInfo, out var responseIsTaskOrValueTask);
         var requestType = GetRequestTypeFromMethod(methodInfo, parameters);
 
         var attributeLookup = serviceClass.GetCustomAttributes(true)
@@ -105,9 +105,9 @@ internal class MethodHandlerMetadataFactory
 
         var interfaceMethodInfo = ResolveInterfaceMethod(serviceClass, hubInterface, methodInfo.Name);
 
-        if (!responseIsTask)
+        if (!responseIsTaskOrValueTask)
         {
-            throw new InvalidOperationException($"A type of the StreamingHub method must be Task or Task<T>. (Member:{serviceClass.Name}.{methodInfo.Name})");
+            throw new InvalidOperationException($"A type of the StreamingHub method must be Task, Task<T>, ValueTask or ValueTask<T>. (Member:{serviceClass.Name}.{methodInfo.Name})");
         }
 
         var methodId = interfaceMethodInfo.GetCustomAttribute<MethodIdAttribute>()?.MethodId ?? FNV1A32.GetHashCode(interfaceMethodInfo.Name);
@@ -187,19 +187,19 @@ internal class MethodHandlerMetadataFactory
         throw new InvalidOperationException($"The method '{methodInfo.Name}' has invalid return type. path:{methodInfo.DeclaringType!.Name + "/" + methodInfo.Name} type:{methodInfo.ReturnType.Name}");
     }
 
-    static Type? UnwrapStreamingHubResponseType(MethodInfo methodInfo, out bool responseIsTask)
+    static Type? UnwrapStreamingHubResponseType(MethodInfo methodInfo, out bool responseIsTaskOrValueTask)
     {
         var t = methodInfo.ReturnType;
 
         // Task<T>
-        if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Task<>))
+        if (t.IsGenericType && (t.GetGenericTypeDefinition() == typeof(Task<>) || t.GetGenericTypeDefinition() == typeof(ValueTask<>)))
         {
-            responseIsTask = true;
+            responseIsTaskOrValueTask = true;
             return t.GetGenericArguments()[0];
         }
-        else if (t == typeof(Task))
+        else if (t == typeof(Task) || t == typeof(ValueTask))
         {
-            responseIsTask = true;
+            responseIsTaskOrValueTask = true;
             return null;
         }
 

--- a/tests/MagicOnion.Generator.Tests/Collector/MagicOnionTypeInfoTest.cs
+++ b/tests/MagicOnion.Generator.Tests/Collector/MagicOnionTypeInfoTest.cs
@@ -698,4 +698,15 @@ public class MagicOnionTypeInfoTest
             MagicOnionTypeInfo.CreateFromType<byte[]>(),
             MagicOnionTypeInfo.CreateFromType<byte>());
     }
+
+    [Fact]
+    public void GetGenericTypeDefinition()
+    {
+        // Arrange
+        var typeInfo = MagicOnionTypeInfo.CreateFromType<ValueTuple<int, string>>();
+        // Act
+        var genericDefinition = typeInfo.GetGenericTypeDefinition();
+        // Assert
+        genericDefinition.Should().Be(MagicOnionTypeInfo.Create("System", "ValueTuple", Array.Empty<MagicOnionTypeInfo>(), true));
+    }
 }

--- a/tests/MagicOnion.Generator.Tests/Collector/MethodCollectorStreamingHubsTest.cs
+++ b/tests/MagicOnion.Generator.Tests/Collector/MethodCollectorStreamingHubsTest.cs
@@ -451,7 +451,7 @@ public interface IMyHubReceiver
         var collector = new MethodCollector();
         var ex = Assert.Throws<InvalidOperationException>(() => collector.Collect(compilation));
     }
-           
+
     [Fact]
     public void ReturnType_Task()
     {
@@ -487,7 +487,7 @@ public interface IMyHubReceiver
         serviceCollection.Hubs[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
         serviceCollection.Hubs[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_Threading_Tasks_Task);
     }
-               
+
     [Fact]
     public void ReturnType_TaskOfT()
     {
@@ -522,6 +522,78 @@ public interface IMyHubReceiver
         serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
         serviceCollection.Hubs[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_String);
         serviceCollection.Hubs[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<Task<string>>());
+    }
+
+    [Fact]
+    public void ReturnType_ValueTask()
+    {
+        // Arrange
+        var source = @"
+using System;
+using System.Threading.Tasks;
+using MagicOnion;
+using MessagePack;
+
+namespace MyNamespace;
+
+public interface IMyHub : IStreamingHub<IMyHub, IMyHubReceiver>
+{
+    ValueTask MethodA();
+}
+
+public interface IMyHubReceiver
+{
+    void EventA();
+}
+";
+        using var tempWorkspace = TemporaryProjectWorkarea.Create();
+        tempWorkspace.AddFileToProject("IMyHub.cs", source);
+        var compilation = tempWorkspace.GetOutputCompilation().Compilation;
+
+        // Act
+        var collector = new MethodCollector();
+        var serviceCollection = collector.Collect(compilation);
+
+        // Assert
+        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
+        serviceCollection.Hubs[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
+        serviceCollection.Hubs[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_Threading_Tasks_ValueTask);
+    }
+
+    [Fact]
+    public void ReturnType_ValueTaskOfT()
+    {
+        // Arrange
+        var source = @"
+using System;
+using System.Threading.Tasks;
+using MagicOnion;
+using MessagePack;
+
+namespace MyNamespace;
+
+public interface IMyHub : IStreamingHub<IMyHub, IMyHubReceiver>
+{
+    ValueTask<string> MethodA();
+}
+
+public interface IMyHubReceiver
+{
+    void EventA();
+}
+";
+        using var tempWorkspace = TemporaryProjectWorkarea.Create();
+        tempWorkspace.AddFileToProject("IMyHub.cs", source);
+        var compilation = tempWorkspace.GetOutputCompilation().Compilation;
+
+        // Act
+        var collector = new MethodCollector();
+        var serviceCollection = collector.Collect(compilation);
+
+        // Assert
+        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
+        serviceCollection.Hubs[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_String);
+        serviceCollection.Hubs[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<ValueTask<string>>());
     }
 
     [Fact]

--- a/tests/MagicOnion.Generator.Tests/GenerateStreamingHub.cs
+++ b/tests/MagicOnion.Generator.Tests/GenerateStreamingHub.cs
@@ -265,6 +265,84 @@ namespace TempProject
     }
 
     [Fact]
+    public async Task Return_ValueTask()
+    {
+        using var tempWorkspace = TemporaryProjectWorkarea.Create();
+        tempWorkspace.AddFileToProject("IMyService.cs", @"
+using System;
+using System.Threading.Tasks;
+using MessagePack;
+using MagicOnion;
+
+namespace TempProject
+{
+    public interface IMyHubReceiver { }
+    public interface IMyHub : IStreamingHub<IMyHub, IMyHubReceiver>
+    {
+        ValueTask A(MyObject a);
+    }
+
+    [MessagePackObject]
+    public class MyObject
+    {
+    }
+}
+            ");
+
+        var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(testOutputHelper), CancellationToken.None);
+        await compiler.GenerateFileAsync(
+            tempWorkspace.CsProjectPath,
+            Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
+            true,
+            "TempProject.Generated",
+            "",
+            "MessagePack.Formatters"
+        );
+
+        var compilation = tempWorkspace.GetOutputCompilation();
+        compilation.GetCompilationErrors().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Return_ValueTaskOfT()
+    {
+        using var tempWorkspace = TemporaryProjectWorkarea.Create();
+        tempWorkspace.AddFileToProject("IMyService.cs", @"
+using System;
+using System.Threading.Tasks;
+using MessagePack;
+using MagicOnion;
+
+namespace TempProject
+{
+    public interface IMyHubReceiver { }
+    public interface IMyHub : IStreamingHub<IMyHub, IMyHubReceiver>
+    {
+        ValueTask<MyObject> A(MyObject a);
+    }
+
+    [MessagePackObject]
+    public class MyObject
+    {
+    }
+}
+            ");
+
+        var compiler = new MagicOnionCompiler(new MagicOnionGeneratorTestOutputLogger(testOutputHelper), CancellationToken.None);
+        await compiler.GenerateFileAsync(
+            tempWorkspace.CsProjectPath,
+            Path.Combine(tempWorkspace.OutputDirectory, "Generated.cs"),
+            true,
+            "TempProject.Generated",
+            "",
+            "MessagePack.Formatters"
+        );
+
+        var compilation = tempWorkspace.GetOutputCompilation();
+        compilation.GetCompilationErrors().Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task Invalid_Return_Void()
     {
         using var tempWorkspace = TemporaryProjectWorkarea.Create();

--- a/tests/MagicOnion.Generator.Tests/MagicOnionGeneratorTestOutputLogger.cs
+++ b/tests/MagicOnion.Generator.Tests/MagicOnionGeneratorTestOutputLogger.cs
@@ -12,7 +12,7 @@ public class MagicOnionGeneratorTestOutputLogger : IMagicOnionGeneratorLogger
         this.outputHelper = outputHelper;
     }
 
-#if TRUE
+#if FALSE
     public void Trace(string message) => outputHelper.WriteLine(message);
 #else
     public void Trace(string message) {}

--- a/tests/MagicOnion.Integration.Tests/StreamingHubTest.cs
+++ b/tests/MagicOnion.Integration.Tests/StreamingHubTest.cs
@@ -129,6 +129,106 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
+    public async Task ValueTask_NoReturn_Parameter_Zero(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    {
+        // Arrange
+        var httpClient = factory.CreateDefaultClient();
+        var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
+
+        var receiver = new Mock<IStreamingHubTestHubReceiver>();
+        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+
+        // Act & Assert
+        await client.ValueTask_NoReturn_Parameter_Zero();
+    }
+
+    [Theory]
+    [MemberData(nameof(EnumerateStreamingHubClientFactory))]
+    public async Task ValueTask_NoReturn_Parameter_One(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    {
+        // Arrange
+        var httpClient = factory.CreateDefaultClient();
+        var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
+
+        var receiver = new Mock<IStreamingHubTestHubReceiver>();
+        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+
+        // Act & Assert
+        await client.ValueTask_NoReturn_Parameter_One(12345);
+    }
+
+    
+    [Theory]
+    [MemberData(nameof(EnumerateStreamingHubClientFactory))]
+    public async Task ValueTask_NoReturn_Parameter_Many(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    {
+        // Arrange
+        var httpClient = factory.CreateDefaultClient();
+        var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
+
+        var receiver = new Mock<IStreamingHubTestHubReceiver>();
+        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+
+        // Act & Assert
+        await client.ValueTask_NoReturn_Parameter_Many(12345, "Hello✨", true);
+    }
+    
+    [Theory]
+    [MemberData(nameof(EnumerateStreamingHubClientFactory))]
+    public async Task ValueTask_Parameter_Zero(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    {
+        // Arrange
+        var httpClient = factory.CreateDefaultClient();
+        var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
+
+        var receiver = new Mock<IStreamingHubTestHubReceiver>();
+        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+
+        // Act
+        var result = await client.ValueTask_Parameter_Zero();
+
+        // Assert
+        result.Should().Be(67890);
+    }
+
+    [Theory]
+    [MemberData(nameof(EnumerateStreamingHubClientFactory))]
+    public async Task ValueTask_Parameter_One(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    {
+        // Arrange
+        var httpClient = factory.CreateDefaultClient();
+        var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
+
+        var receiver = new Mock<IStreamingHubTestHubReceiver>();
+        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+
+        // Act
+        var result = await client.ValueTask_Parameter_One(12345);
+
+        // Assert
+        result.Should().Be(67890);
+    }
+
+    [Theory]
+    [MemberData(nameof(EnumerateStreamingHubClientFactory))]
+    public async Task ValueTask_Parameter_Many(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    {
+        // Arrange
+        var httpClient = factory.CreateDefaultClient();
+        var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
+
+        var receiver = new Mock<IStreamingHubTestHubReceiver>();
+        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+
+        // Act
+        var result = await client.ValueTask_Parameter_Many(12345, "Hello✨", true);
+
+        // Assert
+        result.Should().Be(67890);
+    }
+
+    [Theory]
+    [MemberData(nameof(EnumerateStreamingHubClientFactory))]
     public async Task Receiver_Parameter_Zero(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
     {
         // Arrange
@@ -294,7 +394,44 @@ public class StreamingHubTestHub : StreamingHubBase<IStreamingHubTestHub, IStrea
     {
         return new TaskCompletionSource<int>().Task.WaitAsync(TimeSpan.FromMilliseconds(100));
     }
+    
+    public ValueTask ValueTask_NoReturn_Parameter_Zero()
+    {
+        return default;
+    }
 
+    public ValueTask ValueTask_NoReturn_Parameter_One(int arg0)
+    {
+        Debug.Assert(arg0 == 12345);
+        return default;
+    }
+
+    public ValueTask ValueTask_NoReturn_Parameter_Many(int arg0, string arg1, bool arg2)
+    {
+        Debug.Assert(arg0 == 12345);
+        Debug.Assert(arg1 == "Hello✨");
+        Debug.Assert(arg2 == true);
+        return default;
+    }
+
+    public ValueTask<int> ValueTask_Parameter_Zero()
+    {
+        return ValueTask.FromResult(67890);
+    }
+
+    public ValueTask<int> ValueTask_Parameter_One(int arg0)
+    {
+        Debug.Assert(arg0 == 12345);
+        return ValueTask.FromResult(67890);
+    }
+
+    public ValueTask<int> ValueTask_Parameter_Many(int arg0, string arg1, bool arg2)
+    {
+        Debug.Assert(arg0 == 12345);
+        Debug.Assert(arg1 == "Hello✨");
+        Debug.Assert(arg2 == true);
+        return ValueTask.FromResult(67890);
+    }
 }
 
 public interface IStreamingHubTestHubReceiver
@@ -320,4 +457,13 @@ public interface IStreamingHubTestHub : IStreamingHub<IStreamingHubTestHub, IStr
 
     Task Never();
     Task<int> Never_With_Return();
+
+    ValueTask ValueTask_NoReturn_Parameter_Zero();
+    ValueTask ValueTask_NoReturn_Parameter_One(int arg0);
+    ValueTask ValueTask_NoReturn_Parameter_Many(int arg0, string arg1, bool arg2);
+
+    ValueTask<int> ValueTask_Parameter_Zero();
+    ValueTask<int> ValueTask_Parameter_One(int arg0);
+    ValueTask<int> ValueTask_Parameter_Many(int arg0, string arg1, bool arg2);
+
 }

--- a/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
+++ b/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
@@ -684,6 +684,18 @@ namespace MagicOnion.Integration.Tests
             => base.WriteMessageWithResponseAsync<global::MessagePack.Nil, global::MessagePack.Nil>(-1291900119, global::MessagePack.Nil.Default);
         public global::System.Threading.Tasks.Task<global::System.Int32> Never_With_Return()
             => base.WriteMessageWithResponseAsync<global::MessagePack.Nil, global::System.Int32>(2074829953, global::MessagePack.Nil.Default);
+        public global::System.Threading.Tasks.ValueTask ValueTask_NoReturn_Parameter_Zero()
+            => new global::System.Threading.Tasks.ValueTask(base.WriteMessageWithResponseAsync<global::MessagePack.Nil, global::MessagePack.Nil>(-1145997568, global::MessagePack.Nil.Default));
+        public global::System.Threading.Tasks.ValueTask ValueTask_NoReturn_Parameter_One(global::System.Int32 arg0)
+            => new global::System.Threading.Tasks.ValueTask(base.WriteMessageWithResponseAsync<global::System.Int32, global::MessagePack.Nil>(928334602, arg0));
+        public global::System.Threading.Tasks.ValueTask ValueTask_NoReturn_Parameter_Many(global::System.Int32 arg0, global::System.String arg1, global::System.Boolean arg2)
+            => new global::System.Threading.Tasks.ValueTask(base.WriteMessageWithResponseAsync<global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.String, global::System.Boolean>, global::MessagePack.Nil>(-1965648219, new global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.String, global::System.Boolean>(arg0, arg1, arg2)));
+        public global::System.Threading.Tasks.ValueTask<global::System.Int32> ValueTask_Parameter_Zero()
+            => new global::System.Threading.Tasks.ValueTask<global::System.Int32>(base.WriteMessageWithResponseAsync<global::MessagePack.Nil, global::System.Int32>(658969434, global::MessagePack.Nil.Default));
+        public global::System.Threading.Tasks.ValueTask<global::System.Int32> ValueTask_Parameter_One(global::System.Int32 arg0)
+            => new global::System.Threading.Tasks.ValueTask<global::System.Int32>(base.WriteMessageWithResponseAsync<global::System.Int32, global::System.Int32>(-435674772, arg0));
+        public global::System.Threading.Tasks.ValueTask<global::System.Int32> ValueTask_Parameter_Many(global::System.Int32 arg0, global::System.String arg1, global::System.Boolean arg2)
+            => new global::System.Threading.Tasks.ValueTask<global::System.Int32>(base.WriteMessageWithResponseAsync<global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.String, global::System.Boolean>, global::System.Int32>(-52442641, new global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.String, global::System.Boolean>(arg0, arg1, arg2)));
         
         public global::MagicOnion.Integration.Tests.IStreamingHubTestHub FireAndForget()
             => new FireAndForgetClient(this);
@@ -722,6 +734,18 @@ namespace MagicOnion.Integration.Tests
                 => parent.WriteMessageFireAndForgetAsync<global::MessagePack.Nil, global::MessagePack.Nil>(-1291900119, global::MessagePack.Nil.Default);
             public global::System.Threading.Tasks.Task<global::System.Int32> Never_With_Return()
                 => parent.WriteMessageFireAndForgetAsync<global::MessagePack.Nil, global::System.Int32>(2074829953, global::MessagePack.Nil.Default);
+            public global::System.Threading.Tasks.ValueTask ValueTask_NoReturn_Parameter_Zero()
+                => new global::System.Threading.Tasks.ValueTask(parent.WriteMessageFireAndForgetAsync<global::MessagePack.Nil, global::MessagePack.Nil>(-1145997568, global::MessagePack.Nil.Default));
+            public global::System.Threading.Tasks.ValueTask ValueTask_NoReturn_Parameter_One(global::System.Int32 arg0)
+                => new global::System.Threading.Tasks.ValueTask(parent.WriteMessageFireAndForgetAsync<global::System.Int32, global::MessagePack.Nil>(928334602, arg0));
+            public global::System.Threading.Tasks.ValueTask ValueTask_NoReturn_Parameter_Many(global::System.Int32 arg0, global::System.String arg1, global::System.Boolean arg2)
+                => new global::System.Threading.Tasks.ValueTask(parent.WriteMessageFireAndForgetAsync<global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.String, global::System.Boolean>, global::MessagePack.Nil>(-1965648219, new global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.String, global::System.Boolean>(arg0, arg1, arg2)));
+            public global::System.Threading.Tasks.ValueTask<global::System.Int32> ValueTask_Parameter_Zero()
+                => new global::System.Threading.Tasks.ValueTask<global::System.Int32>(parent.WriteMessageFireAndForgetAsync<global::MessagePack.Nil, global::System.Int32>(658969434, global::MessagePack.Nil.Default));
+            public global::System.Threading.Tasks.ValueTask<global::System.Int32> ValueTask_Parameter_One(global::System.Int32 arg0)
+                => new global::System.Threading.Tasks.ValueTask<global::System.Int32>(parent.WriteMessageFireAndForgetAsync<global::System.Int32, global::System.Int32>(-435674772, arg0));
+            public global::System.Threading.Tasks.ValueTask<global::System.Int32> ValueTask_Parameter_Many(global::System.Int32 arg0, global::System.String arg1, global::System.Boolean arg2)
+                => new global::System.Threading.Tasks.ValueTask<global::System.Int32>(parent.WriteMessageFireAndForgetAsync<global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.String, global::System.Boolean>, global::System.Int32>(-52442641, new global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.String, global::System.Boolean>(arg0, arg1, arg2)));
             
         }
         
@@ -785,6 +809,24 @@ namespace MagicOnion.Integration.Tests
                     base.SetResultForResponse<global::MessagePack.Nil>(taskCompletionSource, data);
                     break;
                 case 2074829953: // Task<Int32> Never_With_Return()
+                    base.SetResultForResponse<global::System.Int32>(taskCompletionSource, data);
+                    break;
+                case -1145997568: // ValueTask ValueTask_NoReturn_Parameter_Zero()
+                    base.SetResultForResponse<global::MessagePack.Nil>(taskCompletionSource, data);
+                    break;
+                case 928334602: // ValueTask ValueTask_NoReturn_Parameter_One(global::System.Int32 arg0)
+                    base.SetResultForResponse<global::MessagePack.Nil>(taskCompletionSource, data);
+                    break;
+                case -1965648219: // ValueTask ValueTask_NoReturn_Parameter_Many(global::System.Int32 arg0, global::System.String arg1, global::System.Boolean arg2)
+                    base.SetResultForResponse<global::MessagePack.Nil>(taskCompletionSource, data);
+                    break;
+                case 658969434: // ValueTask<Int32> ValueTask_Parameter_Zero()
+                    base.SetResultForResponse<global::System.Int32>(taskCompletionSource, data);
+                    break;
+                case -435674772: // ValueTask<Int32> ValueTask_Parameter_One(global::System.Int32 arg0)
+                    base.SetResultForResponse<global::System.Int32>(taskCompletionSource, data);
+                    break;
+                case -52442641: // ValueTask<Int32> ValueTask_Parameter_Many(global::System.Int32 arg0, global::System.String arg1, global::System.Boolean arg2)
                     base.SetResultForResponse<global::System.Int32>(taskCompletionSource, data);
                     break;
             }

--- a/tests/MagicOnion.Server.Tests/StreamingHubMethodHandlerMetadataFactoryTest.cs
+++ b/tests/MagicOnion.Server.Tests/StreamingHubMethodHandlerMetadataFactoryTest.cs
@@ -1,4 +1,4 @@
-﻿using MagicOnion.Server.Hubs;
+using MagicOnion.Server.Hubs;
 using MagicOnion.Server.Internal;
 using MagicOnion.Utils;
 using MessagePack;
@@ -308,6 +308,46 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         metadata.AttributeLookup[typeof(MySecondAttribute)].Should().BeEquivalentTo(new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2));
     }
 
+    [Fact]
+    public void ValueTask()
+    {
+        // Arrange
+        var type = typeof(MyHub);
+        var methodInfo = type.GetMethod(nameof(MyHub.Method_ValueTask))!;
+
+        // Act
+        var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo);
+
+        // Assert
+        metadata.StreamingHubImplementationType.Should().Be<MyHub>();
+        metadata.StreamingHubInterfaceType.Should().Be<IMyHub>();
+        metadata.InterfaceMethod.Should().BeSameAs(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_ValueTask)));
+        metadata.ImplementationMethod.Should().BeSameAs(methodInfo);
+        metadata.Parameters.Should().BeEmpty();
+        metadata.RequestType.Should().Be<Nil>();
+        metadata.ResponseType.Should().BeNull();
+    }
+
+    [Fact]
+    public void ValueTaskOfT()
+    {
+        // Arrange
+        var type = typeof(MyHub);
+        var methodInfo = type.GetMethod(nameof(MyHub.Method_ValueTaskOfValue))!;
+
+        // Act
+        var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo);
+
+        // Assert
+        metadata.StreamingHubImplementationType.Should().Be<MyHub>();
+        metadata.StreamingHubInterfaceType.Should().Be<IMyHub>();
+        metadata.InterfaceMethod.Should().BeSameAs(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_ValueTaskOfValue)));
+        metadata.ImplementationMethod.Should().BeSameAs(methodInfo);
+        metadata.Parameters.Should().BeEmpty();
+        metadata.RequestType.Should().Be<Nil>();
+        metadata.ResponseType.Should().Be<int>();
+    }
+
     interface IMyHubReceiver
     {}
 
@@ -315,6 +355,8 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
     {
         Task Method_Task();
         Task<int> Method_TaskOfValue();
+        ValueTask Method_ValueTask();
+        ValueTask<int> Method_ValueTaskOfValue();
 
         Task Method_Parameterless();
         Task Method_OneParameter(int arg0);
@@ -328,6 +370,8 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
     {
         public Task Method_Task() => throw new NotImplementedException();
         public Task<int> Method_TaskOfValue() => throw new NotImplementedException();
+        public ValueTask Method_ValueTask() => throw new NotImplementedException();
+        public ValueTask<int> Method_ValueTaskOfValue() => throw new NotImplementedException();
         public Task Method_Parameterless() => throw new NotImplementedException();
         public Task Method_OneParameter(int arg0) => throw new NotImplementedException();
         public Task Method_TwoParameters(int arg0, string arg1) => throw new NotImplementedException();


### PR DESCRIPTION
This PR allows `ValueTask` and `ValueTask<T>` as a return type of the hub method. Previously, only `Task` were`Task<T>` was allowed.

## Example
```csharp
public interface IMyHub : IStreamingHub<IMyHub, IMyHubReceiver>
{
    ValueTask FooAsync();
    ValueTask<int> BarAsync();
}
```