### PR TITLE
fix DeclaringType code generate issue #643

### DIFF
--- a/src/MagicOnion.GeneratorCore/CodeAnalysis/MagicOnionTypeInfo.cs
+++ b/src/MagicOnion.GeneratorCore/CodeAnalysis/MagicOnionTypeInfo.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using MagicOnion.Generator.Utils;
 using Microsoft.CodeAnalysis;
 
 namespace MagicOnion.Generator.CodeAnalysis;
@@ -167,7 +168,7 @@ public class MagicOnionTypeInfo : IEquatable<MagicOnionTypeInfo>
             return CreateEnum(type.Namespace, type.Name, CreateFromType(type.GetEnumUnderlyingType()));
         }
 
-        return Create(type.Namespace, type.Name, Array.Empty<MagicOnionTypeInfo>(), type.IsValueType);
+        return Create(type.Namespace, type.GetFullDeclaringTypeName(), Array.Empty<MagicOnionTypeInfo>(), type.IsValueType);
     }
 
     public static MagicOnionTypeInfo CreateFromSymbol(ITypeSymbol symbol)
@@ -186,7 +187,7 @@ public class MagicOnionTypeInfo : IEquatable<MagicOnionTypeInfo>
         if (finalSymbol is INamedTypeSymbol namedTypeSymbol)
         {
             var @namespace = finalSymbol.ContainingNamespace.IsGlobalNamespace ? string.Empty : finalSymbol.ContainingNamespace.ToDisplayString();
-            var name = finalSymbol.Name;
+            var name = finalSymbol.GetFullDeclaringTypeName();
             var typeArguments = namedTypeSymbol.TypeArguments.Select(MagicOnionTypeInfo.CreateFromSymbol).ToArray();
 
             MagicOnionTypeInfo type;

--- a/src/MagicOnion.GeneratorCore/Utils/TypeExtensions.cs
+++ b/src/MagicOnion.GeneratorCore/Utils/TypeExtensions.cs
@@ -1,0 +1,30 @@
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace MagicOnion.Generator.Utils;
+
+internal static class TypeExtensions
+{
+    public static string GetFullDeclaringTypeName(this Type type)
+    {
+        var typeNameParts = new List<string>();
+        while (type != null)
+        {
+            typeNameParts.Insert(0, type.Name);
+            type = type.DeclaringType;
+        }
+        return string.Join(".", typeNameParts);
+    }
+
+    public static string GetFullDeclaringTypeName(this ITypeSymbol typeSymbol)
+    {
+        return typeSymbol.ToDisplayString(
+            new SymbolDisplayFormat(
+                SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
+                SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
+                SymbolDisplayGenericsOptions.None,
+                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.ExpandNullable
+            ));
+    }
+
+}


### PR DESCRIPTION
Hi everyone,

I've developed two extension methods aimed at ensuring the generator accurately retrieves the full type name. Additionally, I've made some modifications to src/MagicOnion.GeneratorCore/CodeAnalysis/MagicOnionTypeInfo.cs.

I conducted local testing on my computer, and it appears that the issue has been resolved. However, as I'm not a Roslyn expert, I'm not completely confident whether this is the optimal solution. I would appreciate it if anyone could provide feedback or suggest improvements.