### PR TITLE
doc: grpc_csharp_ext_dummy_stubs.c also apply to Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1201,8 +1201,8 @@ $ cd ${UNITY_PATH}/Plugins/Grpc.Core/runtime/android/${TARGET_ARCH}
 $ strip.exe libgrpc_csharp_ext.so
 ```
 
-## Workaround for il2cpp + Windows Build failure
-If you do a Windows il2cpp build with the gRPC daily build, the build may fail with following error messages.
+## Workaround for il2cpp + Windows/Linux Build failure
+If you do a Windows/Linux il2cpp build with the gRPC daily build, the build may fail with following error messages.
 
 ```
 20AAB1A42EE7F9CA535031CD347327DE.obj : error LNK2019: unresolved external symbol dlopen referenced in function Mono_dlopen_m7F2DE2CD0870AB15EEA4E0A0BA6C47044E74BB67
@@ -1212,7 +1212,7 @@ C:\Path\To\MyProject\Library\il2cpp_cache\linkresult_C1E926E002526A4D380E4B12B6B
 ```
 
 The reason is because some native function (but not nessessary at the runtime) not found on Windows il2cpp build.
-You can avoid this problem by adding the following code to `grpc_csharp_ext_dummy_stubs.c`.
+You can avoid this problem by adding the following code to `Assets/Pugins/Grpc.Core/runtimes/grpc_csharp_ext_dummy_stubs.c`. Then enable platform you needed, `Windows x86/x64` and/or `Linux x64`.
 
 ```c
 void* dlopen(const char* filename, int flags) {


### PR DESCRIPTION
## tl;dr;

grpc_csharp_ext_dummy_stubs.c is required not only Windows but also Linux.