### PR TITLE
chore: Apply Testcontainers for .NET best practices

### DIFF
--- a/tests/MagicOnion.Server.Redis.Tests/RedisGroupFunctionalTest.cs
+++ b/tests/MagicOnion.Server.Redis.Tests/RedisGroupFunctionalTest.cs
@@ -24,7 +24,7 @@ public class RedisGroupFunctionalTest : IClassFixture<MagicOnionApplicationFacto
                 services.TryAddSingleton<IGroupRepositoryFactory, RedisGroupRepositoryFactory>();
                 services.Configure<RedisGroupOptions>(options =>
                 {
-                    options.ConnectionMultiplexer = StackExchange.Redis.ConnectionMultiplexer.Connect($"127.0.0.1:{redisServer.Port}");
+                    options.ConnectionMultiplexer = StackExchange.Redis.ConnectionMultiplexer.Connect(redisServer.GetConnectionString());
                 });
             });
         });
@@ -36,7 +36,7 @@ public class RedisGroupFunctionalTest : IClassFixture<MagicOnionApplicationFacto
                 services.TryAddSingleton<IGroupRepositoryFactory, RedisGroupRepositoryFactory>();
                 services.Configure<RedisGroupOptions>(options =>
                 {
-                    options.ConnectionMultiplexer = StackExchange.Redis.ConnectionMultiplexer.Connect($"127.0.0.1:{redisServer.Port}");
+                    options.ConnectionMultiplexer = StackExchange.Redis.ConnectionMultiplexer.Connect(redisServer.GetConnectionString());
                 });
             });
         });
@@ -96,7 +96,7 @@ public class RedisGroupFunctionalTest : IClassFixture<MagicOnionApplicationFacto
         beforeCount.Should().Be(2);
         (await client1.GetMemberCountAsync()).Should().Be(1);
     }
-    
+
     [Fact]
     public async Task RemoveMemberFromInMemoryGroup_KeepSubscription()
     {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Applies Testcontainers for .NET best practices. It restructures and cleans up the Redis test fixture. The container object is not nullable, `InitializeAsync` and `DisposeAsync` can immediately return their tasks, no reason to `await`. 

It is recommended to use Testcontainers to resolve the hostname and public mapped port. Both properties may vary due to the Docker host. E.g. the hostname is not always `127.0.0.1` or `localhost`.

## Why is it important?

I noticed you are using Testcontainers for .NET and wanna share some best practices.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
