### PR TITLE
Fix unable to handle an interface with the same name

### DIFF
--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicClientBuilder.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicClientBuilder.cs
@@ -63,7 +63,7 @@ namespace MagicOnion.Client.DynamicClient
             // public class {ServiceName}Client : ClientBase<{ServiceName}>
             // {
             //
-            ctx.ServiceClientType = DynamicClientAssemblyHolder.Assembly.DefineType($"{ctx.Definition.ServiceInterfaceType.Name}Client", TypeAttributes.Public | TypeAttributes.Sealed, constructedBaseClientType, new[] { ctx.Definition.ServiceInterfaceType });
+            ctx.ServiceClientType = DynamicClientAssemblyHolder.Assembly.DefineType($"MagicOnion.DynamicallyGeneratedClient.{ctx.Definition.ServiceInterfaceType.Namespace}.{ctx.Definition.ServiceInterfaceType.Name}Client", TypeAttributes.Public | TypeAttributes.Sealed, constructedBaseClientType, new[] { ctx.Definition.ServiceInterfaceType });
             // Set `IgnoreAttribute` to the generated client type. Hides generated-types from building MagicOnion service definitions.
             ctx.ServiceClientType.SetCustomAttribute(new CustomAttributeBuilder(typeof(IgnoreAttribute).GetConstructor(Type.EmptyTypes), Array.Empty<object>()));
             {

--- a/src/MagicOnion.Client/DynamicClient/DynamicClientBuilder.cs
+++ b/src/MagicOnion.Client/DynamicClient/DynamicClientBuilder.cs
@@ -63,7 +63,7 @@ namespace MagicOnion.Client.DynamicClient
             // public class {ServiceName}Client : ClientBase<{ServiceName}>
             // {
             //
-            ctx.ServiceClientType = DynamicClientAssemblyHolder.Assembly.DefineType($"{ctx.Definition.ServiceInterfaceType.Name}Client", TypeAttributes.Public | TypeAttributes.Sealed, constructedBaseClientType, new[] { ctx.Definition.ServiceInterfaceType });
+            ctx.ServiceClientType = DynamicClientAssemblyHolder.Assembly.DefineType($"MagicOnion.DynamicallyGeneratedClient.{ctx.Definition.ServiceInterfaceType.Namespace}.{ctx.Definition.ServiceInterfaceType.Name}Client", TypeAttributes.Public | TypeAttributes.Sealed, constructedBaseClientType, new[] { ctx.Definition.ServiceInterfaceType });
             // Set `IgnoreAttribute` to the generated client type. Hides generated-types from building MagicOnion service definitions.
             ctx.ServiceClientType.SetCustomAttribute(new CustomAttributeBuilder(typeof(IgnoreAttribute).GetConstructor(Type.EmptyTypes), Array.Empty<object>()));
             {

--- a/tests/MagicOnion.Client.Tests/DynamicClient/SameInterfaceNameTest.cs
+++ b/tests/MagicOnion.Client.Tests/DynamicClient/SameInterfaceNameTest.cs
@@ -1,0 +1,49 @@
+using MagicOnion.Serialization;
+
+namespace MagicOnion.Client.Tests.DynamicClient
+{
+    public class SameInterfaceNameTest
+    {
+        [Fact]
+        public void Create_MagicOnionClient()
+        {
+            var callInvoker = Mock.Of<CallInvoker>();
+            MagicOnionClient.Create<MagicOnion.Client.Tests.DynamicClient.AreaA.IFoo>(callInvoker);
+            MagicOnionClient.Create<MagicOnion.Client.Tests.DynamicClient.AreaB.IFoo>(callInvoker);
+        }
+
+        [Fact]
+        public async Task DynamicStreamingHubClientFactoryProvider_TryGetFactory()
+        {
+            var callInvoker = Mock.Of<CallInvoker>();
+            var receiverA = Mock.Of<MagicOnion.Client.Tests.DynamicClient.AreaA.IBazHubReceiver>();
+            var receiverB = Mock.Of<MagicOnion.Client.Tests.DynamicClient.AreaB.IBazHubReceiver>();
+
+            DynamicStreamingHubClientFactoryProvider.Instance.TryGetFactory<MagicOnion.Client.Tests.DynamicClient.AreaA.IBazHub, MagicOnion.Client.Tests.DynamicClient.AreaA.IBazHubReceiver>(out var factoryA);
+            var clientA = factoryA(callInvoker, receiverA, "", default, MagicOnionSerializerProvider.Default, NullMagicOnionClientLogger.Instance);
+
+            DynamicStreamingHubClientFactoryProvider.Instance.TryGetFactory<MagicOnion.Client.Tests.DynamicClient.AreaB.IBazHub, MagicOnion.Client.Tests.DynamicClient.AreaB.IBazHubReceiver>(out var factoryB);
+            var clientB = factoryB(callInvoker, receiverB, "", default, MagicOnionSerializerProvider.Default, NullMagicOnionClientLogger.Instance);
+        }
+    }
+}
+
+namespace MagicOnion.Client.Tests.DynamicClient.AreaA
+{
+    public interface IFoo : IService<IFoo>
+    {}
+    public interface IBazHub : IStreamingHub<IBazHub, IBazHubReceiver>
+    {}
+    public interface IBazHubReceiver
+    {}
+}
+
+namespace MagicOnion.Client.Tests.DynamicClient.AreaB
+{
+    public interface IFoo : IService<IFoo>
+    {}
+    public interface IBazHub : IStreamingHub<IBazHub, IBazHubReceiver>
+    {}
+    public interface IBazHubReceiver
+    {}
+}


### PR DESCRIPTION
This PR fixes unable to handle an interface with the same name in a different namespace.

Fix #649 