### PR TITLE
Bump `OpenTelemetry` to `1.3.2` version

### DIFF
--- a/src/MagicOnion.Server.OpenTelemetry/MagicOnion.Server.OpenTelemetry.csproj
+++ b/src/MagicOnion.Server.OpenTelemetry/MagicOnion.Server.OpenTelemetry.csproj
@@ -19,14 +19,14 @@
         <Description>Telemetry Extensions of MagicOnion.</Description>
         <PackageTags>$(PackageTags);OpenTelemetry</PackageTags>
         <!-- Match to OpenTelemetry-dotnet rc version. 1.1.0-beta2 -> beta2-1.0.0 -->
-        <VersionSuffix>beta2-1.1.0</VersionSuffix>
+        <VersionSuffix>1.3.2</VersionSuffix>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
-      <PackageReference Include="OpenTelemetry" Version="1.1.0-beta2" />
+      <PackageReference Include="OpenTelemetry" Version="1.3.2" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request bumps `OpenTelemetry` package in `MagicOnion.Server.OpenTelemetry` package, to `1.3.2` version.