### PR TITLE
Introduce ClientFactoryProvider

### DIFF
--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
@@ -30,14 +30,67 @@ namespace MagicOnion
 #endif
         public static void Register()
         {
-            if(isRegistered) return;
+            if (isRegistered) return;
             isRegistered = true;
 
-            MagicOnionClientRegistry<global::ChatApp.Shared.Services.IChatService>.Register((x, y) => new ChatApp.Shared.Services.ChatServiceClient(x, y));
+            global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default =
+                (global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableMagicOnionClientFactoryProvider immutableMagicOnionClientFactoryProvider)
+                    ? immutableMagicOnionClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
+                    : new ImmutableMagicOnionClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
 
-            StreamingHubClientRegistry<global::ChatApp.Shared.Hubs.IChatHub, global::ChatApp.Shared.Hubs.IChatHubReceiver>.Register((a, _, b, c, d, e) => new ChatApp.Shared.Hubs.ChatHubClient(a, b, c, d, e));
+            global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default =
+                (global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableStreamingHubClientFactoryProvider immutableStreamingHubClientFactoryProvider)
+                    ? immutableStreamingHubClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
+                    : new ImmutableStreamingHubClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
         }
     }
+
+    public partial class MagicOnionGeneratedClientFactoryProvider : IMagicOnionClientFactoryProvider, IStreamingHubClientFactoryProvider
+    {
+        public static MagicOnionGeneratedClientFactoryProvider Instance { get; } = new MagicOnionGeneratedClientFactoryProvider();
+
+        MagicOnionGeneratedClientFactoryProvider() {}
+
+        bool IMagicOnionClientFactoryProvider.TryGetFactory<T>(out global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> factory)
+            => (factory = MagicOnionClientFactoryCache<T>.Factory) != null;
+
+        bool IStreamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory)
+            => (factory = StreamingHubClientFactoryCache<TStreamingHub, TReceiver>.Factory) != null;
+
+        static class MagicOnionClientFactoryCache<T> where T : global::MagicOnion.IService<T>
+        {
+            public readonly static global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> Factory;
+
+            static MagicOnionClientFactoryCache()
+            {
+                object factory = default(global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T>);
+
+                if (typeof(T) == typeof(global::ChatApp.Shared.Services.IChatService))
+                {
+                    factory = ((global::MagicOnion.Client.MagicOnionClientFactoryDelegate<global::ChatApp.Shared.Services.IChatService>)((x, y) => new ChatApp.Shared.Services.ChatServiceClient(x, y)));
+                }
+                Factory = (global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T>)factory;
+            }
+        }
+        
+        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            public readonly static global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory;
+
+            static StreamingHubClientFactoryCache()
+            {
+                object factory = default(global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>);
+
+                if (typeof(TStreamingHub) == typeof(global::ChatApp.Shared.Hubs.IChatHub) && typeof(TReceiver) == typeof(global::ChatApp.Shared.Hubs.IChatHubReceiver))
+                {
+                    factory = ((global::MagicOnion.Client.StreamingHubClientFactoryDelegate<global::ChatApp.Shared.Hubs.IChatHub, global::ChatApp.Shared.Hubs.IChatHubReceiver>)((a, _, b, c, d, e) => new ChatApp.Shared.Hubs.ChatHubClient(a, b, c, d, e)));
+                }
+
+                Factory = (global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>)factory;
+            }
+        }
+    }
+
 }
 
 #pragma warning restore 168

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
@@ -73,7 +73,7 @@ namespace MagicOnion
             }
         }
         
-        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : global::MagicOnion.IStreamingHub<TStreamingHub, TReceiver>
         {
             public readonly static global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory;
 

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
@@ -36,25 +36,25 @@ namespace MagicOnion
             global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default =
                 (global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableMagicOnionClientFactoryProvider immutableMagicOnionClientFactoryProvider)
                     ? immutableMagicOnionClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
-                    : new ImmutableMagicOnionClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
+                    : new global::MagicOnion.Client.ImmutableMagicOnionClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
 
             global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default =
                 (global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableStreamingHubClientFactoryProvider immutableStreamingHubClientFactoryProvider)
                     ? immutableStreamingHubClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
-                    : new ImmutableStreamingHubClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
+                    : new global::MagicOnion.Client.ImmutableStreamingHubClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
         }
     }
 
-    public partial class MagicOnionGeneratedClientFactoryProvider : IMagicOnionClientFactoryProvider, IStreamingHubClientFactoryProvider
+    public partial class MagicOnionGeneratedClientFactoryProvider : global::MagicOnion.Client.IMagicOnionClientFactoryProvider, global::MagicOnion.Client.IStreamingHubClientFactoryProvider
     {
         public static MagicOnionGeneratedClientFactoryProvider Instance { get; } = new MagicOnionGeneratedClientFactoryProvider();
 
         MagicOnionGeneratedClientFactoryProvider() {}
 
-        bool IMagicOnionClientFactoryProvider.TryGetFactory<T>(out global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> factory)
+        bool global::MagicOnion.Client.IMagicOnionClientFactoryProvider.TryGetFactory<T>(out global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> factory)
             => (factory = MagicOnionClientFactoryCache<T>.Factory) != null;
 
-        bool IStreamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory)
+        bool global::MagicOnion.Client.IStreamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory)
             => (factory = StreamingHubClientFactoryCache<TStreamingHub, TReceiver>.Factory) != null;
 
         static class MagicOnionClientFactoryCache<T> where T : global::MagicOnion.IService<T>

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClient.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClient.cs
@@ -11,37 +11,37 @@ namespace MagicOnion.Client
         public static T Create<T>(ChannelBase channel)
             where T : IService<T>
         {
-            return Create<T>(channel.CreateCallInvoker(), MagicOnionSerializerProvider.Default, emptyFilters);
+            return Create<T>(channel.CreateCallInvoker(), MagicOnionSerializerProvider.Default, emptyFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(ChannelBase channel, IClientFilter[] clientFilters)
             where T : IService<T>
         {
-            return Create<T>(channel.CreateCallInvoker(), MagicOnionSerializerProvider.Default, clientFilters);
+            return Create<T>(channel.CreateCallInvoker(), MagicOnionSerializerProvider.Default, clientFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(ChannelBase channel, IMagicOnionSerializerProvider serializerProvider)
             where T : IService<T>
         {
-            return Create<T>(channel.CreateCallInvoker(), serializerProvider, emptyFilters);
+            return Create<T>(channel.CreateCallInvoker(), serializerProvider, emptyFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(CallInvoker invoker)
             where T : IService<T>
         {
-            return Create<T>(invoker, MagicOnionSerializerProvider.Default, emptyFilters);
+            return Create<T>(invoker, MagicOnionSerializerProvider.Default, emptyFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(CallInvoker invoker, IClientFilter[] clientFilters)
             where T : IService<T>
         {
-            return Create<T>(invoker, MagicOnionSerializerProvider.Default, clientFilters);
+            return Create<T>(invoker, MagicOnionSerializerProvider.Default, clientFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(CallInvoker invoker, IMagicOnionSerializerProvider serializerProvider)
             where T : IService<T>
         {
-            return Create<T>(invoker, serializerProvider, emptyFilters);
+            return Create<T>(invoker, serializerProvider, emptyFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(CallInvoker invoker, IMagicOnionSerializerProvider serializerProvider, IClientFilter[] clientFilters)
@@ -50,37 +50,36 @@ namespace MagicOnion.Client
             if (invoker == null) throw new ArgumentNullException(nameof(invoker));
 
             var clientOptions = new MagicOnionClientOptions(invoker, default, default, clientFilters);
-            return Create<T>(clientOptions, serializerProvider);
+            return Create<T>(clientOptions, serializerProvider, MagicOnionClientFactoryProvider.Default);
+        }
+
+        public static T Create<T>(CallInvoker invoker, IMagicOnionSerializerProvider serializerProvider, IClientFilter[] clientFilters, IMagicOnionClientFactoryProvider clientFactoryProvider)
+            where T : IService<T>
+        {
+            if (invoker == null) throw new ArgumentNullException(nameof(invoker));
+
+            var clientOptions = new MagicOnionClientOptions(invoker, default, default, clientFilters);
+            return Create<T>(clientOptions, serializerProvider, clientFactoryProvider);
         }
 
         public static T Create<T>(MagicOnionClientOptions clientOptions, IMagicOnionSerializerProvider serializerProvider)
             where T : IService<T>
         {
-            var ctor = MagicOnionClientRegistry<T>.constructor;
-            if (ctor == null)
-            {
-#if ((ENABLE_IL2CPP && !UNITY_EDITOR) || NET_STANDARD_2_0)
-                throw new InvalidOperationException($"Unable to find a client factory of type '{typeof(T)}'. If the application is running on IL2CPP or AOT, dynamic code generation is not supported. Please use the code generator (moc).");
-#else
-                var t = MagicOnion.Client.DynamicClient.DynamicClientBuilder<T>.ClientType;
-                return (T)Activator.CreateInstance(t, clientOptions, serializerProvider);
-#endif
-            }
-            else
-            {
-                return ctor(clientOptions, serializerProvider);
-            }
+            return Create<T>(clientOptions, serializerProvider, MagicOnionClientFactoryProvider.Default);
         }
-    }
 
-    public static class MagicOnionClientRegistry<T>
-        where T : IService<T>
-    {
-        internal static Func<MagicOnionClientOptions, IMagicOnionSerializerProvider, T> constructor;
-
-        public static void Register(Func<MagicOnionClientOptions, IMagicOnionSerializerProvider, T> ctor)
+        public static T Create<T>(MagicOnionClientOptions clientOptions, IMagicOnionSerializerProvider serializerProvider, IMagicOnionClientFactoryProvider clientFactoryProvider)
+            where T : IService<T>
         {
-            constructor = ctor;
+            if (serializerProvider is null) throw new ArgumentNullException(nameof(serializerProvider));
+            if (clientFactoryProvider is null) throw new ArgumentNullException(nameof(clientFactoryProvider));
+
+            if (!clientFactoryProvider.TryGetFactory<T>(out var factory))
+            {
+                throw new NotSupportedException($"Unable to get client factory for service type '{typeof(T).FullName}'.");
+            }
+
+            return factory(clientOptions, serializerProvider);
         }
     }
 }

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClientFactoryProvider.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClientFactoryProvider.cs
@@ -1,0 +1,102 @@
+using MagicOnion.Serialization;
+using System;
+using System.Linq;
+using MagicOnion.Client.DynamicClient;
+
+namespace MagicOnion.Client
+{
+    /// <summary>
+    /// Provides to get a MagicOnionClient factory of the specified service type.
+    /// </summary>
+    public static class MagicOnionClientFactoryProvider
+    {
+        /// <summary>
+        /// Gets or set the MagicOnionClient factory provider to use by default.
+        /// </summary>
+        public static IMagicOnionClientFactoryProvider Default { get; set; }
+#if ((ENABLE_IL2CPP && !UNITY_EDITOR) || NET_STANDARD_2_0)
+            = DynamicNotSupportedMagicOnionClientFactoryProvider.Instance;
+#else
+            = DynamicMagicOnionClientFactoryProvider.Instance;
+#endif
+    }
+
+    public delegate T MagicOnionClientFactoryDelegate<out T>(MagicOnionClientOptions clientOptions, IMagicOnionSerializerProvider serializerProvider) where T : IService<T>;
+
+    /// <summary>
+    /// Provides to get a MagicOnionClient factory of the specified service type.
+    /// </summary>
+    public interface IMagicOnionClientFactoryProvider
+    {
+        /// <summary>
+        /// Gets the MagicOnionClient factory of the specified service type. A return value indicates whether a factory was found or not.
+        /// </summary>
+        /// <typeparam name="T">A MagicOnion service interface type.</typeparam>
+        /// <param name="factory">A MagicOnionClient factory of specified service type.</param>
+        /// <returns>The value indicates whether a factory was found or not.</returns>
+        bool TryGetFactory<T>(out MagicOnionClientFactoryDelegate<T> factory) where T : IService<T>;
+    }
+    
+    public class ImmutableMagicOnionClientFactoryProvider : IMagicOnionClientFactoryProvider
+    {
+        readonly IMagicOnionClientFactoryProvider[] providers;
+
+        public ImmutableMagicOnionClientFactoryProvider(params IMagicOnionClientFactoryProvider[] providers)
+        {
+            this.providers = providers;
+        }
+
+        public ImmutableMagicOnionClientFactoryProvider Add(IMagicOnionClientFactoryProvider provider)
+        {
+            return new ImmutableMagicOnionClientFactoryProvider(providers.Append(provider).ToArray());
+        }
+
+        public bool TryGetFactory<T>(out MagicOnionClientFactoryDelegate<T> factory) where T : IService<T>
+        {
+            foreach (var provider in providers)
+            {
+                if (provider.TryGetFactory<T>(out factory))
+                {
+                    return true;
+                }
+            }
+
+            factory = default;
+            return false;
+        }
+    }
+
+    public class DynamicNotSupportedMagicOnionClientFactoryProvider : IMagicOnionClientFactoryProvider
+    {
+        public static IMagicOnionClientFactoryProvider Instance { get; } = new DynamicNotSupportedMagicOnionClientFactoryProvider();
+
+        DynamicNotSupportedMagicOnionClientFactoryProvider() { }
+
+        public bool TryGetFactory<T>(out MagicOnionClientFactoryDelegate<T> factory) where T : IService<T>
+        {
+            throw new InvalidOperationException($"Unable to find a client factory of type '{typeof(T)}'. If the application is running on IL2CPP or AOT, dynamic code generation is not supported. Please use the code generator (moc).");
+        }
+    }
+
+    /// <summary>
+    /// Provides to get a MagicOnionClient factory of the specified service type. The provider is backed by DynamicMagicOnionClientBuilder.
+    /// </summary>
+    public class DynamicMagicOnionClientFactoryProvider : IMagicOnionClientFactoryProvider
+    {
+        public static IMagicOnionClientFactoryProvider Instance { get; } = new DynamicMagicOnionClientFactoryProvider();
+
+        DynamicMagicOnionClientFactoryProvider() { }
+
+        public bool TryGetFactory<T>(out MagicOnionClientFactoryDelegate<T> factory) where T : IService<T>
+        {
+            factory = Cache<T>.Factory;
+            return true;
+        }
+
+        static class Cache<T> where T : IService<T>
+        {
+            public static readonly MagicOnionClientFactoryDelegate<T> Factory
+                = (clientOptions, serializerProvider) => (T)Activator.CreateInstance(DynamicClientBuilder<T>.ClientType, clientOptions, serializerProvider);
+        }
+    }
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClientFactoryProvider.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClientFactoryProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 358a767cf48bbf64cb1d8137431a7d15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientFactoryProvider.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientFactoryProvider.cs
@@ -1,0 +1,103 @@
+using Grpc.Core;
+using System;
+using System.Linq;
+using MagicOnion.Client.DynamicClient;
+using MagicOnion.Serialization;
+
+namespace MagicOnion.Client
+{
+    /// <summary>
+    /// Provides to get a StreamingHubClient factory of the specified service type.
+    /// </summary>
+    public static class StreamingHubClientFactoryProvider
+    {
+        /// <summary>
+        /// Gets or set the StreamingHubClient factory provider to use by default.
+        /// </summary>
+        public static IStreamingHubClientFactoryProvider Default { get; set; }
+#if ((ENABLE_IL2CPP && !UNITY_EDITOR) || NET_STANDARD_2_0)
+            = DynamicNotSupportedStreamingHubClientFactoryProvider.Instance;
+#else
+            = DynamicStreamingHubClientFactoryProvider.Instance;
+#endif
+    }
+
+    public delegate TStreamingHub StreamingHubClientFactoryDelegate<out TStreamingHub, in TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host, CallOptions callOptions, IMagicOnionSerializerProvider serializerProvider, IMagicOnionClientLogger logger)
+        where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>;
+
+    /// <summary>
+    /// Provides to get a StreamingHubClient factory of the specified service type.
+    /// </summary>
+    public interface IStreamingHubClientFactoryProvider
+    {
+        /// <summary>
+        /// Gets the StreamingHubClient factory of the specified service type. A return value indicates whether a factory was found or not.
+        /// </summary>
+        /// <typeparam name="TStreamingHub">A MagicOnion StreamingHub interface type.</typeparam>
+        /// <typeparam name="TReceiver">A hub receiver interface type.</typeparam>
+        /// <param name="factory">A StreamingHubClient factory of specified service type.</param>
+        /// <returns>The value indicates whether a factory was found or not.</returns>
+        bool TryGetFactory<TStreamingHub, TReceiver>(out StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory) where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>;
+    }
+
+    public class ImmutableStreamingHubClientFactoryProvider : IStreamingHubClientFactoryProvider
+    {
+        readonly IStreamingHubClientFactoryProvider[] providers;
+
+        public ImmutableStreamingHubClientFactoryProvider(params IStreamingHubClientFactoryProvider[] providers)
+        {
+            this.providers = providers;
+        }
+
+        public ImmutableStreamingHubClientFactoryProvider Add(IStreamingHubClientFactoryProvider provider)
+        {
+            return new ImmutableStreamingHubClientFactoryProvider(providers.Append(provider).ToArray());
+        }
+
+        public bool TryGetFactory<TStreamingHub, TReceiver>(out StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory) where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            foreach (var provider in providers)
+            {
+                if (provider.TryGetFactory<TStreamingHub, TReceiver>(out factory))
+                {
+                    return true;
+                }
+            }
+
+            factory = default;
+            return false;
+        }
+    }
+
+    public class DynamicNotSupportedStreamingHubClientFactoryProvider : IStreamingHubClientFactoryProvider
+    {
+        public static IStreamingHubClientFactoryProvider Instance { get; } = new DynamicNotSupportedStreamingHubClientFactoryProvider();
+
+        DynamicNotSupportedStreamingHubClientFactoryProvider() { }
+
+        public bool TryGetFactory<TStreamingHub, TReceiver>(out StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory) where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            throw new InvalidOperationException($"Unable to find a client factory of type '{typeof(TStreamingHub)}'. If the application is running on IL2CPP or AOT, dynamic code generation is not supported. Please use the code generator (moc).");
+        }
+    }
+
+    public class DynamicStreamingHubClientFactoryProvider : IStreamingHubClientFactoryProvider
+    {
+        public static IStreamingHubClientFactoryProvider Instance { get; } = new DynamicStreamingHubClientFactoryProvider();
+
+        DynamicStreamingHubClientFactoryProvider() { }
+
+        public bool TryGetFactory<TStreamingHub, TReceiver>(out StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory) where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            factory = Cache<TStreamingHub, TReceiver>.Factory;
+            return true;
+        }
+
+        static class Cache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            public static readonly StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory
+                = (callInvoker, receiver, host, callOptions, serializerProvider, logger)
+                    => (TStreamingHub)Activator.CreateInstance(DynamicStreamingHubClientBuilder<TStreamingHub, TReceiver>.ClientType, callInvoker, host, callOptions, serializerProvider, logger);
+        }
+    }
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientFactoryProvider.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientFactoryProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70ec2efab29de214babd557dfc0de777
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client/MagicOnionClient.cs
+++ b/src/MagicOnion.Client/MagicOnionClient.cs
@@ -11,37 +11,37 @@ namespace MagicOnion.Client
         public static T Create<T>(ChannelBase channel)
             where T : IService<T>
         {
-            return Create<T>(channel.CreateCallInvoker(), MagicOnionSerializerProvider.Default, emptyFilters);
+            return Create<T>(channel.CreateCallInvoker(), MagicOnionSerializerProvider.Default, emptyFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(ChannelBase channel, IClientFilter[] clientFilters)
             where T : IService<T>
         {
-            return Create<T>(channel.CreateCallInvoker(), MagicOnionSerializerProvider.Default, clientFilters);
+            return Create<T>(channel.CreateCallInvoker(), MagicOnionSerializerProvider.Default, clientFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(ChannelBase channel, IMagicOnionSerializerProvider serializerProvider)
             where T : IService<T>
         {
-            return Create<T>(channel.CreateCallInvoker(), serializerProvider, emptyFilters);
+            return Create<T>(channel.CreateCallInvoker(), serializerProvider, emptyFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(CallInvoker invoker)
             where T : IService<T>
         {
-            return Create<T>(invoker, MagicOnionSerializerProvider.Default, emptyFilters);
+            return Create<T>(invoker, MagicOnionSerializerProvider.Default, emptyFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(CallInvoker invoker, IClientFilter[] clientFilters)
             where T : IService<T>
         {
-            return Create<T>(invoker, MagicOnionSerializerProvider.Default, clientFilters);
+            return Create<T>(invoker, MagicOnionSerializerProvider.Default, clientFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(CallInvoker invoker, IMagicOnionSerializerProvider serializerProvider)
             where T : IService<T>
         {
-            return Create<T>(invoker, serializerProvider, emptyFilters);
+            return Create<T>(invoker, serializerProvider, emptyFilters, MagicOnionClientFactoryProvider.Default);
         }
 
         public static T Create<T>(CallInvoker invoker, IMagicOnionSerializerProvider serializerProvider, IClientFilter[] clientFilters)
@@ -50,37 +50,36 @@ namespace MagicOnion.Client
             if (invoker == null) throw new ArgumentNullException(nameof(invoker));
 
             var clientOptions = new MagicOnionClientOptions(invoker, default, default, clientFilters);
-            return Create<T>(clientOptions, serializerProvider);
+            return Create<T>(clientOptions, serializerProvider, MagicOnionClientFactoryProvider.Default);
+        }
+
+        public static T Create<T>(CallInvoker invoker, IMagicOnionSerializerProvider serializerProvider, IClientFilter[] clientFilters, IMagicOnionClientFactoryProvider clientFactoryProvider)
+            where T : IService<T>
+        {
+            if (invoker == null) throw new ArgumentNullException(nameof(invoker));
+
+            var clientOptions = new MagicOnionClientOptions(invoker, default, default, clientFilters);
+            return Create<T>(clientOptions, serializerProvider, clientFactoryProvider);
         }
 
         public static T Create<T>(MagicOnionClientOptions clientOptions, IMagicOnionSerializerProvider serializerProvider)
             where T : IService<T>
         {
-            var ctor = MagicOnionClientRegistry<T>.constructor;
-            if (ctor == null)
-            {
-#if ((ENABLE_IL2CPP && !UNITY_EDITOR) || NET_STANDARD_2_0)
-                throw new InvalidOperationException($"Unable to find a client factory of type '{typeof(T)}'. If the application is running on IL2CPP or AOT, dynamic code generation is not supported. Please use the code generator (moc).");
-#else
-                var t = MagicOnion.Client.DynamicClient.DynamicClientBuilder<T>.ClientType;
-                return (T)Activator.CreateInstance(t, clientOptions, serializerProvider);
-#endif
-            }
-            else
-            {
-                return ctor(clientOptions, serializerProvider);
-            }
+            return Create<T>(clientOptions, serializerProvider, MagicOnionClientFactoryProvider.Default);
         }
-    }
 
-    public static class MagicOnionClientRegistry<T>
-        where T : IService<T>
-    {
-        internal static Func<MagicOnionClientOptions, IMagicOnionSerializerProvider, T> constructor;
-
-        public static void Register(Func<MagicOnionClientOptions, IMagicOnionSerializerProvider, T> ctor)
+        public static T Create<T>(MagicOnionClientOptions clientOptions, IMagicOnionSerializerProvider serializerProvider, IMagicOnionClientFactoryProvider clientFactoryProvider)
+            where T : IService<T>
         {
-            constructor = ctor;
+            if (serializerProvider is null) throw new ArgumentNullException(nameof(serializerProvider));
+            if (clientFactoryProvider is null) throw new ArgumentNullException(nameof(clientFactoryProvider));
+
+            if (!clientFactoryProvider.TryGetFactory<T>(out var factory))
+            {
+                throw new NotSupportedException($"Unable to get client factory for service type '{typeof(T).FullName}'.");
+            }
+
+            return factory(clientOptions, serializerProvider);
         }
     }
 }

--- a/src/MagicOnion.Client/MagicOnionClientFactoryProvider.cs
+++ b/src/MagicOnion.Client/MagicOnionClientFactoryProvider.cs
@@ -1,0 +1,102 @@
+using MagicOnion.Serialization;
+using System;
+using System.Linq;
+using MagicOnion.Client.DynamicClient;
+
+namespace MagicOnion.Client
+{
+    /// <summary>
+    /// Provides to get a MagicOnionClient factory of the specified service type.
+    /// </summary>
+    public static class MagicOnionClientFactoryProvider
+    {
+        /// <summary>
+        /// Gets or set the MagicOnionClient factory provider to use by default.
+        /// </summary>
+        public static IMagicOnionClientFactoryProvider Default { get; set; }
+#if ((ENABLE_IL2CPP && !UNITY_EDITOR) || NET_STANDARD_2_0)
+            = DynamicNotSupportedMagicOnionClientFactoryProvider.Instance;
+#else
+            = DynamicMagicOnionClientFactoryProvider.Instance;
+#endif
+    }
+
+    public delegate T MagicOnionClientFactoryDelegate<out T>(MagicOnionClientOptions clientOptions, IMagicOnionSerializerProvider serializerProvider) where T : IService<T>;
+
+    /// <summary>
+    /// Provides to get a MagicOnionClient factory of the specified service type.
+    /// </summary>
+    public interface IMagicOnionClientFactoryProvider
+    {
+        /// <summary>
+        /// Gets the MagicOnionClient factory of the specified service type. A return value indicates whether a factory was found or not.
+        /// </summary>
+        /// <typeparam name="T">A MagicOnion service interface type.</typeparam>
+        /// <param name="factory">A MagicOnionClient factory of specified service type.</param>
+        /// <returns>The value indicates whether a factory was found or not.</returns>
+        bool TryGetFactory<T>(out MagicOnionClientFactoryDelegate<T> factory) where T : IService<T>;
+    }
+    
+    public class ImmutableMagicOnionClientFactoryProvider : IMagicOnionClientFactoryProvider
+    {
+        readonly IMagicOnionClientFactoryProvider[] providers;
+
+        public ImmutableMagicOnionClientFactoryProvider(params IMagicOnionClientFactoryProvider[] providers)
+        {
+            this.providers = providers;
+        }
+
+        public ImmutableMagicOnionClientFactoryProvider Add(IMagicOnionClientFactoryProvider provider)
+        {
+            return new ImmutableMagicOnionClientFactoryProvider(providers.Append(provider).ToArray());
+        }
+
+        public bool TryGetFactory<T>(out MagicOnionClientFactoryDelegate<T> factory) where T : IService<T>
+        {
+            foreach (var provider in providers)
+            {
+                if (provider.TryGetFactory<T>(out factory))
+                {
+                    return true;
+                }
+            }
+
+            factory = default;
+            return false;
+        }
+    }
+
+    public class DynamicNotSupportedMagicOnionClientFactoryProvider : IMagicOnionClientFactoryProvider
+    {
+        public static IMagicOnionClientFactoryProvider Instance { get; } = new DynamicNotSupportedMagicOnionClientFactoryProvider();
+
+        DynamicNotSupportedMagicOnionClientFactoryProvider() { }
+
+        public bool TryGetFactory<T>(out MagicOnionClientFactoryDelegate<T> factory) where T : IService<T>
+        {
+            throw new InvalidOperationException($"Unable to find a client factory of type '{typeof(T)}'. If the application is running on IL2CPP or AOT, dynamic code generation is not supported. Please use the code generator (moc).");
+        }
+    }
+
+    /// <summary>
+    /// Provides to get a MagicOnionClient factory of the specified service type. The provider is backed by DynamicMagicOnionClientBuilder.
+    /// </summary>
+    public class DynamicMagicOnionClientFactoryProvider : IMagicOnionClientFactoryProvider
+    {
+        public static IMagicOnionClientFactoryProvider Instance { get; } = new DynamicMagicOnionClientFactoryProvider();
+
+        DynamicMagicOnionClientFactoryProvider() { }
+
+        public bool TryGetFactory<T>(out MagicOnionClientFactoryDelegate<T> factory) where T : IService<T>
+        {
+            factory = Cache<T>.Factory;
+            return true;
+        }
+
+        static class Cache<T> where T : IService<T>
+        {
+            public static readonly MagicOnionClientFactoryDelegate<T> Factory
+                = (clientOptions, serializerProvider) => (T)Activator.CreateInstance(DynamicClientBuilder<T>.ClientType, clientOptions, serializerProvider);
+        }
+    }
+}

--- a/src/MagicOnion.Client/StreamingHubClientFactoryProvider.cs
+++ b/src/MagicOnion.Client/StreamingHubClientFactoryProvider.cs
@@ -1,0 +1,103 @@
+using Grpc.Core;
+using System;
+using System.Linq;
+using MagicOnion.Client.DynamicClient;
+using MagicOnion.Serialization;
+
+namespace MagicOnion.Client
+{
+    /// <summary>
+    /// Provides to get a StreamingHubClient factory of the specified service type.
+    /// </summary>
+    public static class StreamingHubClientFactoryProvider
+    {
+        /// <summary>
+        /// Gets or set the StreamingHubClient factory provider to use by default.
+        /// </summary>
+        public static IStreamingHubClientFactoryProvider Default { get; set; }
+#if ((ENABLE_IL2CPP && !UNITY_EDITOR) || NET_STANDARD_2_0)
+            = DynamicNotSupportedStreamingHubClientFactoryProvider.Instance;
+#else
+            = DynamicStreamingHubClientFactoryProvider.Instance;
+#endif
+    }
+
+    public delegate TStreamingHub StreamingHubClientFactoryDelegate<out TStreamingHub, in TReceiver>(CallInvoker callInvoker, TReceiver receiver, string host, CallOptions callOptions, IMagicOnionSerializerProvider serializerProvider, IMagicOnionClientLogger logger)
+        where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>;
+
+    /// <summary>
+    /// Provides to get a StreamingHubClient factory of the specified service type.
+    /// </summary>
+    public interface IStreamingHubClientFactoryProvider
+    {
+        /// <summary>
+        /// Gets the StreamingHubClient factory of the specified service type. A return value indicates whether a factory was found or not.
+        /// </summary>
+        /// <typeparam name="TStreamingHub">A MagicOnion StreamingHub interface type.</typeparam>
+        /// <typeparam name="TReceiver">A hub receiver interface type.</typeparam>
+        /// <param name="factory">A StreamingHubClient factory of specified service type.</param>
+        /// <returns>The value indicates whether a factory was found or not.</returns>
+        bool TryGetFactory<TStreamingHub, TReceiver>(out StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory) where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>;
+    }
+
+    public class ImmutableStreamingHubClientFactoryProvider : IStreamingHubClientFactoryProvider
+    {
+        readonly IStreamingHubClientFactoryProvider[] providers;
+
+        public ImmutableStreamingHubClientFactoryProvider(params IStreamingHubClientFactoryProvider[] providers)
+        {
+            this.providers = providers;
+        }
+
+        public ImmutableStreamingHubClientFactoryProvider Add(IStreamingHubClientFactoryProvider provider)
+        {
+            return new ImmutableStreamingHubClientFactoryProvider(providers.Append(provider).ToArray());
+        }
+
+        public bool TryGetFactory<TStreamingHub, TReceiver>(out StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory) where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            foreach (var provider in providers)
+            {
+                if (provider.TryGetFactory<TStreamingHub, TReceiver>(out factory))
+                {
+                    return true;
+                }
+            }
+
+            factory = default;
+            return false;
+        }
+    }
+
+    public class DynamicNotSupportedStreamingHubClientFactoryProvider : IStreamingHubClientFactoryProvider
+    {
+        public static IStreamingHubClientFactoryProvider Instance { get; } = new DynamicNotSupportedStreamingHubClientFactoryProvider();
+
+        DynamicNotSupportedStreamingHubClientFactoryProvider() { }
+
+        public bool TryGetFactory<TStreamingHub, TReceiver>(out StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory) where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            throw new InvalidOperationException($"Unable to find a client factory of type '{typeof(TStreamingHub)}'. If the application is running on IL2CPP or AOT, dynamic code generation is not supported. Please use the code generator (moc).");
+        }
+    }
+
+    public class DynamicStreamingHubClientFactoryProvider : IStreamingHubClientFactoryProvider
+    {
+        public static IStreamingHubClientFactoryProvider Instance { get; } = new DynamicStreamingHubClientFactoryProvider();
+
+        DynamicStreamingHubClientFactoryProvider() { }
+
+        public bool TryGetFactory<TStreamingHub, TReceiver>(out StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory) where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            factory = Cache<TStreamingHub, TReceiver>.Factory;
+            return true;
+        }
+
+        static class Cache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            public static readonly StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory
+                = (callInvoker, receiver, host, callOptions, serializerProvider, logger)
+                    => (TStreamingHub)Activator.CreateInstance(DynamicStreamingHubClientBuilder<TStreamingHub, TReceiver>.ClientType, callInvoker, host, callOptions, serializerProvider, logger);
+        }
+    }
+}

--- a/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.cs
+++ b/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.cs
@@ -113,7 +113,7 @@ namespace ");
             }
         }
         
-        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : global::MagicOnion.IStreamingHub<TStreamingHub, TReceiver>
         {
             public readonly static global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory;
 

--- a/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.cs
+++ b/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.cs
@@ -64,31 +64,33 @@ namespace ");
                     ".Client.MagicOnionClientFactoryProvider.Default is global::MagicOnion.Client.Imm" +
                     "utableMagicOnionClientFactoryProvider immutableMagicOnionClientFactoryProvider)\r" +
                     "\n                    ? immutableMagicOnionClientFactoryProvider.Add(MagicOnionGe" +
-                    "neratedClientFactoryProvider.Instance)\r\n                    : new ImmutableMagic" +
-                    "OnionClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);\r\n" +
-                    "\r\n            global::MagicOnion.Client.StreamingHubClientFactoryProvider.Defaul" +
-                    "t =\r\n                (global::MagicOnion.Client.StreamingHubClientFactoryProvide" +
-                    "r.Default is global::MagicOnion.Client.ImmutableStreamingHubClientFactoryProvide" +
-                    "r immutableStreamingHubClientFactoryProvider)\r\n                    ? immutableSt" +
-                    "reamingHubClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Ins" +
-                    "tance)\r\n                    : new ImmutableStreamingHubClientFactoryProvider(Mag" +
-                    "icOnionGeneratedClientFactoryProvider.Instance);\r\n        }\r\n    }\r\n\r\n    public" +
-                    " partial class MagicOnionGeneratedClientFactoryProvider : IMagicOnionClientFacto" +
-                    "ryProvider, IStreamingHubClientFactoryProvider\r\n    {\r\n        public static Mag" +
-                    "icOnionGeneratedClientFactoryProvider Instance { get; } = new MagicOnionGenerate" +
-                    "dClientFactoryProvider();\r\n\r\n        MagicOnionGeneratedClientFactoryProvider() " +
-                    "{}\r\n\r\n        bool IMagicOnionClientFactoryProvider.TryGetFactory<T>(out global:" +
-                    ":MagicOnion.Client.MagicOnionClientFactoryDelegate<T> factory)\r\n            => (" +
-                    "factory = MagicOnionClientFactoryCache<T>.Factory) != null;\r\n\r\n        bool IStr" +
-                    "eamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out globa" +
-                    "l::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>" +
-                    " factory)\r\n            => (factory = StreamingHubClientFactoryCache<TStreamingHu" +
-                    "b, TReceiver>.Factory) != null;\r\n\r\n        static class MagicOnionClientFactoryC" +
-                    "ache<T> where T : global::MagicOnion.IService<T>\r\n        {\r\n            public " +
-                    "readonly static global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> Fac" +
-                    "tory;\r\n\r\n            static MagicOnionClientFactoryCache()\r\n            {\r\n     " +
-                    "           object factory = default(global::MagicOnion.Client.MagicOnionClientFa" +
-                    "ctoryDelegate<T>);\r\n\r\n");
+                    "neratedClientFactoryProvider.Instance)\r\n                    : new global::MagicO" +
+                    "nion.Client.ImmutableMagicOnionClientFactoryProvider(MagicOnionGeneratedClientFa" +
+                    "ctoryProvider.Instance);\r\n\r\n            global::MagicOnion.Client.StreamingHubCl" +
+                    "ientFactoryProvider.Default =\r\n                (global::MagicOnion.Client.Stream" +
+                    "ingHubClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableStream" +
+                    "ingHubClientFactoryProvider immutableStreamingHubClientFactoryProvider)\r\n       " +
+                    "             ? immutableStreamingHubClientFactoryProvider.Add(MagicOnionGenerate" +
+                    "dClientFactoryProvider.Instance)\r\n                    : new global::MagicOnion.C" +
+                    "lient.ImmutableStreamingHubClientFactoryProvider(MagicOnionGeneratedClientFactor" +
+                    "yProvider.Instance);\r\n        }\r\n    }\r\n\r\n    public partial class MagicOnionGen" +
+                    "eratedClientFactoryProvider : global::MagicOnion.Client.IMagicOnionClientFactory" +
+                    "Provider, global::MagicOnion.Client.IStreamingHubClientFactoryProvider\r\n    {\r\n " +
+                    "       public static MagicOnionGeneratedClientFactoryProvider Instance { get; } " +
+                    "= new MagicOnionGeneratedClientFactoryProvider();\r\n\r\n        MagicOnionGenerated" +
+                    "ClientFactoryProvider() {}\r\n\r\n        bool global::MagicOnion.Client.IMagicOnion" +
+                    "ClientFactoryProvider.TryGetFactory<T>(out global::MagicOnion.Client.MagicOnionC" +
+                    "lientFactoryDelegate<T> factory)\r\n            => (factory = MagicOnionClientFact" +
+                    "oryCache<T>.Factory) != null;\r\n\r\n        bool global::MagicOnion.Client.IStreami" +
+                    "ngHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out global::M" +
+                    "agicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> fac" +
+                    "tory)\r\n            => (factory = StreamingHubClientFactoryCache<TStreamingHub, T" +
+                    "Receiver>.Factory) != null;\r\n\r\n        static class MagicOnionClientFactoryCache" +
+                    "<T> where T : global::MagicOnion.IService<T>\r\n        {\r\n            public read" +
+                    "only static global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> Factory" +
+                    ";\r\n\r\n            static MagicOnionClientFactoryCache()\r\n            {\r\n         " +
+                    "       object factory = default(global::MagicOnion.Client.MagicOnionClientFactor" +
+                    "yDelegate<T>);\r\n\r\n");
  foreach(var serviceInfo in Services) { 
  if(serviceInfo.HasIfDirectiveCondition) { 
             this.Write("#if ");

--- a/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.cs
+++ b/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.cs
@@ -58,44 +58,104 @@ namespace ");
                     "tyEngine.RuntimeInitializeLoadType.BeforeSceneLoad)]\r\n#elif NET5_0_OR_GREATER\r\n " +
                     "       [System.Runtime.CompilerServices.ModuleInitializer]\r\n#endif\r\n");
  } 
-            this.Write("        public static void Register()\r\n        {\r\n            if(isRegistered) re" +
-                    "turn;\r\n            isRegistered = true;\r\n\r\n");
+            this.Write("        public static void Register()\r\n        {\r\n            if (isRegistered) r" +
+                    "eturn;\r\n            isRegistered = true;\r\n\r\n            global::MagicOnion.Clien" +
+                    "t.MagicOnionClientFactoryProvider.Default =\r\n                (global::MagicOnion" +
+                    ".Client.MagicOnionClientFactoryProvider.Default is global::MagicOnion.Client.Imm" +
+                    "utableMagicOnionClientFactoryProvider immutableMagicOnionClientFactoryProvider)\r" +
+                    "\n                    ? immutableMagicOnionClientFactoryProvider.Add(MagicOnionGe" +
+                    "neratedClientFactoryProvider.Instance)\r\n                    : new ImmutableMagic" +
+                    "OnionClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);\r\n" +
+                    "\r\n            global::MagicOnion.Client.StreamingHubClientFactoryProvider.Defaul" +
+                    "t =\r\n                (global::MagicOnion.Client.StreamingHubClientFactoryProvide" +
+                    "r.Default is global::MagicOnion.Client.ImmutableStreamingHubClientFactoryProvide" +
+                    "r immutableStreamingHubClientFactoryProvider)\r\n                    ? immutableSt" +
+                    "reamingHubClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Ins" +
+                    "tance)\r\n                    : new ImmutableStreamingHubClientFactoryProvider(Mag" +
+                    "icOnionGeneratedClientFactoryProvider.Instance);\r\n        }\r\n    }\r\n\r\n    public" +
+                    " partial class MagicOnionGeneratedClientFactoryProvider : IMagicOnionClientFacto" +
+                    "ryProvider, IStreamingHubClientFactoryProvider\r\n    {\r\n        public static Mag" +
+                    "icOnionGeneratedClientFactoryProvider Instance { get; } = new MagicOnionGenerate" +
+                    "dClientFactoryProvider();\r\n\r\n        MagicOnionGeneratedClientFactoryProvider() " +
+                    "{}\r\n\r\n        bool IMagicOnionClientFactoryProvider.TryGetFactory<T>(out global:" +
+                    ":MagicOnion.Client.MagicOnionClientFactoryDelegate<T> factory)\r\n            => (" +
+                    "factory = MagicOnionClientFactoryCache<T>.Factory) != null;\r\n\r\n        bool IStr" +
+                    "eamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out globa" +
+                    "l::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>" +
+                    " factory)\r\n            => (factory = StreamingHubClientFactoryCache<TStreamingHu" +
+                    "b, TReceiver>.Factory) != null;\r\n\r\n        static class MagicOnionClientFactoryC" +
+                    "ache<T> where T : global::MagicOnion.IService<T>\r\n        {\r\n            public " +
+                    "readonly static global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> Fac" +
+                    "tory;\r\n\r\n            static MagicOnionClientFactoryCache()\r\n            {\r\n     " +
+                    "           object factory = default(global::MagicOnion.Client.MagicOnionClientFa" +
+                    "ctoryDelegate<T>);\r\n\r\n");
  foreach(var serviceInfo in Services) { 
  if(serviceInfo.HasIfDirectiveCondition) { 
             this.Write("#if ");
             this.Write(this.ToStringHelper.ToStringWithCulture(serviceInfo.IfDirectiveCondition));
             this.Write("\r\n");
  } 
-            this.Write("            MagicOnionClientRegistry<");
+            this.Write("                if (typeof(T) == typeof(");
             this.Write(this.ToStringHelper.ToStringWithCulture(serviceInfo.ServiceType.FullName));
-            this.Write(">.Register((x, y) => new ");
+            this.Write("))\r\n                {\r\n                    factory = ((global::MagicOnion.Client." +
+                    "MagicOnionClientFactoryDelegate<");
+            this.Write(this.ToStringHelper.ToStringWithCulture(serviceInfo.ServiceType.FullName));
+            this.Write(">)((x, y) => new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(serviceInfo.GetClientFullName()));
-            this.Write("(x, y));\r\n");
+            this.Write("(x, y)));\r\n                }\r\n");
  if(serviceInfo.HasIfDirectiveCondition) { 
             this.Write("#endif\r\n");
  } 
  } // foreach 
-            this.Write("\r\n");
+            this.Write(@"                Factory = (global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T>)factory;
+            }
+        }
+        
+        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            public readonly static global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory;
+
+            static StreamingHubClientFactoryCache()
+            {
+                object factory = default(global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>);
+
+");
  foreach(var hubInfo in Hubs) { 
  if(hubInfo.HasIfDirectiveCondition) { 
             this.Write("#if ");
             this.Write(this.ToStringHelper.ToStringWithCulture(hubInfo.IfDirectiveCondition));
             this.Write("\r\n");
  } 
-            this.Write("            StreamingHubClientRegistry<");
+            this.Write("                if (typeof(TStreamingHub) == typeof(");
+            this.Write(this.ToStringHelper.ToStringWithCulture(hubInfo.ServiceType.FullName));
+            this.Write(") && typeof(TReceiver) == typeof(");
+            this.Write(this.ToStringHelper.ToStringWithCulture(hubInfo.Receiver.ReceiverType.FullName));
+            this.Write("))\r\n                {\r\n                    factory = ((global::MagicOnion.Client." +
+                    "StreamingHubClientFactoryDelegate<");
             this.Write(this.ToStringHelper.ToStringWithCulture(hubInfo.ServiceType.FullName));
             this.Write(", ");
             this.Write(this.ToStringHelper.ToStringWithCulture(hubInfo.Receiver.ReceiverType.FullName));
-            this.Write(">.Register((a, _, b, c, d, e) => new ");
+            this.Write(">)((a, _, b, c, d, e) => new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(hubInfo.GetClientFullName()));
-            this.Write("(a, b, c, d, e));\r\n");
+            this.Write("(a, b, c, d, e)));\r\n                }\r\n");
  if(hubInfo.HasIfDirectiveCondition) { 
             this.Write("#endif\r\n");
  } 
  } // foreach 
-            this.Write("        }\r\n    }\r\n}\r\n\r\n#pragma warning restore 168\r\n#pragma warning restore 219\r\n" +
-                    "#pragma warning restore 414\r\n#pragma warning restore 612\r\n#pragma warning restor" +
-                    "e 618\r\n");
+            this.Write(@"
+                Factory = (global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>)factory;
+            }
+        }
+    }
+
+}
+
+#pragma warning restore 168
+#pragma warning restore 219
+#pragma warning restore 414
+#pragma warning restore 612
+#pragma warning restore 618
+");
             return this.GenerationEnvironment.ToString();
         }
     }

--- a/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.tt
+++ b/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.tt
@@ -37,30 +37,83 @@ namespace <#= Namespace #>
 <# } #>
         public static void Register()
         {
-            if(isRegistered) return;
+            if (isRegistered) return;
             isRegistered = true;
+
+            global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default =
+                (global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableMagicOnionClientFactoryProvider immutableMagicOnionClientFactoryProvider)
+                    ? immutableMagicOnionClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
+                    : new ImmutableMagicOnionClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
+
+            global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default =
+                (global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableStreamingHubClientFactoryProvider immutableStreamingHubClientFactoryProvider)
+                    ? immutableStreamingHubClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
+                    : new ImmutableStreamingHubClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
+        }
+    }
+
+    public partial class MagicOnionGeneratedClientFactoryProvider : IMagicOnionClientFactoryProvider, IStreamingHubClientFactoryProvider
+    {
+        public static MagicOnionGeneratedClientFactoryProvider Instance { get; } = new MagicOnionGeneratedClientFactoryProvider();
+
+        MagicOnionGeneratedClientFactoryProvider() {}
+
+        bool IMagicOnionClientFactoryProvider.TryGetFactory<T>(out global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> factory)
+            => (factory = MagicOnionClientFactoryCache<T>.Factory) != null;
+
+        bool IStreamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory)
+            => (factory = StreamingHubClientFactoryCache<TStreamingHub, TReceiver>.Factory) != null;
+
+        static class MagicOnionClientFactoryCache<T> where T : global::MagicOnion.IService<T>
+        {
+            public readonly static global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> Factory;
+
+            static MagicOnionClientFactoryCache()
+            {
+                object factory = default(global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T>);
 
 <# foreach(var serviceInfo in Services) { #>
 <# if(serviceInfo.HasIfDirectiveCondition) { #>
 #if <#= serviceInfo.IfDirectiveCondition #>
 <# } #>
-            MagicOnionClientRegistry<<#= serviceInfo.ServiceType.FullName #>>.Register((x, y) => new <#= serviceInfo.GetClientFullName() #>(x, y));
+                if (typeof(T) == typeof(<#= serviceInfo.ServiceType.FullName #>))
+                {
+                    factory = ((global::MagicOnion.Client.MagicOnionClientFactoryDelegate<<#= serviceInfo.ServiceType.FullName #>>)((x, y) => new <#= serviceInfo.GetClientFullName() #>(x, y)));
+                }
 <# if(serviceInfo.HasIfDirectiveCondition) { #>
 #endif
 <# } #>
 <# } // foreach #>
+                Factory = (global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T>)factory;
+            }
+        }
+        
+        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            public readonly static global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory;
+
+            static StreamingHubClientFactoryCache()
+            {
+                object factory = default(global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>);
 
 <# foreach(var hubInfo in Hubs) { #>
 <# if(hubInfo.HasIfDirectiveCondition) { #>
 #if <#= hubInfo.IfDirectiveCondition #>
 <# } #>
-            StreamingHubClientRegistry<<#= hubInfo.ServiceType.FullName #>, <#= hubInfo.Receiver.ReceiverType.FullName #>>.Register((a, _, b, c, d, e) => new <#= hubInfo.GetClientFullName() #>(a, b, c, d, e));
+                if (typeof(TStreamingHub) == typeof(<#= hubInfo.ServiceType.FullName #>) && typeof(TReceiver) == typeof(<#= hubInfo.Receiver.ReceiverType.FullName #>))
+                {
+                    factory = ((global::MagicOnion.Client.StreamingHubClientFactoryDelegate<<#= hubInfo.ServiceType.FullName #>, <#= hubInfo.Receiver.ReceiverType.FullName #>>)((a, _, b, c, d, e) => new <#= hubInfo.GetClientFullName() #>(a, b, c, d, e)));
+                }
 <# if(hubInfo.HasIfDirectiveCondition) { #>
 #endif
 <# } #>
 <# } // foreach #>
+
+                Factory = (global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>)factory;
+            }
         }
     }
+
 }
 
 #pragma warning restore 168

--- a/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.tt
+++ b/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.tt
@@ -43,25 +43,25 @@ namespace <#= Namespace #>
             global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default =
                 (global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableMagicOnionClientFactoryProvider immutableMagicOnionClientFactoryProvider)
                     ? immutableMagicOnionClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
-                    : new ImmutableMagicOnionClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
+                    : new global::MagicOnion.Client.ImmutableMagicOnionClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
 
             global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default =
                 (global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableStreamingHubClientFactoryProvider immutableStreamingHubClientFactoryProvider)
                     ? immutableStreamingHubClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
-                    : new ImmutableStreamingHubClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
+                    : new global::MagicOnion.Client.ImmutableStreamingHubClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
         }
     }
 
-    public partial class MagicOnionGeneratedClientFactoryProvider : IMagicOnionClientFactoryProvider, IStreamingHubClientFactoryProvider
+    public partial class MagicOnionGeneratedClientFactoryProvider : global::MagicOnion.Client.IMagicOnionClientFactoryProvider, global::MagicOnion.Client.IStreamingHubClientFactoryProvider
     {
         public static MagicOnionGeneratedClientFactoryProvider Instance { get; } = new MagicOnionGeneratedClientFactoryProvider();
 
         MagicOnionGeneratedClientFactoryProvider() {}
 
-        bool IMagicOnionClientFactoryProvider.TryGetFactory<T>(out global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> factory)
+        bool global::MagicOnion.Client.IMagicOnionClientFactoryProvider.TryGetFactory<T>(out global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> factory)
             => (factory = MagicOnionClientFactoryCache<T>.Factory) != null;
 
-        bool IStreamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory)
+        bool global::MagicOnion.Client.IStreamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory)
             => (factory = StreamingHubClientFactoryCache<TStreamingHub, TReceiver>.Factory) != null;
 
         static class MagicOnionClientFactoryCache<T> where T : global::MagicOnion.IService<T>

--- a/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.tt
+++ b/src/MagicOnion.GeneratorCore/CodeGen/RegisterTemplate.tt
@@ -88,7 +88,7 @@ namespace <#= Namespace #>
             }
         }
         
-        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : global::MagicOnion.IStreamingHub<TStreamingHub, TReceiver>
         {
             public readonly static global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory;
 

--- a/tests/MagicOnion.Integration.Tests/DynamicArgumentTupleTest.cs
+++ b/tests/MagicOnion.Integration.Tests/DynamicArgumentTupleTest.cs
@@ -3,6 +3,7 @@ using Grpc.Net.Client;
 using MagicOnion.Server;
 using Xunit.Abstractions;
 using MagicOnion.Serialization;
+using MagicOnion.Integration.Tests.Generated;
 
 namespace MagicOnion.Integration.Tests;
 
@@ -17,16 +18,16 @@ public class DynamicArgumentTupleServiceTest : IClassFixture<MagicOnionApplicati
 
     public static IEnumerable<object[]> EnumerateMagicOnionClientFactory()
     {
-        yield return new [] { new TestMagicOnionClientFactory<IDynamicArgumentTupleService>("Dynamic", x => MagicOnionClient.Create<IDynamicArgumentTupleService>(x, MagicOnionSerializerProvider.Default)) };
-        yield return new [] { new TestMagicOnionClientFactory<IDynamicArgumentTupleService>("Generated", x => new DynamicArgumentTupleServiceClient(x, MagicOnionSerializerProvider.Default)) };
+        yield return new [] { new TestMagicOnionClientFactory("Dynamic", DynamicMagicOnionClientFactoryProvider.Instance) };
+        yield return new [] { new TestMagicOnionClientFactory("Generated", MagicOnionGeneratedClientFactoryProvider.Instance) };
     }
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task Unary1(TestMagicOnionClientFactory<IDynamicArgumentTupleService> clientFactory)
+    public async Task Unary1(TestMagicOnionClientFactory clientFactory)
     {
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel);
+        var client = clientFactory.Create<IDynamicArgumentTupleService>(channel);
         var result  = await client.Unary1(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         result.Should().Be(120);
     }

--- a/tests/MagicOnion.Integration.Tests/MemoryPack/MemoryPackSerializerStreamingHubTest.cs
+++ b/tests/MagicOnion.Integration.Tests/MemoryPack/MemoryPackSerializerStreamingHubTest.cs
@@ -1,5 +1,6 @@
 using Grpc.Net.Client;
 using MagicOnion.Client;
+using MagicOnion.Integration.Tests.Generated;
 using MagicOnion.Server.Hubs;
 using MagicOnionTestServer;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -20,23 +21,18 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
 
     public static IEnumerable<object[]> EnumerateStreamingHubClientFactory()
     {
-        yield return new[] { new TestStreamingHubClientFactory<IMemoryPackSerializerTestHub, IMemoryPackSerializerTestHubReceiver>("Dynamic", (callInvoker, receiver, serializerProvider) => StreamingHubClient.ConnectAsync<IMemoryPackSerializerTestHub, IMemoryPackSerializerTestHubReceiver>(callInvoker, receiver, serializerProvider: serializerProvider)) };
-        yield return new[] { new TestStreamingHubClientFactory<IMemoryPackSerializerTestHub, IMemoryPackSerializerTestHubReceiver>("Static", async (callInvoker, receiver, serializerProvider) =>
-        {
-            var client = new MemoryPackSerializerTestHubClient(callInvoker, string.Empty, new CallOptions(), serializerProvider ?? MemoryPackMagicOnionSerializerProvider.Instance, NullMagicOnionClientLogger.Instance);
-            await client.__ConnectAndSubscribeAsync(receiver, default);
-            return client;
-        })};
+        yield return new [] { new TestStreamingHubClientFactory("Dynamic", DynamicStreamingHubClientFactoryProvider.Instance) };
+        yield return new [] { new TestStreamingHubClientFactory("Static", MagicOnionGeneratedClientFactoryProvider.Instance)};
     }
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task StreamingHub_Parameterless(TestStreamingHubClientFactory<IMemoryPackSerializerTestHub, IMemoryPackSerializerTestHubReceiver> clientFactory)
+    public async Task StreamingHub_Parameterless(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
         var receiver = new Receiver();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver, messageSerializer: MemoryPackMagicOnionSerializerProvider.Instance);
+        var client = await clientFactory.CreateAndConnectAsync<IMemoryPackSerializerTestHub, IMemoryPackSerializerTestHubReceiver>(channel, receiver, serializerProvider: MemoryPackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result = await client.MethodParameterless();
@@ -47,12 +43,12 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task StreamingHub_Parameter_One(TestStreamingHubClientFactory<IMemoryPackSerializerTestHub, IMemoryPackSerializerTestHubReceiver> clientFactory)
+    public async Task StreamingHub_Parameter_One(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
         var receiver = new Receiver();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver, messageSerializer: MemoryPackMagicOnionSerializerProvider.Instance);
+        var client = await clientFactory.CreateAndConnectAsync<IMemoryPackSerializerTestHub, IMemoryPackSerializerTestHubReceiver>(channel, receiver, serializerProvider: MemoryPackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result = await client.MethodParameter_One(12345);
@@ -63,12 +59,12 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task StreamingHub_Parameter_Many(TestStreamingHubClientFactory<IMemoryPackSerializerTestHub, IMemoryPackSerializerTestHubReceiver> clientFactory)
+    public async Task StreamingHub_Parameter_Many(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
         var receiver = new Receiver();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver, messageSerializer: MemoryPackMagicOnionSerializerProvider.Instance);
+        var client = await clientFactory.CreateAndConnectAsync<IMemoryPackSerializerTestHub, IMemoryPackSerializerTestHubReceiver>(channel, receiver, serializerProvider: MemoryPackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result = await client.MethodParameter_Many(12345, "6789");
@@ -79,12 +75,12 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task StreamingHub_Callback(TestStreamingHubClientFactory<IMemoryPackSerializerTestHub, IMemoryPackSerializerTestHubReceiver> clientFactory)
+    public async Task StreamingHub_Callback(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
         var receiver = new Receiver();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver, messageSerializer: MemoryPackMagicOnionSerializerProvider.Instance);
+        var client = await clientFactory.CreateAndConnectAsync<IMemoryPackSerializerTestHub, IMemoryPackSerializerTestHubReceiver>(channel, receiver, serializerProvider: MemoryPackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result = await client.Callback(12345, "6789");

--- a/tests/MagicOnion.Integration.Tests/MemoryPack/MemoryPackSerializerUnaryTest.cs
+++ b/tests/MagicOnion.Integration.Tests/MemoryPack/MemoryPackSerializerUnaryTest.cs
@@ -1,5 +1,6 @@
 using Grpc.Net.Client;
 using MagicOnion.Client;
+using MagicOnion.Integration.Tests.Generated;
 using MagicOnion.Serialization;
 using MagicOnion.Server;
 using MagicOnionTestServer;
@@ -23,17 +24,17 @@ public class MemoryPackSerializerUnaryTest : IClassFixture<MagicOnionApplication
 
     public static IEnumerable<object[]> EnumerateMagicOnionClientFactory()
     {
-        yield return new[] { new TestMagicOnionClientFactory<IMemoryPackSerializerTestService>("Dynamic", (x, messageSerializer) => MagicOnionClient.Create<IMemoryPackSerializerTestService>(x, messageSerializer)) };
-        yield return new[] { new TestMagicOnionClientFactory<IMemoryPackSerializerTestService>("Generated", (x, messageSerializer) => new MemoryPackSerializerTestServiceClient(x, messageSerializer ?? MessagePackMagicOnionSerializerProvider.Default)) };
+        yield return new [] { new TestMagicOnionClientFactory("Dynamic", DynamicMagicOnionClientFactoryProvider.Instance) };
+        yield return new [] { new TestMagicOnionClientFactory("Generated", MagicOnionGeneratedClientFactoryProvider.Instance) };
     }
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task Unary_Incompatible(TestMagicOnionClientFactory<IMemoryPackSerializerTestService> clientFactory)
+    public async Task Unary_Incompatible(TestMagicOnionClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel, MessagePackMagicOnionSerializerProvider.Default); // Use MagicOnionMessagePackMessageSerializer by client. but the server still use XorMagicOnionMessagePackSerializer.
+        var client = clientFactory.Create<IMemoryPackSerializerTestService>(channel, MessagePackMagicOnionSerializerProvider.Default); // Use MagicOnionMessagePackMessageSerializer by client. but the server still use XorMagicOnionMessagePackSerializer.
 
         // Act
         var result = Record.ExceptionAsync(async () => await client.UnaryReturnNil());
@@ -44,11 +45,11 @@ public class MemoryPackSerializerUnaryTest : IClassFixture<MagicOnionApplication
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task Unary_ReturnNil(TestMagicOnionClientFactory<IMemoryPackSerializerTestService> clientFactory)
+    public async Task Unary_ReturnNil(TestMagicOnionClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel, MemoryPackMagicOnionSerializerProvider.Instance);
+        var client = clientFactory.Create<IMemoryPackSerializerTestService>(channel, MemoryPackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result = await client.UnaryReturnNil();
@@ -59,11 +60,11 @@ public class MemoryPackSerializerUnaryTest : IClassFixture<MagicOnionApplication
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task Unary_Parameterless(TestMagicOnionClientFactory<IMemoryPackSerializerTestService> clientFactory)
+    public async Task Unary_Parameterless(TestMagicOnionClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel, MemoryPackMagicOnionSerializerProvider.Instance);
+        var client = clientFactory.Create<IMemoryPackSerializerTestService>(channel, MemoryPackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result = await client.UnaryParameterless();
@@ -74,11 +75,11 @@ public class MemoryPackSerializerUnaryTest : IClassFixture<MagicOnionApplication
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task Unary_Parameter_Many(TestMagicOnionClientFactory<IMemoryPackSerializerTestService> clientFactory)
+    public async Task Unary_Parameter_Many(TestMagicOnionClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel, MemoryPackMagicOnionSerializerProvider.Instance);
+        var client = clientFactory.Create<IMemoryPackSerializerTestService>(channel, MemoryPackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result = await client.Unary1(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, "15");

--- a/tests/MagicOnion.Integration.Tests/SerializerStreamingHubTest.cs
+++ b/tests/MagicOnion.Integration.Tests/SerializerStreamingHubTest.cs
@@ -1,5 +1,6 @@
 using Grpc.Net.Client;
 using MagicOnion.Client;
+using MagicOnion.Integration.Tests.Generated;
 using MagicOnion.Serialization;
 using MagicOnion.Server.Hubs;
 using MagicOnionTestServer;
@@ -21,23 +22,18 @@ public class SerializerStreamingHubTest : IClassFixture<MagicOnionApplicationFac
 
     public static IEnumerable<object[]> EnumerateStreamingHubClientFactory()
     {
-        yield return new [] { new TestStreamingHubClientFactory<ISerializerTestHub, ISerializerTestHubReceiver>("Dynamic", (callInvoker, receiver, serializerProvider) => StreamingHubClient.ConnectAsync<ISerializerTestHub, ISerializerTestHubReceiver>(callInvoker, receiver, serializerProvider: serializerProvider)) };
-        yield return new [] { new TestStreamingHubClientFactory<ISerializerTestHub, ISerializerTestHubReceiver>("Static", async (callInvoker, receiver, serializerProvider) =>
-        {
-            var client = new SerializerTestHubClient(callInvoker, string.Empty, new CallOptions(), serializerProvider ?? MagicOnionSerializerProvider.Default, NullMagicOnionClientLogger.Instance);
-            await client.__ConnectAndSubscribeAsync(receiver, default);
-            return client;
-        })};
+        yield return new [] { new TestStreamingHubClientFactory("Dynamic", DynamicStreamingHubClientFactoryProvider.Instance) };
+        yield return new [] { new TestStreamingHubClientFactory("Static", MagicOnionGeneratedClientFactoryProvider.Instance)};
     }
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task StreamingHub_Parameterless(TestStreamingHubClientFactory<ISerializerTestHub, ISerializerTestHubReceiver> clientFactory)
+    public async Task StreamingHub_Parameterless(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
         var receiver = new Receiver();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver, messageSerializer: XorMessagePackMagicOnionSerializerProvider.Instance);
+        var client = await clientFactory.CreateAndConnectAsync<ISerializerTestHub, ISerializerTestHubReceiver>(channel, receiver, serializerProvider: XorMessagePackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result  = await client.MethodParameterless();
@@ -48,12 +44,12 @@ public class SerializerStreamingHubTest : IClassFixture<MagicOnionApplicationFac
     
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task StreamingHub_Parameter_One(TestStreamingHubClientFactory<ISerializerTestHub, ISerializerTestHubReceiver> clientFactory)
+    public async Task StreamingHub_Parameter_One(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
         var receiver = new Receiver();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver, messageSerializer: XorMessagePackMagicOnionSerializerProvider.Instance);
+        var client = await clientFactory.CreateAndConnectAsync<ISerializerTestHub, ISerializerTestHubReceiver>(channel, receiver, serializerProvider: XorMessagePackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result  = await client.MethodParameter_One(12345);
@@ -64,12 +60,12 @@ public class SerializerStreamingHubTest : IClassFixture<MagicOnionApplicationFac
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task StreamingHub_Parameter_Many(TestStreamingHubClientFactory<ISerializerTestHub, ISerializerTestHubReceiver> clientFactory)
+    public async Task StreamingHub_Parameter_Many(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
         var receiver = new Receiver();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver, messageSerializer: XorMessagePackMagicOnionSerializerProvider.Instance);
+        var client = await clientFactory.CreateAndConnectAsync<ISerializerTestHub, ISerializerTestHubReceiver>(channel, receiver, serializerProvider: XorMessagePackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result  = await client.MethodParameter_Many(12345, "6789");
@@ -80,12 +76,12 @@ public class SerializerStreamingHubTest : IClassFixture<MagicOnionApplicationFac
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task StreamingHub_Callback(TestStreamingHubClientFactory<ISerializerTestHub, ISerializerTestHubReceiver> clientFactory)
+    public async Task StreamingHub_Callback(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
         var receiver = new Receiver();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver, messageSerializer: XorMessagePackMagicOnionSerializerProvider.Instance);
+        var client = await clientFactory.CreateAndConnectAsync<ISerializerTestHub, ISerializerTestHubReceiver>(channel, receiver, serializerProvider: XorMessagePackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result  = await client.Callback(12345, "6789");

--- a/tests/MagicOnion.Integration.Tests/SerializerUnaryTest.cs
+++ b/tests/MagicOnion.Integration.Tests/SerializerUnaryTest.cs
@@ -1,5 +1,6 @@
 using Grpc.Net.Client;
 using MagicOnion.Client;
+using MagicOnion.Integration.Tests.Generated;
 using MagicOnion.Serialization;
 using MagicOnion.Server;
 using MagicOnionTestServer;
@@ -23,17 +24,17 @@ public class SerializerUnaryTest : IClassFixture<MagicOnionApplicationFactory<Se
     
     public static IEnumerable<object[]> EnumerateMagicOnionClientFactory()
     {
-        yield return new [] { new TestMagicOnionClientFactory<ISerializerTestService>("Dynamic", (x, messageSerializer) => MagicOnionClient.Create<ISerializerTestService>(x, messageSerializer)) };
-        yield return new [] { new TestMagicOnionClientFactory<ISerializerTestService>("Generated", (x, messageSerializer) => new SerializerTestServiceClient(x, messageSerializer ?? MessagePackMagicOnionSerializerProvider.Default)) };
+        yield return new [] { new TestMagicOnionClientFactory("Dynamic", DynamicMagicOnionClientFactoryProvider.Instance) };
+        yield return new [] { new TestMagicOnionClientFactory("Generated", MagicOnionGeneratedClientFactoryProvider.Instance) };
     }
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task Unary_Incompatible(TestMagicOnionClientFactory<ISerializerTestService> clientFactory)
+    public async Task Unary_Incompatible(TestMagicOnionClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel, MessagePackMagicOnionSerializerProvider.Default); // Use MagicOnionMessagePackMessageSerializer by client. but the server still use XorMagicOnionMessagePackSerializer.
+        var client = clientFactory.Create<ISerializerTestService>(channel, MessagePackMagicOnionSerializerProvider.Default); // Use MagicOnionMessagePackMessageSerializer by client. but the server still use XorMagicOnionMessagePackSerializer.
 
         // Act
         var result  = Record.ExceptionAsync(async () => await client.UnaryReturnNil());
@@ -44,11 +45,11 @@ public class SerializerUnaryTest : IClassFixture<MagicOnionApplicationFactory<Se
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task Unary_ReturnNil(TestMagicOnionClientFactory<ISerializerTestService> clientFactory)
+    public async Task Unary_ReturnNil(TestMagicOnionClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel, XorMessagePackMagicOnionSerializerProvider.Instance);
+        var client = clientFactory.Create<ISerializerTestService>(channel, XorMessagePackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result  = await client.UnaryReturnNil();
@@ -59,11 +60,11 @@ public class SerializerUnaryTest : IClassFixture<MagicOnionApplicationFactory<Se
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task Unary_Parameterless(TestMagicOnionClientFactory<ISerializerTestService> clientFactory)
+    public async Task Unary_Parameterless(TestMagicOnionClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel, XorMessagePackMagicOnionSerializerProvider.Instance);
+        var client = clientFactory.Create<ISerializerTestService>(channel, XorMessagePackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result  = await client.UnaryParameterless();
@@ -74,11 +75,11 @@ public class SerializerUnaryTest : IClassFixture<MagicOnionApplicationFactory<Se
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task Unary_Parameter_Many(TestMagicOnionClientFactory<ISerializerTestService> clientFactory)
+    public async Task Unary_Parameter_Many(TestMagicOnionClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel, XorMessagePackMagicOnionSerializerProvider.Instance);
+        var client = clientFactory.Create<ISerializerTestService>(channel, XorMessagePackMagicOnionSerializerProvider.Instance);
 
         // Act
         var result  = await client.Unary1(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);

--- a/tests/MagicOnion.Integration.Tests/StreamingHubTest.cs
+++ b/tests/MagicOnion.Integration.Tests/StreamingHubTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using Grpc.Net.Client;
 using MagicOnion.Client;
+using MagicOnion.Integration.Tests.Generated;
 using MagicOnion.Serialization;
 using MagicOnion.Server.Hubs;
 
@@ -18,25 +19,20 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     public static IEnumerable<object[]> EnumerateStreamingHubClientFactory()
     {
-        yield return new [] { new TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver>("Dynamic", (callInvoker, receiver, serializerProvider) => StreamingHubClient.ConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(callInvoker, receiver, serializerProvider: serializerProvider)) };
-        yield return new [] { new TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver>("Static", async (callInvoker, receiver, serializerProvider) =>
-        {
-            var client = new StreamingHubTestHubClient(callInvoker, string.Empty, new CallOptions(), serializerProvider ?? MagicOnionSerializerProvider.Default, NullMagicOnionClientLogger.Instance);
-            await client.__ConnectAndSubscribeAsync(receiver, default);
-            return client;
-        })};
+        yield return new [] { new TestStreamingHubClientFactory("Dynamic", DynamicStreamingHubClientFactoryProvider.Instance) };
+        yield return new [] { new TestStreamingHubClientFactory("Static", MagicOnionGeneratedClientFactoryProvider.Instance)};
     }
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task NoReturn_Parameter_Zero(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task NoReturn_Parameter_Zero(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act & Assert
         await client.NoReturn_Parameter_Zero();
@@ -44,14 +40,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task NoReturn_Parameter_One(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task NoReturn_Parameter_One(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act & Assert
         await client.NoReturn_Parameter_One(12345);
@@ -60,14 +56,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
     
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task NoReturn_Parameter_Many(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task NoReturn_Parameter_Many(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act & Assert
         await client.NoReturn_Parameter_Many(12345, "Hello✨", true);
@@ -75,14 +71,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
     
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task Parameter_Zero(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task Parameter_Zero(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act
         var result = await client.Parameter_Zero();
@@ -93,14 +89,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task Parameter_One(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task Parameter_One(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act
         var result = await client.Parameter_One(12345);
@@ -111,14 +107,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task Parameter_Many(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task Parameter_Many(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act
         var result = await client.Parameter_Many(12345, "Hello✨", true);
@@ -129,14 +125,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task ValueTask_NoReturn_Parameter_Zero(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task ValueTask_NoReturn_Parameter_Zero(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act & Assert
         await client.ValueTask_NoReturn_Parameter_Zero();
@@ -144,14 +140,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task ValueTask_NoReturn_Parameter_One(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task ValueTask_NoReturn_Parameter_One(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act & Assert
         await client.ValueTask_NoReturn_Parameter_One(12345);
@@ -160,14 +156,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
     
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task ValueTask_NoReturn_Parameter_Many(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task ValueTask_NoReturn_Parameter_Many(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act & Assert
         await client.ValueTask_NoReturn_Parameter_Many(12345, "Hello✨", true);
@@ -175,14 +171,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
     
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task ValueTask_Parameter_Zero(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task ValueTask_Parameter_Zero(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act
         var result = await client.ValueTask_Parameter_Zero();
@@ -193,14 +189,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task ValueTask_Parameter_One(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task ValueTask_Parameter_One(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act
         var result = await client.ValueTask_Parameter_One(12345);
@@ -211,14 +207,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task ValueTask_Parameter_Many(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task ValueTask_Parameter_Many(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act
         var result = await client.ValueTask_Parameter_Many(12345, "Hello✨", true);
@@ -229,14 +225,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task Receiver_Parameter_Zero(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task Receiver_Parameter_Zero(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act
         await client.CallReceiver_Parameter_Zero();
@@ -248,14 +244,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task Receiver_Parameter_One(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task Receiver_Parameter_One(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act
         await client.CallReceiver_Parameter_One(12345);
@@ -267,14 +263,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task Receiver_Parameter_Many(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task Receiver_Parameter_Many(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
 
         // Act
         await client.CallReceiver_Parameter_Many(12345, "Hello✨", true);
@@ -286,14 +282,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task Forget_NoReturnValue(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task Forget_NoReturnValue(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
         client = client.FireAndForget(); // Use FireAndForget client
 
         // Act
@@ -302,14 +298,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task Forget_WithReturnValue(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task Forget_WithReturnValue(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
         client = client.FireAndForget(); // Use FireAndForget client
 
         // Act
@@ -321,14 +317,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task ValueTask_Forget_NoReturnValue(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task ValueTask_Forget_NoReturnValue(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
         client = client.FireAndForget(); // Use FireAndForget client
 
         // Act
@@ -337,14 +333,14 @@ public class StreamingHubTest : IClassFixture<MagicOnionApplicationFactory<Strea
 
     [Theory]
     [MemberData(nameof(EnumerateStreamingHubClientFactory))]
-    public async Task ValueTask_Forget_WithReturnValue(TestStreamingHubClientFactory<IStreamingHubTestHub, IStreamingHubTestHubReceiver> clientFactory)
+    public async Task ValueTask_Forget_WithReturnValue(TestStreamingHubClientFactory clientFactory)
     {
         // Arrange
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient });
 
         var receiver = new Mock<IStreamingHubTestHubReceiver>();
-        var client = await clientFactory.CreateAndConnectAsync(channel, receiver.Object);
+        var client = await clientFactory.CreateAndConnectAsync<IStreamingHubTestHub, IStreamingHubTestHubReceiver>(channel, receiver.Object);
         client = client.FireAndForget(); // Use FireAndForget client
 
         // Act

--- a/tests/MagicOnion.Integration.Tests/StreamingServiceTest.cs
+++ b/tests/MagicOnion.Integration.Tests/StreamingServiceTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using MagicOnion.Client;
+using MagicOnion.Integration.Tests.Generated;
 using MagicOnion.Server;
 using MagicOnion.Serialization;
 
@@ -21,17 +22,17 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
 
     public static IEnumerable<object[]> EnumerateMagicOnionClientFactory()
     {
-        yield return new [] { new TestMagicOnionClientFactory<IStreamingTestService>("Dynamic", x => MagicOnionClient.Create<IStreamingTestService>(x, MagicOnionSerializerProvider.Default)) };
-        yield return new [] { new TestMagicOnionClientFactory<IStreamingTestService>("Generated", x => new StreamingTestServiceClient(x, MagicOnionSerializerProvider.Default)) };
+        yield return new [] { new TestMagicOnionClientFactory("Dynamic", DynamicMagicOnionClientFactoryProvider.Instance) };
+        yield return new [] { new TestMagicOnionClientFactory("Generated", MagicOnionGeneratedClientFactoryProvider.Instance) };
     }
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task ClientStreaming_1(TestMagicOnionClientFactory<IStreamingTestService> clientFactory)
+    public async Task ClientStreaming_1(TestMagicOnionClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel);
+        var client = clientFactory.Create<IStreamingTestService>(channel);
         var result  = await client.ClientStreaming();
 
         // Act
@@ -46,11 +47,11 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task ServerStreaming_1(TestMagicOnionClientFactory<IStreamingTestService> clientFactory)
+    public async Task ServerStreaming_1(TestMagicOnionClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel);
+        var client = clientFactory.Create<IStreamingTestService>(channel);
         var result  = await client.ServerStreaming(123, 456);
 
         // Act
@@ -66,11 +67,11 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task DuplexStreaming_1(TestMagicOnionClientFactory<IStreamingTestService> clientFactory)
+    public async Task DuplexStreaming_1(TestMagicOnionClientFactory clientFactory)
     {
         // Arrange
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel);
+        var client = clientFactory.Create<IStreamingTestService>(channel);
         var result  = await client.DuplexStreaming();
 
         // Act

--- a/tests/MagicOnion.Integration.Tests/TestMagicOnionClientFactory.cs
+++ b/tests/MagicOnion.Integration.Tests/TestMagicOnionClientFactory.cs
@@ -3,16 +3,12 @@ using MagicOnion.Serialization;
 
 namespace MagicOnion.Integration.Tests;
 
-public record TestMagicOnionClientFactory<T>(string Name, Func<MagicOnionClientOptions, IMagicOnionSerializerProvider?, T> FactoryMethod)
+public record TestMagicOnionClientFactory(string Name, IMagicOnionClientFactoryProvider FactoryProvider)
 {
-    public TestMagicOnionClientFactory(string name, Func<MagicOnionClientOptions, T> factoryMethod)
-        : this(name, (x, _) => factoryMethod(x))
-    { }
-
     public override string ToString() => Name;
 
-    public T Create(ChannelBase channelBase, IMagicOnionSerializerProvider? messageSerializer = default)
-        => Create(channelBase, Array.Empty<IClientFilter>(), messageSerializer);
-    public T Create(ChannelBase channelBase, IEnumerable<IClientFilter> filters, IMagicOnionSerializerProvider? messageSerializer = default)
-        => FactoryMethod(new MagicOnionClientOptions(channelBase.CreateCallInvoker(), string.Empty, new CallOptions(), filters.ToArray()), messageSerializer);
+    public T Create<T>(ChannelBase channelBase, IMagicOnionSerializerProvider? messageSerializer = default) where T : IService<T>
+        => Create<T>(channelBase, Array.Empty<IClientFilter>(), messageSerializer);
+    public T Create<T>(ChannelBase channelBase, IEnumerable<IClientFilter> filters, IMagicOnionSerializerProvider? messageSerializer = default) where T : IService<T>
+        => MagicOnionClient.Create<T>(new MagicOnionClientOptions(channelBase.CreateCallInvoker(), string.Empty, new CallOptions(), filters.ToArray()), messageSerializer ?? MagicOnionSerializerProvider.Default, FactoryProvider);
 }

--- a/tests/MagicOnion.Integration.Tests/TestStreamingHubClientFactory.cs
+++ b/tests/MagicOnion.Integration.Tests/TestStreamingHubClientFactory.cs
@@ -1,10 +1,12 @@
+using MagicOnion.Client;
 using MagicOnion.Serialization;
 
 namespace MagicOnion.Integration.Tests;
 
-public record TestStreamingHubClientFactory<T, TReceiver>(string Name, Func<CallInvoker, TReceiver, IMagicOnionSerializerProvider?, Task<T>> FactoryMethod)
+public record TestStreamingHubClientFactory(string Name, IStreamingHubClientFactoryProvider FactoryProvider)
 {
     public override string ToString() => Name;
-    public Task<T> CreateAndConnectAsync(ChannelBase channelBase, TReceiver receiver, IMagicOnionSerializerProvider? messageSerializer = default)
-        => FactoryMethod(channelBase.CreateCallInvoker(), receiver, messageSerializer);
+    public Task<T> CreateAndConnectAsync<T, TReceiver>(ChannelBase channelBase, TReceiver receiver, IMagicOnionSerializerProvider? serializerProvider = default)
+        where T : IStreamingHub<T, TReceiver>
+        => StreamingHubClient.ConnectAsync<T, TReceiver>(channelBase.CreateCallInvoker(), receiver, serializerProvider: serializerProvider, factoryProvider: FactoryProvider);
 }

--- a/tests/MagicOnion.Integration.Tests/UnaryServiceTest.cs
+++ b/tests/MagicOnion.Integration.Tests/UnaryServiceTest.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using MagicOnion.Client;
 using MagicOnion.Server;
+using MagicOnion.Integration.Tests.Generated;
 
 namespace MagicOnion.Integration.Tests;
 
@@ -21,16 +22,16 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
 
     public static IEnumerable<object[]> EnumerateMagicOnionClientFactory()
     {
-        yield return new [] { new TestMagicOnionClientFactory<IUnaryService>("Dynamic", x => MagicOnionClient.Create<IUnaryService>(x, MagicOnionSerializerProvider.Default)) };
-        yield return new [] { new TestMagicOnionClientFactory<IUnaryService>("Generated", x => new UnaryServiceClient(x, MagicOnionSerializerProvider.Default)) };
+        yield return new [] { new TestMagicOnionClientFactory("Dynamic", DynamicMagicOnionClientFactoryProvider.Instance) };
+        yield return new [] { new TestMagicOnionClientFactory("Generated", MagicOnionGeneratedClientFactoryProvider.Instance) };
     }
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task NonGeneric(TestMagicOnionClientFactory<IUnaryService> clientFactory)
+    public async Task NonGeneric(TestMagicOnionClientFactory clientFactory)
     {
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel);
+        var client = clientFactory.Create<IUnaryService>(channel);
         var result = client.NonGeneric(123);
         await result;
 
@@ -39,10 +40,10 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
 
     [Theory]
     [MemberData(nameof(EnumerateMagicOnionClientFactory))]
-    public async Task ManyParametersReturnsValueType(TestMagicOnionClientFactory<IUnaryService> clientFactory)
+    public async Task ManyParametersReturnsValueType(TestMagicOnionClientFactory clientFactory)
     {
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
-        var client = clientFactory.Create(channel);
+        var client = clientFactory.Create<IUnaryService>(channel);
         var result  = await client.ManyParametersReturnsValueType(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         result.Should().Be(120);
     }

--- a/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
+++ b/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
@@ -25,22 +25,99 @@ namespace MagicOnion.Integration.Tests.Generated
 
         public static void Register()
         {
-            if(isRegistered) return;
+            if (isRegistered) return;
             isRegistered = true;
 
-            MagicOnionClientRegistry<global::MagicOnion.Integration.Tests.IClientFilterTestService>.Register((x, y) => new MagicOnion.Integration.Tests.ClientFilterTestServiceClient(x, y));
-            MagicOnionClientRegistry<global::MagicOnion.Integration.Tests.IDynamicArgumentTupleService>.Register((x, y) => new MagicOnion.Integration.Tests.DynamicArgumentTupleServiceClient(x, y));
-            MagicOnionClientRegistry<global::MagicOnion.Integration.Tests.ISerializerTestService>.Register((x, y) => new MagicOnion.Integration.Tests.SerializerTestServiceClient(x, y));
-            MagicOnionClientRegistry<global::MagicOnion.Integration.Tests.IStreamingTestService>.Register((x, y) => new MagicOnion.Integration.Tests.StreamingTestServiceClient(x, y));
-            MagicOnionClientRegistry<global::MagicOnion.Integration.Tests.IUnaryService>.Register((x, y) => new MagicOnion.Integration.Tests.UnaryServiceClient(x, y));
-            MagicOnionClientRegistry<global::MagicOnion.Integration.Tests.MemoryPack.IMemoryPackSerializerTestService>.Register((x, y) => new MagicOnion.Integration.Tests.MemoryPack.MemoryPackSerializerTestServiceClient(x, y));
+            global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default =
+                (global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableMagicOnionClientFactoryProvider immutableMagicOnionClientFactoryProvider)
+                    ? immutableMagicOnionClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
+                    : new ImmutableMagicOnionClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
 
-            StreamingHubClientRegistry<global::MagicOnion.Integration.Tests.IHandCraftedStreamingHubClientTestHub, global::MagicOnion.Integration.Tests.IHandCraftedStreamingHubClientTestHubReceiver>.Register((a, _, b, c, d, e) => new MagicOnion.Integration.Tests.HandCraftedStreamingHubClientTestHubClient(a, b, c, d, e));
-            StreamingHubClientRegistry<global::MagicOnion.Integration.Tests.ISerializerTestHub, global::MagicOnion.Integration.Tests.ISerializerTestHubReceiver>.Register((a, _, b, c, d, e) => new MagicOnion.Integration.Tests.SerializerTestHubClient(a, b, c, d, e));
-            StreamingHubClientRegistry<global::MagicOnion.Integration.Tests.IStreamingHubTestHub, global::MagicOnion.Integration.Tests.IStreamingHubTestHubReceiver>.Register((a, _, b, c, d, e) => new MagicOnion.Integration.Tests.StreamingHubTestHubClient(a, b, c, d, e));
-            StreamingHubClientRegistry<global::MagicOnion.Integration.Tests.MemoryPack.IMemoryPackSerializerTestHub, global::MagicOnion.Integration.Tests.MemoryPack.IMemoryPackSerializerTestHubReceiver>.Register((a, _, b, c, d, e) => new MagicOnion.Integration.Tests.MemoryPack.MemoryPackSerializerTestHubClient(a, b, c, d, e));
+            global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default =
+                (global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableStreamingHubClientFactoryProvider immutableStreamingHubClientFactoryProvider)
+                    ? immutableStreamingHubClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
+                    : new ImmutableStreamingHubClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
         }
     }
+
+    public partial class MagicOnionGeneratedClientFactoryProvider : IMagicOnionClientFactoryProvider, IStreamingHubClientFactoryProvider
+    {
+        public static MagicOnionGeneratedClientFactoryProvider Instance { get; } = new MagicOnionGeneratedClientFactoryProvider();
+
+        MagicOnionGeneratedClientFactoryProvider() {}
+
+        bool IMagicOnionClientFactoryProvider.TryGetFactory<T>(out global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> factory)
+            => (factory = MagicOnionClientFactoryCache<T>.Factory) != null;
+
+        bool IStreamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory)
+            => (factory = StreamingHubClientFactoryCache<TStreamingHub, TReceiver>.Factory) != null;
+
+        static class MagicOnionClientFactoryCache<T> where T : global::MagicOnion.IService<T>
+        {
+            public readonly static global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> Factory;
+
+            static MagicOnionClientFactoryCache()
+            {
+                object factory = default(global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T>);
+
+                if (typeof(T) == typeof(global::MagicOnion.Integration.Tests.IClientFilterTestService))
+                {
+                    factory = ((global::MagicOnion.Client.MagicOnionClientFactoryDelegate<global::MagicOnion.Integration.Tests.IClientFilterTestService>)((x, y) => new MagicOnion.Integration.Tests.ClientFilterTestServiceClient(x, y)));
+                }
+                if (typeof(T) == typeof(global::MagicOnion.Integration.Tests.IDynamicArgumentTupleService))
+                {
+                    factory = ((global::MagicOnion.Client.MagicOnionClientFactoryDelegate<global::MagicOnion.Integration.Tests.IDynamicArgumentTupleService>)((x, y) => new MagicOnion.Integration.Tests.DynamicArgumentTupleServiceClient(x, y)));
+                }
+                if (typeof(T) == typeof(global::MagicOnion.Integration.Tests.ISerializerTestService))
+                {
+                    factory = ((global::MagicOnion.Client.MagicOnionClientFactoryDelegate<global::MagicOnion.Integration.Tests.ISerializerTestService>)((x, y) => new MagicOnion.Integration.Tests.SerializerTestServiceClient(x, y)));
+                }
+                if (typeof(T) == typeof(global::MagicOnion.Integration.Tests.IStreamingTestService))
+                {
+                    factory = ((global::MagicOnion.Client.MagicOnionClientFactoryDelegate<global::MagicOnion.Integration.Tests.IStreamingTestService>)((x, y) => new MagicOnion.Integration.Tests.StreamingTestServiceClient(x, y)));
+                }
+                if (typeof(T) == typeof(global::MagicOnion.Integration.Tests.IUnaryService))
+                {
+                    factory = ((global::MagicOnion.Client.MagicOnionClientFactoryDelegate<global::MagicOnion.Integration.Tests.IUnaryService>)((x, y) => new MagicOnion.Integration.Tests.UnaryServiceClient(x, y)));
+                }
+                if (typeof(T) == typeof(global::MagicOnion.Integration.Tests.MemoryPack.IMemoryPackSerializerTestService))
+                {
+                    factory = ((global::MagicOnion.Client.MagicOnionClientFactoryDelegate<global::MagicOnion.Integration.Tests.MemoryPack.IMemoryPackSerializerTestService>)((x, y) => new MagicOnion.Integration.Tests.MemoryPack.MemoryPackSerializerTestServiceClient(x, y)));
+                }
+                Factory = (global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T>)factory;
+            }
+        }
+        
+        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        {
+            public readonly static global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory;
+
+            static StreamingHubClientFactoryCache()
+            {
+                object factory = default(global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>);
+
+                if (typeof(TStreamingHub) == typeof(global::MagicOnion.Integration.Tests.IHandCraftedStreamingHubClientTestHub) && typeof(TReceiver) == typeof(global::MagicOnion.Integration.Tests.IHandCraftedStreamingHubClientTestHubReceiver))
+                {
+                    factory = ((global::MagicOnion.Client.StreamingHubClientFactoryDelegate<global::MagicOnion.Integration.Tests.IHandCraftedStreamingHubClientTestHub, global::MagicOnion.Integration.Tests.IHandCraftedStreamingHubClientTestHubReceiver>)((a, _, b, c, d, e) => new MagicOnion.Integration.Tests.HandCraftedStreamingHubClientTestHubClient(a, b, c, d, e)));
+                }
+                if (typeof(TStreamingHub) == typeof(global::MagicOnion.Integration.Tests.ISerializerTestHub) && typeof(TReceiver) == typeof(global::MagicOnion.Integration.Tests.ISerializerTestHubReceiver))
+                {
+                    factory = ((global::MagicOnion.Client.StreamingHubClientFactoryDelegate<global::MagicOnion.Integration.Tests.ISerializerTestHub, global::MagicOnion.Integration.Tests.ISerializerTestHubReceiver>)((a, _, b, c, d, e) => new MagicOnion.Integration.Tests.SerializerTestHubClient(a, b, c, d, e)));
+                }
+                if (typeof(TStreamingHub) == typeof(global::MagicOnion.Integration.Tests.IStreamingHubTestHub) && typeof(TReceiver) == typeof(global::MagicOnion.Integration.Tests.IStreamingHubTestHubReceiver))
+                {
+                    factory = ((global::MagicOnion.Client.StreamingHubClientFactoryDelegate<global::MagicOnion.Integration.Tests.IStreamingHubTestHub, global::MagicOnion.Integration.Tests.IStreamingHubTestHubReceiver>)((a, _, b, c, d, e) => new MagicOnion.Integration.Tests.StreamingHubTestHubClient(a, b, c, d, e)));
+                }
+                if (typeof(TStreamingHub) == typeof(global::MagicOnion.Integration.Tests.MemoryPack.IMemoryPackSerializerTestHub) && typeof(TReceiver) == typeof(global::MagicOnion.Integration.Tests.MemoryPack.IMemoryPackSerializerTestHubReceiver))
+                {
+                    factory = ((global::MagicOnion.Client.StreamingHubClientFactoryDelegate<global::MagicOnion.Integration.Tests.MemoryPack.IMemoryPackSerializerTestHub, global::MagicOnion.Integration.Tests.MemoryPack.IMemoryPackSerializerTestHubReceiver>)((a, _, b, c, d, e) => new MagicOnion.Integration.Tests.MemoryPack.MemoryPackSerializerTestHubClient(a, b, c, d, e)));
+                }
+
+                Factory = (global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>)factory;
+            }
+        }
+    }
+
 }
 
 #pragma warning restore 168

--- a/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
+++ b/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
@@ -88,7 +88,7 @@ namespace MagicOnion.Integration.Tests.Generated
             }
         }
         
-        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
+        static class StreamingHubClientFactoryCache<TStreamingHub, TReceiver> where TStreamingHub : global::MagicOnion.IStreamingHub<TStreamingHub, TReceiver>
         {
             public readonly static global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory;
 

--- a/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
+++ b/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
@@ -31,25 +31,25 @@ namespace MagicOnion.Integration.Tests.Generated
             global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default =
                 (global::MagicOnion.Client.MagicOnionClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableMagicOnionClientFactoryProvider immutableMagicOnionClientFactoryProvider)
                     ? immutableMagicOnionClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
-                    : new ImmutableMagicOnionClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
+                    : new global::MagicOnion.Client.ImmutableMagicOnionClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
 
             global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default =
                 (global::MagicOnion.Client.StreamingHubClientFactoryProvider.Default is global::MagicOnion.Client.ImmutableStreamingHubClientFactoryProvider immutableStreamingHubClientFactoryProvider)
                     ? immutableStreamingHubClientFactoryProvider.Add(MagicOnionGeneratedClientFactoryProvider.Instance)
-                    : new ImmutableStreamingHubClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
+                    : new global::MagicOnion.Client.ImmutableStreamingHubClientFactoryProvider(MagicOnionGeneratedClientFactoryProvider.Instance);
         }
     }
 
-    public partial class MagicOnionGeneratedClientFactoryProvider : IMagicOnionClientFactoryProvider, IStreamingHubClientFactoryProvider
+    public partial class MagicOnionGeneratedClientFactoryProvider : global::MagicOnion.Client.IMagicOnionClientFactoryProvider, global::MagicOnion.Client.IStreamingHubClientFactoryProvider
     {
         public static MagicOnionGeneratedClientFactoryProvider Instance { get; } = new MagicOnionGeneratedClientFactoryProvider();
 
         MagicOnionGeneratedClientFactoryProvider() {}
 
-        bool IMagicOnionClientFactoryProvider.TryGetFactory<T>(out global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> factory)
+        bool global::MagicOnion.Client.IMagicOnionClientFactoryProvider.TryGetFactory<T>(out global::MagicOnion.Client.MagicOnionClientFactoryDelegate<T> factory)
             => (factory = MagicOnionClientFactoryCache<T>.Factory) != null;
 
-        bool IStreamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory)
+        bool global::MagicOnion.Client.IStreamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out global::MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> factory)
             => (factory = StreamingHubClientFactoryCache<TStreamingHub, TReceiver>.Factory) != null;
 
         static class MagicOnionClientFactoryCache<T> where T : global::MagicOnion.IService<T>


### PR DESCRIPTION
This PR introduces extension points to MagicOnionClient/StreamingHubClient instance creation mechanism.
It allows factories to be treated as instances instead of global, static registrations.

- `IMagicOnionClientFactoryProvider` interface
- `IStreamingHubClientFactoryProvider` interface