### PR TITLE
Emit type hints for Ahead-of-Time compilation

### DIFF
--- a/src/MagicOnion.GeneratorCore/CodeAnalysis/SerializationInfo.cs
+++ b/src/MagicOnion.GeneratorCore/CodeAnalysis/SerializationInfo.cs
@@ -48,3 +48,19 @@ public class EnumSerializationInfo : ISerializationFormatterRegisterInfo
         IfDirectiveConditions = ifDirectiveConditions;
     }
 }
+
+public class SerializationTypeHintInfo : ISerializationFormatterRegisterInfo
+{
+    public string FullName { get; }
+
+    string ISerializationFormatterRegisterInfo.FormatterName => string.Empty; // Dummy
+
+    public IReadOnlyList<string> IfDirectiveConditions { get; }
+    public bool HasIfDirectiveConditions => IfDirectiveConditions.Any();
+
+    public SerializationTypeHintInfo(string fullName, IReadOnlyList<string> ifDirectiveConditions)
+    {
+        FullName = fullName;
+        IfDirectiveConditions = ifDirectiveConditions;
+    }
+}

--- a/src/MagicOnion.GeneratorCore/CodeGen/SerializationFormatterCodeGenContext.cs
+++ b/src/MagicOnion.GeneratorCore/CodeGen/SerializationFormatterCodeGenContext.cs
@@ -11,15 +11,17 @@ public class SerializationFormatterCodeGenContext
     public string FormatterNamespace { get; }
     public string InitializerName { get; }
     public IReadOnlyList<ISerializationFormatterRegisterInfo> FormatterRegistrations { get; }
+    public IReadOnlyList<SerializationTypeHintInfo> TypeHints { get; }
 
     public IndentedTextWriter TextWriter { get; }
 
-    public SerializationFormatterCodeGenContext(string @namespace, string formatterNamespace, string initializerName, IReadOnlyList<ISerializationFormatterRegisterInfo> formatterRegistrations)
+    public SerializationFormatterCodeGenContext(string @namespace, string formatterNamespace, string initializerName, IReadOnlyList<ISerializationFormatterRegisterInfo> formatterRegistrations, IReadOnlyList<SerializationTypeHintInfo> typeHints)
     {
         Namespace = @namespace;
         FormatterNamespace = formatterNamespace;
         InitializerName = initializerName;
         FormatterRegistrations = formatterRegistrations;
+        TypeHints = typeHints;
 
         underlyingWriter = new StringWriter();
         TextWriter = new IndentedTextWriter(underlyingWriter);

--- a/src/MagicOnion.GeneratorCore/MagicOnionCompiler.cs
+++ b/src/MagicOnion.GeneratorCore/MagicOnionCompiler.cs
@@ -110,7 +110,7 @@ public class MagicOnionCompiler
             DisableAutoRegisterOnInitialize = disableAutoRegister,
         };
 
-        var formatterCodeGenContext = new SerializationFormatterCodeGenContext(serialization.Namespace, namespaceDot + "Formatters", serialization.InitializerName, serializationInfoCollection.RequireRegistrationFormatters);
+        var formatterCodeGenContext = new SerializationFormatterCodeGenContext(serialization.Namespace, namespaceDot + "Formatters", serialization.InitializerName, serializationInfoCollection.RequireRegistrationFormatters, serializationInfoCollection.TypeHints);
         var resolverTexts = serialization.Generator.Build(formatterCodeGenContext);
 
         if (Path.GetExtension(output) == ".cs")

--- a/tests/MagicOnion.Generator.Tests/Collector/SerializationInfoCollectorTest.cs
+++ b/tests/MagicOnion.Generator.Tests/Collector/SerializationInfoCollectorTest.cs
@@ -33,6 +33,7 @@ public class SerializationInfoCollectorTest
         serializationInfoCollection.Should().NotBeNull();
         serializationInfoCollection.Enums.Should().BeEmpty();
         serializationInfoCollection.Generics.Should().BeEmpty();
+        serializationInfoCollection.TypeHints.Should().HaveCount(3);
     }
 
     [Fact]
@@ -55,6 +56,7 @@ public class SerializationInfoCollectorTest
         serializationInfoCollection.Generics.Should().HaveCount(2);
         serializationInfoCollection.Generics[0].FormatterName.Should().Be("global::MessagePack.Formatters.NullableFormatter<global::MyNamespace.MyGenericObject>()");
         serializationInfoCollection.Generics[1].FormatterName.Should().Be("global::MessagePack.Formatters.NullableFormatter<global::MyNamespace.YetAnotherGenericObject>()");
+        serializationInfoCollection.TypeHints.Should().HaveCount(4); // Non-nullable + Nullable
     }
 
     [Fact]
@@ -83,6 +85,7 @@ public class SerializationInfoCollectorTest
         serializationInfoCollection.Generics[1].FormatterName.Should().Be("global::MessagePack.Formatters.MyNamespace.YetAnotherGenericObjectFormatter<global::System.String>()");
         serializationInfoCollection.Generics[1].IfDirectiveConditions.Should().HaveCount(2);
         serializationInfoCollection.Generics[1].IfDirectiveConditions.Should().BeEquivalentTo("CONST_2 || DEBUG", "CONST_3");
+        serializationInfoCollection.TypeHints.Should().HaveCount(4); // int, string, MyGenericObject<string>, YetAnotherGenericObject<string>
     }
 
     [Fact]
@@ -104,6 +107,7 @@ public class SerializationInfoCollectorTest
         serializationInfoCollection.Generics.Should().HaveCount(2);
         serializationInfoCollection.Generics[0].FormatterName.Should().Be("global::MessagePack.Formatters.MyNamespace.MyGenericObjectFormatter<global::System.String, global::System.Int64>()");
         serializationInfoCollection.Generics[1].FormatterName.Should().Be("global::MessagePack.Formatters.MyNamespace.MyGenericObjectFormatter<global::System.String, global::System.Int32>()");
+        serializationInfoCollection.TypeHints.Should().HaveCount(5); // string, int, long, MyGenericObject<string, long>, MyGenericObject<string, int>
     }
 
     [Fact]
@@ -139,6 +143,7 @@ public class SerializationInfoCollectorTest
         serializationInfoCollection.Enums[2].Name.Should().Be("YetAnotherEnum");
         serializationInfoCollection.Enums[2].FormatterName.Should().Be("YetAnotherEnumFormatter()");
         serializationInfoCollection.Enums[2].HasIfDirectiveConditions.Should().BeFalse();
+        serializationInfoCollection.TypeHints.Should().HaveCount(6); // MyEnum, MyEnumConditional, YetAnotherEnum, MyGenericObject<MyEnum>, MyGenericObject<MyEnumConditional>, MyGenericObject<YetAnotherEnum>
     }
         
     [Fact]
@@ -158,9 +163,9 @@ public class SerializationInfoCollectorTest
         // Assert
         serializationInfoCollection.Should().NotBeNull();
         serializationInfoCollection.Generics.Should().BeEmpty();
-    }  
+        serializationInfoCollection.TypeHints.Should().HaveCount(3); // byte, ArraySegment<byte>, Nullable<ArraySegment<byte>>
+    }
 
-    
     [Fact]
     public void KnownTypes_Array_SkipBuiltInTypes()
     {
@@ -199,6 +204,7 @@ public class SerializationInfoCollectorTest
         // Assert
         serializationInfoCollection.Should().NotBeNull();
         serializationInfoCollection.Generics.Should().BeEmpty();
+        serializationInfoCollection.TypeHints.Should().HaveCount(46);
     }  
     
     [Fact]
@@ -224,6 +230,7 @@ public class SerializationInfoCollectorTest
         serializationInfoCollection.Generics[1].FormatterName.Should().Be("global::MessagePack.Formatters.TwoDimensionalArrayFormatter<global::MyNamespace.MyObject>()");
         serializationInfoCollection.Generics[2].FormatterName.Should().Be("global::MessagePack.Formatters.ThreeDimensionalArrayFormatter<global::MyNamespace.MyObject>()");
         serializationInfoCollection.Generics[3].FormatterName.Should().Be("global::MessagePack.Formatters.FourDimensionalArrayFormatter<global::MyNamespace.MyObject>()");
+        serializationInfoCollection.TypeHints.Should().HaveCount(5); // MyObject, MyObject[], MyObject[,], MyObject[,,], MyObject[,,,]
     }
 
     [Fact]
@@ -265,6 +272,7 @@ public class SerializationInfoCollectorTest
         serializationInfoCollection.Generics[9].FormatterName.Should().Be("global::MessagePack.Formatters.KeyValuePairFormatter<global::System.String, global::MyNamespace.MyObject>()");
         serializationInfoCollection.Generics[10].FormatterName.Should().Be("global::MessagePack.Formatters.InterfaceLookupFormatter<global::System.String, global::MyNamespace.MyObject>()");
         serializationInfoCollection.Generics[11].FormatterName.Should().Be("global::MessagePack.Formatters.InterfaceGroupingFormatter<global::System.String, global::MyNamespace.MyObject>()");
+        serializationInfoCollection.TypeHints.Should().HaveCount(14);
     }
     
     [Fact]
@@ -296,6 +304,7 @@ public class SerializationInfoCollectorTest
         serializationInfoCollection.Should().NotBeNull();
         serializationInfoCollection.Enums.Should().BeEmpty();
         serializationInfoCollection.Generics.Should().BeEmpty();
+        serializationInfoCollection.TypeHints.Should().HaveCount(26);
     }
 
     [Fact]
@@ -329,6 +338,7 @@ public class SerializationInfoCollectorTest
         serializationInfoCollection.Generics[5].FormatterName.Should().Be("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte>()");
         serializationInfoCollection.Generics[6].FormatterName.Should().Be("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte, global::System.Int16>()");
         serializationInfoCollection.Generics[7].FormatterName.Should().Be("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte, global::System.Int16, global::System.Guid>()");
+        serializationInfoCollection.TypeHints.Should().HaveCount(8 + 8);
     }
 
     [Fact]
@@ -383,6 +393,7 @@ public class SerializationInfoCollectorTest
         serializationInfoCollection.Generics.Should().HaveCount(2);
         serializationInfoCollection.Generics[0].FormatterName.Should().Be("global::MagicOnion.DynamicArgumentTupleFormatter<global::System.String, global::System.Int64>(default(global::System.String), default(global::System.Int64))");
         serializationInfoCollection.Generics[1].FormatterName.Should().Be("global::MagicOnion.DynamicArgumentTupleFormatter<global::System.String, global::System.Int32>(default(global::System.String), default(global::System.Int32))");
+        serializationInfoCollection.TypeHints.Should().HaveCount(5); // string, long, int, DynamicArgumentTuple<string, long>, DynamicArgumentTuple<string, int>
     }
 
     [Fact]

--- a/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
+++ b/tests/MagicOnion.Integration.Tests/_GeneratedClient.cs
@@ -133,6 +133,8 @@ namespace MagicOnion.Integration.Tests.Generated.Resolvers
 {
     using global::System;
     using global::MessagePack;
+
+    partial class PreserveAttribute : global::System.Attribute {}
     public class MagicOnionResolver : global::MessagePack.IFormatterResolver
     {
         public static readonly global::MessagePack.IFormatterResolver Instance = new MagicOnionResolver();
@@ -188,6 +190,28 @@ namespace MagicOnion.Integration.Tests.Generated.Resolvers
                 case 4: return new global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.Int32>();
                 default: return null;
             }
+        }
+    }
+    /// <summary>Type hints for Ahead-of-Time compilation.</summary>
+    [MagicOnion.Integration.Tests.Generated.Resolvers.Preserve]
+    internal static class TypeHints
+    {
+        [MagicOnion.Integration.Tests.Generated.Resolvers.Preserve]
+        internal static void Register()
+        {
+            _ = MagicOnionResolver.Instance.GetFormatter<global::System.Int32>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.Int32>>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::MessagePack.Nil>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32, global::System.Int32>>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::System.ValueTuple<global::System.Int32, global::System.Int32>>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::MagicOnion.Integration.Tests.MyStreamingResponse>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::MagicOnion.Integration.Tests.MyStreamingRequest>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::MagicOnion.Integration.Tests.MyUnaryResponse>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::MagicOnion.Integration.Tests.MyUnaryRequest>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.String>>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::System.String>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::MagicOnion.DynamicArgumentTuple<global::System.Int32, global::System.String, global::System.Boolean>>();
+            _ = MagicOnionResolver.Instance.GetFormatter<global::System.Boolean>();
         }
     }
 }


### PR DESCRIPTION
This is a workaround for an issue where Unity IL2CPP is unable to recognize generic virtual method calls for MessagePack's `IFormatterResolver` due to the serialization flow through the interface.

Type Hint to enable IL2CPP to generate code for `GetFormatter<T>`.