### PR TITLE
Remove `UnaryResult()` and `ReturnNil()` helper methods

### DIFF
--- a/perf/BenchmarkApp/PerformanceTest.Server/PerfTestService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerfTestService.cs
@@ -9,7 +9,7 @@ public class PerfTestService : ServiceBase<IPerfTestService>, IPerfTestService
 {
     public UnaryResult<ServerInformation> GetServerInformationAsync()
     {
-        return UnaryResult(new ServerInformation(
+        return UnaryResult.FromResult(new ServerInformation(
             Environment.MachineName,
             ApplicationInformation.Current.MagicOnionVersion,
             ApplicationInformation.Current.GrpcNetVersion,
@@ -46,11 +46,11 @@ public class PerfTestService : ServiceBase<IPerfTestService>, IPerfTestService
 
     public UnaryResult<(int StatusCode, byte[] Data)> UnaryLargePayloadAsync(string arg1, int arg2, byte[] arg3)
     {
-        return UnaryResult((123, arg3));
+        return UnaryResult.FromResult((123, arg3));
     }
 
     public UnaryResult<ComplexResponse> UnaryComplexAsync(string arg1, int arg2)
     {
-        return UnaryResult(ComplexResponse.Cached);
+        return UnaryResult.FromResult(ComplexResponse.Cached);
     }
 }

--- a/samples/ChatApp/ChatApp.Server/ChatService.cs
+++ b/samples/ChatApp/ChatApp.Server/ChatService.cs
@@ -15,16 +15,16 @@ namespace ChatApp.Server
             _logger = logger;
         }
 
-        public UnaryResult<Nil> GenerateException(string message)
+        public UnaryResult GenerateException(string message)
         {
             throw new System.NotImplementedException();
         }
 
-        public UnaryResult<Nil> SendReportAsync(string message)
+        public UnaryResult SendReportAsync(string message)
         {
             _logger.LogDebug($"{message}");
 
-            return UnaryResult(Nil.Default);
+            return UnaryResult.CompletedResult;
         }
     }
 }

--- a/samples/ChatApp/ChatApp.Shared/Services/IChatService.cs
+++ b/samples/ChatApp/ChatApp.Shared/Services/IChatService.cs
@@ -1,4 +1,4 @@
-﻿using MagicOnion;
+using MagicOnion;
 using MessagePack;
 
 namespace ChatApp.Shared.Services
@@ -8,7 +8,7 @@ namespace ChatApp.Shared.Services
     /// </summary>
     public interface IChatService : IService<IChatService>
     {
-        UnaryResult<Nil> GenerateException(string message);
-        UnaryResult<Nil> SendReportAsync(string message);
+        UnaryResult GenerateException(string message);
+        UnaryResult SendReportAsync(string message);
     }
 }

--- a/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
+++ b/samples/ChatApp/ChatApp.Unity/Assets/Scripts/Generated/MagicOnion.Generated.cs
@@ -233,10 +233,10 @@ namespace ChatApp.Shared.Services
         protected override global::MagicOnion.Client.MagicOnionClientBase<IChatService> Clone(global::MagicOnion.Client.MagicOnionClientOptions options)
             => new ChatServiceClient(options, core);
         
-        public global::MagicOnion.UnaryResult<global::MessagePack.Nil> GenerateException(global::System.String message)
-            => this.core.GenerateException.InvokeUnary(this, "IChatService/GenerateException", message);
-        public global::MagicOnion.UnaryResult<global::MessagePack.Nil> SendReportAsync(global::System.String message)
-            => this.core.SendReportAsync.InvokeUnary(this, "IChatService/SendReportAsync", message);
+        public global::MagicOnion.UnaryResult GenerateException(global::System.String message)
+            => this.core.GenerateException.InvokeUnaryNonGeneric(this, "IChatService/GenerateException", message);
+        public global::MagicOnion.UnaryResult SendReportAsync(global::System.String message)
+            => this.core.SendReportAsync.InvokeUnaryNonGeneric(this, "IChatService/SendReportAsync", message);
     }
 }
 

--- a/sandbox/Sandbox.AspNetCore/Services/GreeterService.cs
+++ b/sandbox/Sandbox.AspNetCore/Services/GreeterService.cs
@@ -16,7 +16,7 @@ namespace Sandbox.AspNetCore.Services
     {
         public UnaryResult<string> HelloAsync()
         {
-            return UnaryResult("Konnichiwa from MagicOnion + ASP.NET Core");
+            return UnaryResult.FromResult("Konnichiwa from MagicOnion + ASP.NET Core");
         }
     }
 }

--- a/src/MagicOnion.Abstractions/UnaryResult.cs
+++ b/src/MagicOnion.Abstractions/UnaryResult.cs
@@ -170,6 +170,7 @@ namespace MagicOnion
         /// <summary>
         /// Gets the result that contains <see cref="F:MessagePack.Nil.Default"/> as the result value.
         /// </summary>
+        [Obsolete("Use `UnaryResult` or `UnaryResult.FromResult(Nil.Default)` instead.")]
         public static UnaryResult<Nil> Nil
             => new UnaryResult<Nil>(MessagePack.Nil.Default);
     }

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Abstractions/UnaryResult.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Abstractions/UnaryResult.cs
@@ -170,6 +170,7 @@ namespace MagicOnion
         /// <summary>
         /// Gets the result that contains <see cref="F:MessagePack.Nil.Default"/> as the result value.
         /// </summary>
+        [Obsolete("Use `UnaryResult` or `UnaryResult.FromResult(Nil.Default)` instead.")]
         public static UnaryResult<Nil> Nil
             => new UnaryResult<Nil>(MessagePack.Nil.Default);
     }

--- a/src/MagicOnion.Server/Service.cs
+++ b/src/MagicOnion.Server/Service.cs
@@ -20,16 +20,6 @@ public abstract class ServiceBase<TServiceInterface> : IService<TServiceInterfac
 
     // Helpers
 
-    protected UnaryResult<TResponse> UnaryResult<TResponse>(TResponse result)
-    {
-        return new MagicOnion.UnaryResult<TResponse>(result);
-    }
-
-    protected UnaryResult<Nil> ReturnNil()
-    {
-        return new MagicOnion.UnaryResult<Nil>(Nil.Default);
-    }
-
     protected TResponse ReturnStatusCode<TResponse>(int statusCode, string detail)
     {
         Context.CallContext.Status = new Status((StatusCode)statusCode, detail ?? "");

--- a/tests/MagicOnion.Integration.Tests/ClientFilterTest.cs
+++ b/tests/MagicOnion.Integration.Tests/ClientFilterTest.cs
@@ -106,7 +106,7 @@ public class ClientFilterTestService : ServiceBase<IClientFilterTestService>, IC
             Context.CallContext.ResponseTrailers.Add(item);
         }
 
-        return ReturnNil();
+        return UnaryResult.FromResult(Nil.Default);
     }
 
     public UnaryResult<Nil> AlwaysError()

--- a/tests/MagicOnion.Integration.Tests/DynamicArgumentTupleTest.cs
+++ b/tests/MagicOnion.Integration.Tests/DynamicArgumentTupleTest.cs
@@ -43,6 +43,6 @@ public class DynamicArgumentTupleService : ServiceBase<IDynamicArgumentTupleServ
 {
     public UnaryResult<int> Unary1(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14)
     {
-        return UnaryResult(arg0 + arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + arg14);
+        return UnaryResult.FromResult(arg0 + arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + arg14);
     }
 }

--- a/tests/MagicOnion.Integration.Tests/MemoryPack/MemoryPackSerializerUnaryTest.cs
+++ b/tests/MagicOnion.Integration.Tests/MemoryPack/MemoryPackSerializerUnaryTest.cs
@@ -101,10 +101,10 @@ public interface IMemoryPackSerializerTestService : IService<IMemoryPackSerializ
 public class MemoryPackSerializerTestService : ServiceBase<IMemoryPackSerializerTestService>, IMemoryPackSerializerTestService
 {
     public UnaryResult<Nil> UnaryReturnNil()
-        => UnaryResult(Nil.Default);
+        => UnaryResult.FromResult(Nil.Default);
     public UnaryResult<int> UnaryParameterless()
-        => UnaryResult(123);
+        => UnaryResult.FromResult(123);
 
     public UnaryResult<int> Unary1(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, string arg14)
-        => UnaryResult(arg0 + arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + int.Parse(arg14));
+        => UnaryResult.FromResult(arg0 + arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + int.Parse(arg14));
 }

--- a/tests/MagicOnion.Integration.Tests/SerializerUnaryTest.cs
+++ b/tests/MagicOnion.Integration.Tests/SerializerUnaryTest.cs
@@ -101,10 +101,10 @@ public interface ISerializerTestService : IService<ISerializerTestService>
 public class SerializerTestService : ServiceBase<ISerializerTestService>, ISerializerTestService
 {
     public UnaryResult<Nil> UnaryReturnNil()
-        => UnaryResult(Nil.Default);
+        => UnaryResult.FromResult(Nil.Default);
     public UnaryResult<int> UnaryParameterless()
-        => UnaryResult(123);
+        => UnaryResult.FromResult(123);
 
     public UnaryResult<int> Unary1(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14)
-        => UnaryResult(arg0 + arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + arg14);
+        => UnaryResult.FromResult(arg0 + arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + arg14);
 }

--- a/tests/MagicOnion.Integration.Tests/UnaryServiceTest.cs
+++ b/tests/MagicOnion.Integration.Tests/UnaryServiceTest.cs
@@ -67,6 +67,6 @@ public class UnaryService : ServiceBase<IUnaryService>, IUnaryService
 
     public UnaryResult<int> ManyParametersReturnsValueType(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14)
     {
-        return UnaryResult(arg0 + arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + arg14);
+        return UnaryResult.FromResult(arg0 + arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + arg14);
     }
 }

--- a/tests/MagicOnion.Server.Tests/ArgumentPatternTest.cs
+++ b/tests/MagicOnion.Server.Tests/ArgumentPatternTest.cs
@@ -79,7 +79,7 @@ public class ArgumentPattern : ServiceBase<IArgumentPattern>, IArgumentPattern
 
     public UnaryResult<MyResponse> Unary1(int x, int y, string z = "unknown")
     {
-        return UnaryResult(new MyResponse
+        return UnaryResult.FromResult(new MyResponse
         {
             Id = x + y,
             Data = z
@@ -88,7 +88,7 @@ public class ArgumentPattern : ServiceBase<IArgumentPattern>, IArgumentPattern
 
     public UnaryResult<MyResponse> Unary2(MyRequest req)
     {
-        return UnaryResult(new MyResponse
+        return UnaryResult.FromResult(new MyResponse
         {
             Id = req.Id,
             Data = req.Data
@@ -97,7 +97,7 @@ public class ArgumentPattern : ServiceBase<IArgumentPattern>, IArgumentPattern
 
     public UnaryResult<MyResponse> Unary3()
     {
-        return UnaryResult(new MyResponse
+        return UnaryResult.FromResult(new MyResponse
         {
             Id = -1,
             Data = "NoArg"
@@ -106,12 +106,12 @@ public class ArgumentPattern : ServiceBase<IArgumentPattern>, IArgumentPattern
 
     public UnaryResult<Nil> Unary4()
     {
-        return UnaryResult(Nil.Default);
+        return UnaryResult.FromResult(Nil.Default);
     }
 
     public UnaryResult<MyStructResponse> Unary5(MyStructRequest req)
     {
-        return UnaryResult(new MyStructResponse
+        return UnaryResult.FromResult(new MyStructResponse
         {
             X = req.X,
             Y = req.Y

--- a/tests/MagicOnion.Server.Tests/FilterConstructorInjectionTest.cs
+++ b/tests/MagicOnion.Server.Tests/FilterConstructorInjectionTest.cs
@@ -188,30 +188,30 @@ public class FilterConstructorInjectionTester : ServiceBase<IFilterConstructorIn
 {
     public UnaryResult<int> A()
     {
-        return UnaryResult(0);
+        return UnaryResult.FromResult(0);
     }
 
     [FromTypeFilter(typeof(ConstructorInjectedFilter2Attribute))]
     public UnaryResult<int> B()
     {
-        return UnaryResult(0);
+        return UnaryResult.FromResult(0);
     }
 
     [FromTypeFilter(typeof(ConstructorInjectedFilter3Attribute), Arguments = new object[] { "foo", 987654 })]
     public UnaryResult<int> C()
     {
-        return UnaryResult(0);
+        return UnaryResult.FromResult(0);
     }
 
     [FromServiceFilter(typeof(ServiceFilterForMethodTestFilterAttribute))]
     public UnaryResult<int> D()
     {
-        return UnaryResult(0);
+        return UnaryResult.FromResult(0);
     }
 
     [FilterFactoryTestFilter("Hogemoge")]
     public UnaryResult<int> E()
     {
-        return UnaryResult(0);
+        return UnaryResult.FromResult(0);
     }
 }

--- a/tests/MagicOnion.Server.Tests/FilterTest.cs
+++ b/tests/MagicOnion.Server.Tests/FilterTest.cs
@@ -132,14 +132,14 @@ public class FilterTester : ServiceBase<IFilterTester>, IFilterTester
     [SimpleFilter1(Order = 10)]
     public UnaryResult<int> A()
     {
-        return UnaryResult(0);
+        return UnaryResult.FromResult(0);
     }
 
     [SimpleFilter1(Order = 300)]
     [MultiFilter2(99, 30, Z = 4595, Order = 200)]
     public UnaryResult<int> B()
     {
-        return UnaryResult(999);
+        return UnaryResult.FromResult(999);
     }
 
     [SimpleFilter1(Order = int.MinValue)]

--- a/tests/MagicOnion.Server.Tests/InterfaceInheritanceTest.cs
+++ b/tests/MagicOnion.Server.Tests/InterfaceInheritanceTest.cs
@@ -21,11 +21,11 @@ public interface IInterfaceInheritanceService : IService<IInterfaceInheritanceSe
 
 public class InterfaceInheritanceService : ServiceBase<IInterfaceInheritanceService>, IInterfaceInheritanceService
 {
-    public UnaryResult<int> UnaryBaseBase(int x, int y) => UnaryResult(x - y);
+    public UnaryResult<int> UnaryBaseBase(int x, int y) => UnaryResult.FromResult(x - y);
 
-    public UnaryResult<int> UnaryBase(int x, int y) => UnaryResult(x * y);
+    public UnaryResult<int> UnaryBase(int x, int y) => UnaryResult.FromResult(x * y);
 
-    public UnaryResult<int> Unary1(int x, int y) => UnaryResult(x + y);
+    public UnaryResult<int> Unary1(int x, int y) => UnaryResult.FromResult(x + y);
 }
 
 public class InterfaceInheritanceTest : IClassFixture<ServerFixture<InterfaceInheritanceService>>

--- a/tests/MagicOnion.Server.Tests/ServerErrorTest.cs
+++ b/tests/MagicOnion.Server.Tests/ServerErrorTest.cs
@@ -11,12 +11,12 @@ public class OverloadService : ServiceBase<IOverloadMethod>, IOverloadMethod
 {
     public UnaryResult<int> Hoge(int x)
     {
-        return UnaryResult(0);
+        return UnaryResult.FromResult(0);
     }
 
     public UnaryResult<int> Hoge(int x, int y)
     {
-        return UnaryResult(0);
+        return UnaryResult.FromResult(0);
     }
 }
 

--- a/tests/samples/AuthSample/ServicesAndHubs.cs
+++ b/tests/samples/AuthSample/ServicesAndHubs.cs
@@ -15,10 +15,10 @@ public interface IAuthorizeClassService : IService<IAuthorizeClassService>
 [Authorize]
 public class AuthorizeClassService : ServiceBase<IAuthorizeClassService>, IAuthorizeClassService
 {
-    public UnaryResult<string> GetUserNameAsync() => UnaryResult(Context.CallContext.GetHttpContext().User.Identity?.Name ?? throw new InvalidOperationException("Unauthenticated"));
+    public UnaryResult<string> GetUserNameAsync() => UnaryResult.FromResult(Context.CallContext.GetHttpContext().User.Identity?.Name ?? throw new InvalidOperationException("Unauthenticated"));
 
     [AllowAnonymous]
-    public UnaryResult<int> AddAsync(int a, int b) => UnaryResult(a + b);
+    public UnaryResult<int> AddAsync(int a, int b) => UnaryResult.FromResult(a + b);
 }
 
 public interface IAuthorizeMethodService : IService<IAuthorizeMethodService>
@@ -30,9 +30,9 @@ public interface IAuthorizeMethodService : IService<IAuthorizeMethodService>
 public class AuthorizeMethodService : ServiceBase<IAuthorizeMethodService>, IAuthorizeMethodService
 {
     [Authorize]
-    public UnaryResult<string> GetUserNameAsync() => UnaryResult(Context.CallContext.GetHttpContext().User.Identity?.Name ?? throw new InvalidOperationException("Unauthenticated"));
+    public UnaryResult<string> GetUserNameAsync() => UnaryResult.FromResult(Context.CallContext.GetHttpContext().User.Identity?.Name ?? throw new InvalidOperationException("Unauthenticated"));
 
-    public UnaryResult<int> AddAsync(int a, int b) => UnaryResult(a + b);
+    public UnaryResult<int> AddAsync(int a, int b) => UnaryResult.FromResult(a + b);
 }
 
 public interface IAuthorizeHubReceiver {}

--- a/tests/samples/BasicServerSample/Services/BasicUnaryService.cs
+++ b/tests/samples/BasicServerSample/Services/BasicUnaryService.cs
@@ -64,49 +64,49 @@ public class BasicUnaryService : ServiceBase<IBasicUnaryService>, IBasicUnarySer
         => throw new ReturnStatusException(statusCode, nameof(ReturnTypeIsNilAndNonSuccessResponseAsync));
 
     public UnaryResult<Nil> NoParameterReturnNilAsync()
-        => UnaryResult(Nil.Default);
+        => UnaryResult.FromResult(Nil.Default);
 
     public UnaryResult<int> NoParameterReturnValueTypeAsync()
-        => UnaryResult(1234);
+        => UnaryResult.FromResult(1234);
 
     public UnaryResult<MyResponse> NoParameterReturnRefTypeAsync()
-        => UnaryResult(new MyResponse("1234"));
+        => UnaryResult.FromResult(new MyResponse("1234"));
 
     public UnaryResult<Nil> OneValueTypeParameterReturnNilAsync(int a)
-        => UnaryResult(Nil.Default);
+        => UnaryResult.FromResult(Nil.Default);
 
     public UnaryResult<Nil> TwoValueTypeParametersReturnNilAsync(int a, int b)
-        => UnaryResult(Nil.Default);
+        => UnaryResult.FromResult(Nil.Default);
 
     public UnaryResult<int> OneValueTypeParameterReturnValueTypeAsync(int a)
-        => UnaryResult(a);
+        => UnaryResult.FromResult(a);
 
     public UnaryResult<int> TwoValueTypeParametersReturnValueTypeAsync(int a, int b)
-        => UnaryResult(a + b);
+        => UnaryResult.FromResult(a + b);
 
     public UnaryResult<MyResponse> OneValueTypeParameterReturnRefTypeAsync(int a)
-        => UnaryResult(new MyResponse(a.ToString()));
+        => UnaryResult.FromResult(new MyResponse(a.ToString()));
 
     public UnaryResult<MyResponse> TwoValueTypeParametersReturnRefTypeAsync(int a, int b)
-        => UnaryResult(new MyResponse((a + b).ToString()));
+        => UnaryResult.FromResult(new MyResponse((a + b).ToString()));
 
     public UnaryResult<Nil> OneRefTypeParameterReturnNilAsync(MyRequest a)
-        => UnaryResult(Nil.Default);
+        => UnaryResult.FromResult(Nil.Default);
 
     public UnaryResult<Nil> TwoRefTypeParametersReturnNilAsync(MyRequest a, MyRequest b)
-        => UnaryResult(Nil.Default);
+        => UnaryResult.FromResult(Nil.Default);
 
     public UnaryResult<int> OneRefTypeParameterReturnValueTypeAsync(MyRequest a)
-        => UnaryResult(a.Value);
+        => UnaryResult.FromResult(a.Value);
 
     public UnaryResult<int> TwoRefTypeParametersReturnValueTypeAsync(MyRequest a, MyRequest b)
-        => UnaryResult(a.Value + b.Value);
+        => UnaryResult.FromResult(a.Value + b.Value);
 
     public UnaryResult<MyResponse> OneRefTypeParameterReturnRefTypeAsync(MyRequest a)
-        => UnaryResult(new MyResponse(a.Value.ToString()));
+        => UnaryResult.FromResult(new MyResponse(a.Value.ToString()));
 
     public UnaryResult<MyResponse> TwoRefTypeParametersReturnRefTypeAsync(MyRequest a, MyRequest b)
-        => UnaryResult(new MyResponse((a.Value + b.Value).ToString()));
+        => UnaryResult.FromResult(new MyResponse((a.Value + b.Value).ToString()));
 
     public UnaryResult NonGenericNoParameterAsync()
         => MagicOnion.UnaryResult.CompletedResult;


### PR DESCRIPTION
This PR removes `UnaryResult()` and `ReturnNil()` helper methods from `ServiceBase<T>`.
If you want to return a value instead of using the async method, use `UnaryResult.FromResult<T>(T value)`.

## Breaking changes
- Remove `ServiceBase<T>.UnaryResult()`
- Remove `ServiceBase<T>.ReturnNil()`

## Notable changes
- `UnaryResult.Nil` is now deprecated. Use non-generic `UnaryResult` return type or `UnaryResult.FromResult(Nil.Default)` instead.