### PR TITLE
Add StreamingHub metrics

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,8 @@
     <PackageVersion Include="MemoryPack" Version="$(MemoryPackVersion)" />
     <PackageVersion Include="MessagePack" Version="$(MessagePackVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="8.0.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
 
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
@@ -33,6 +35,7 @@
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.0.0" />
     <!-- from https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2-beta1.23163.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />

--- a/src/MagicOnion.Server/Diagnostics/MagicOnionMetrics.cs
+++ b/src/MagicOnion.Server/Diagnostics/MagicOnionMetrics.cs
@@ -1,0 +1,110 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using MagicOnion.Server.Hubs;
+using MagicOnion.Server.Internal;
+
+namespace MagicOnion.Server.Diagnostics;
+
+internal class MagicOnionMetrics : IDisposable
+{
+    public const string MeterName = "MagicOnion.Server";
+
+    static readonly object BoxedTrue = true;
+    static readonly object BoxedFalse = false;
+
+    readonly Meter meter;
+    readonly UpDownCounter<long> streamingHubConnections;
+    readonly Histogram<long> streamingHubMethodDuration;
+    readonly Counter<long> streamingHubMethodCompletedCounter;
+    readonly Counter<long> streamingHubMethodExceptionCounter;
+
+    public MagicOnionMetrics(IMeterFactory meterFactory)
+    {
+        meter = meterFactory.Create(MeterName);
+
+        streamingHubConnections = meter.CreateUpDownCounter<long>(
+            "magiconion.server.streaminghub.connections",
+            unit: "{connection}"
+        );
+        streamingHubMethodDuration = meter.CreateHistogram<long>(
+            "magiconion.server.streaminghub.method_duration",
+            unit: "ms"
+        );
+        streamingHubMethodCompletedCounter = meter.CreateCounter<long>(
+            "magiconion.server.streaminghub.method_completed",
+            unit: "{request}"
+        );
+        streamingHubMethodExceptionCounter = meter.CreateCounter<long>(
+            "magiconion.server.streaminghub.exceptions",
+            unit: "{exception}"
+        );
+    }
+
+    public void StreamingHubConnectionIncrement(in MetricsContext context, string serviceInterfaceType)
+    {
+        if (context.StreamingHubConnectionsEnabled)
+        {
+            streamingHubConnections.Add(1, InitializeTagListForStreamingHub(serviceInterfaceType));
+        }
+    }
+
+    public void StreamingHubConnectionDecrement(in MetricsContext context, string serviceInterfaceType)
+    {
+        if (context.StreamingHubConnectionsEnabled)
+        {
+            streamingHubConnections.Add(-1, InitializeTagListForStreamingHub(serviceInterfaceType));
+        }
+    }
+
+    public void StreamingHubMethodCompleted(in MetricsContext context, StreamingHubHandler handler, long startingTimestamp, long endingTimestamp, bool isErrorOrInterrupted)
+    {
+        if (context.StreamingHubMethodDurationEnabled || context.StreamingHubMethodCompletedCounterEnabled)
+        {
+            var tags = InitializeTagListForStreamingHub(handler.HubName);
+            tags.Add("rpc.method", handler.MethodInfo.Name);
+            tags.Add("magiconion.streaminghub.is_error", isErrorOrInterrupted ? BoxedTrue : BoxedFalse);
+            streamingHubMethodDuration.Record((long)StopwatchHelper.GetElapsedTime(startingTimestamp, endingTimestamp).TotalMilliseconds, tags);
+            streamingHubMethodCompletedCounter.Add(1, tags);
+        }
+    }
+
+    public void StreamingHubException(in MetricsContext context, StreamingHubHandler handler, Exception exception)
+    {
+        if (context.StreamingHubMethodExceptionCounterEnabled)
+        {
+            var tags = InitializeTagListForStreamingHub(handler.HubName);
+            tags.Add("rpc.method", handler.MethodInfo.Name);
+            tags.Add("error.type", exception.GetType().FullName!);
+            streamingHubMethodExceptionCounter.Add(1, tags);
+        }
+    }
+
+    static TagList InitializeTagListForStreamingHub(string hubName)
+    {
+        return new TagList()
+        {
+            {"rpc.system", "magiconion"},
+            {"rpc.service", hubName},
+        };
+    }
+
+    public void Dispose()
+    {
+        meter.Dispose();
+    }
+
+    public MetricsContext CreateContext()
+        => new MetricsContext(
+            streamingHubConnections.Enabled,
+            streamingHubMethodDuration.Enabled,
+            streamingHubMethodCompletedCounter.Enabled,
+            streamingHubMethodExceptionCounter.Enabled
+        );
+}
+
+internal readonly record struct MetricsContext(
+    bool StreamingHubConnectionsEnabled,
+    bool StreamingHubMethodDurationEnabled,
+    bool StreamingHubMethodCompletedCounterEnabled,
+    bool StreamingHubMethodExceptionCounterEnabled
+);

--- a/src/MagicOnion.Server/Extensions/MagicOnionServicesExtensions.cs
+++ b/src/MagicOnion.Server/Extensions/MagicOnionServicesExtensions.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Grpc.AspNetCore.Server.Model;
 using MagicOnion.Server;
+using MagicOnion.Server.Diagnostics;
 using MagicOnion.Server.Glue;
 using MagicOnion.Server.Hubs;
 using Microsoft.Extensions.Configuration;
@@ -42,6 +43,9 @@ public static class MagicOnionServicesExtensions
 
         services.AddSingleton<MagicOnionServiceDefinitionGlueDescriptor>(sp => new MagicOnionServiceDefinitionGlueDescriptor(glueServiceType, sp.GetRequiredService<MagicOnionServiceDefinition>()));
         services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IServiceMethodProvider<>).MakeGenericType(glueServiceType), typeof(MagicOnionGlueServiceMethodProvider<>).MakeGenericType(glueServiceType)));
+
+        services.AddMetrics();
+        services.TryAddSingleton<MagicOnionMetrics>();
 
         services.AddOptions<MagicOnionOptions>(configName)
             .Configure<IConfiguration>((o, configuration) =>

--- a/src/MagicOnion.Server/Internal/StopwatchHelper.cs
+++ b/src/MagicOnion.Server/Internal/StopwatchHelper.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics;
+
+namespace MagicOnion.Server.Internal;
+
+internal static class StopwatchHelper
+{
+#if NET7_0_OR_GREATER
+    public static TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp)
+        => Stopwatch.GetElapsedTime(startingTimestamp, endingTimestamp);
+#else
+#pragma warning disable IDE1006 // Naming Styles
+    const long TicksPerSecond = TicksPerMillisecond * 1000;
+    const long TicksPerMillisecond = 10000;
+    static readonly double tickFrequency = (double)TicksPerSecond / Stopwatch.Frequency;
+#pragma warning restore IDE1006 // Naming Styles
+
+    public static TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp)
+        => new TimeSpan((long)((endingTimestamp - startingTimestamp) * tickFrequency));
+#endif
+}

--- a/src/MagicOnion.Server/MagicOnion.Server.csproj
+++ b/src/MagicOnion.Server/MagicOnion.Server.csproj
@@ -5,6 +5,7 @@
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
 
     <DefineConstants>$(DefineConstants);NON_UNITY</DefineConstants>
 
@@ -20,6 +21,11 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore.Server" />
     <PackageReference Include="Grpc.Core.Api" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MagicOnion.Server/Service.cs
+++ b/src/MagicOnion.Server/Service.cs
@@ -1,4 +1,5 @@
 using Grpc.Core;
+using MagicOnion.Server.Diagnostics;
 using MessagePack;
 
 namespace MagicOnion.Server;
@@ -6,16 +7,15 @@ namespace MagicOnion.Server;
 public abstract class ServiceBase<TServiceInterface> : IService<TServiceInterface>
     where TServiceInterface : IServiceMarker
 {
-    public ServiceContext Context { get; set; }
+    // NOTE: Properties `Context` and `Metrics` are set by an internal setter during instance activation of the service.
+    //       For details, please refer to `ServiceProviderHelper.CreateService`.
+    public ServiceContext Context { get; internal set; }
+    internal MagicOnionMetrics Metrics { get; set; }
 
     public ServiceBase()
     {
         this.Context = default!;
-    }
-
-    internal ServiceBase(ServiceContext context)
-    {
-        this.Context = context;
+        this.Metrics = default!;
     }
 
     // Helpers

--- a/src/MagicOnion.Server/ServiceContext.cs
+++ b/src/MagicOnion.Server/ServiceContext.cs
@@ -4,6 +4,7 @@ using MagicOnion.Server.Diagnostics;
 using System.Collections.Concurrent;
 using System.Reflection;
 using MagicOnion.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace MagicOnion.Server;
@@ -82,6 +83,7 @@ public class ServiceContext : IServiceContext
     internal object? Result { get; set; }
     internal ILogger Logger { get; }
     internal MethodHandler MethodHandler { get; }
+    internal MetricsContext Metrics { get; }
 
     public ServiceContext(
         Type serviceType,
@@ -106,6 +108,8 @@ public class ServiceContext : IServiceContext
         this.Logger = logger;
         this.MethodHandler = methodHandler;
         this.ServiceProvider = serviceProvider;
+
+        this.Metrics = serviceProvider.GetRequiredService<MagicOnionMetrics>().CreateContext();
     }
 
     /// <summary>Gets a request object.</summary>

--- a/src/MagicOnion.Server/ServiceProviderHelper.cs
+++ b/src/MagicOnion.Server/ServiceProviderHelper.cs
@@ -1,3 +1,4 @@
+using MagicOnion.Server.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MagicOnion.Server;
@@ -10,6 +11,7 @@ internal static class ServiceProviderHelper
     {
         var instance = ActivatorUtilities.CreateInstance<TServiceBase>(context.ServiceProvider);
         instance.Context = context;
+        instance.Metrics = context.ServiceProvider.GetRequiredService<MagicOnionMetrics>();
         return instance;
     }
 }

--- a/tests/MagicOnion.Server.Tests/MagicOnion.Server.Tests.csproj
+++ b/tests/MagicOnion.Server.Tests/MagicOnion.Server.Tests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
+++ b/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
@@ -147,7 +147,8 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
         values[0].Tags["error.type"].Should().Be("System.InvalidOperationException");
     }
 
-    class Receiver : IMagicOnionMetricsTestHubReceiver;
+    class Receiver : IMagicOnionMetricsTestHubReceiver
+    {}
 }
 
 public class MagicOnionMetricsTestHub : StreamingHubBase<IMagicOnionMetricsTestHub, IMagicOnionMetricsTestHubReceiver>, IMagicOnionMetricsTestHub

--- a/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
+++ b/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
@@ -1,0 +1,192 @@
+using System.Diagnostics.Metrics;
+using Grpc.Net.Client;
+using MagicOnion.Client;
+using MagicOnion.Serialization.MessagePack;
+using MagicOnion.Server.Diagnostics;
+using MagicOnion.Server.Hubs;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+
+namespace MagicOnion.Server.Tests;
+
+public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<MagicOnionMetricsTestHub>>
+{
+    readonly WebApplicationFactory<MagicOnionTestServer.Program> factory;
+    readonly TestMeterFactory meterFactory;
+
+    public MagicOnionMetricsTest(MagicOnionApplicationFactory<MagicOnionMetricsTestHub> fixture)
+    {
+        meterFactory = new TestMeterFactory();
+        factory = fixture.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<MagicOnionMetrics>(new MagicOnionMetrics(meterFactory));
+            });
+        });
+    }
+
+    [Fact]
+    public async Task StreamingHubConnectionCounter()
+    {
+        var receiver = new Receiver();
+        using var collector = new MetricCollector<long>(meterFactory, MagicOnionMetrics.MeterName, "magiconion.server.streaminghub.connections");
+        IReadOnlyList<CollectedMeasurement<long>> values = collector.GetMeasurementSnapshot();
+        IReadOnlyList<CollectedMeasurement<long>> values2;
+        IReadOnlyList<CollectedMeasurement<long>> values3;
+
+        {
+            using var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
+            var client = await StreamingHubClient.ConnectAsync<IMagicOnionMetricsTestHub, IMagicOnionMetricsTestHubReceiver>(channel, receiver, serializerProvider: MessagePackMagicOnionSerializerProvider.Default);
+            values2 = collector.GetMeasurementSnapshot();
+            await client.DisposeAsync();
+        }
+
+        values3 = collector.GetMeasurementSnapshot();
+
+        values.Should().BeEmpty();
+
+        values2.Should().HaveCount(1);
+        values2[0].Value.Should().Be(1);
+        values2[0].Tags["rpc.system"].Should().Be("magiconion");
+        values2[0].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
+
+        values3.Should().HaveCount(2);
+        values3[0].Value.Should().Be(1);
+        values3[1].Value.Should().Be(-1);
+        values3[1].Tags["rpc.system"].Should().Be("magiconion");
+        values3[1].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
+    }
+
+    [Fact]
+    public async Task StreamingHubMethodDuration()
+    {
+        var receiver = new Receiver();
+        using var collector = new MetricCollector<long>(meterFactory, MagicOnionMetrics.MeterName, "magiconion.server.streaminghub.method_duration");
+        using var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
+        var client = await StreamingHubClient.ConnectAsync<IMagicOnionMetricsTestHub, IMagicOnionMetricsTestHubReceiver>(channel, receiver, serializerProvider: MessagePackMagicOnionSerializerProvider.Default);
+
+        await client.SleepAsync();
+
+        var values = collector.GetMeasurementSnapshot();
+
+        values.Should().HaveCount(1);
+        values[0].Value.Should().BeGreaterThanOrEqualTo(100);
+        values[0].Tags["rpc.system"].Should().Be("magiconion");
+        values[0].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
+        values[0].Tags["rpc.method"].Should().Be(nameof(IMagicOnionMetricsTestHub.SleepAsync));
+    }
+
+    [Fact]
+    public async Task StreamingHubMethodCompleted()
+    {
+        var receiver = new Receiver();
+        using var collector = new MetricCollector<long>(meterFactory, MagicOnionMetrics.MeterName, "magiconion.server.streaminghub.method_completed");
+        using var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
+        var client = await StreamingHubClient.ConnectAsync<IMagicOnionMetricsTestHub, IMagicOnionMetricsTestHubReceiver>(channel, receiver, serializerProvider: MessagePackMagicOnionSerializerProvider.Default);
+
+        await client.MethodAsync();
+
+        var values = collector.GetMeasurementSnapshot();
+
+        values.Should().HaveCount(1);
+        values[0].Value.Should().Be(1);
+        values[0].Tags["rpc.system"].Should().Be("magiconion");
+        values[0].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
+        values[0].Tags["rpc.method"].Should().Be(nameof(IMagicOnionMetricsTestHub.MethodAsync));
+        values[0].Tags["magiconion.streaminghub.is_error"].Should().Be(false);
+    }
+
+    [Fact]
+    public async Task StreamingHubMethodCompleted_Failure()
+    {
+        var receiver = new Receiver();
+        using var collector = new MetricCollector<long>(meterFactory, MagicOnionMetrics.MeterName, "magiconion.server.streaminghub.method_completed");
+        using var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
+        var client = await StreamingHubClient.ConnectAsync<IMagicOnionMetricsTestHub, IMagicOnionMetricsTestHubReceiver>(channel, receiver, serializerProvider: MessagePackMagicOnionSerializerProvider.Default);
+
+        try
+        {
+            await client.ThrowAsync();
+        }
+        catch
+        { }
+
+        var values = collector.GetMeasurementSnapshot();
+
+        values.Should().HaveCount(1);
+        values[0].Value.Should().Be(1);
+        values[0].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
+        values[0].Tags["rpc.method"].Should().Be(nameof(IMagicOnionMetricsTestHub.ThrowAsync));
+        values[0].Tags["magiconion.streaminghub.is_error"].Should().Be(true);
+    }
+
+    [Fact]
+    public async Task StreamingHubException()
+    {
+        var receiver = new Receiver();
+        using var collector = new MetricCollector<long>(meterFactory, MagicOnionMetrics.MeterName, "magiconion.server.streaminghub.exceptions");
+        using var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
+        var client = await StreamingHubClient.ConnectAsync<IMagicOnionMetricsTestHub, IMagicOnionMetricsTestHubReceiver>(channel, receiver, serializerProvider: MessagePackMagicOnionSerializerProvider.Default);
+
+        try
+        {
+            await client.ThrowAsync();
+        }
+        catch
+        { }
+
+        var values = collector.GetMeasurementSnapshot();
+
+        values.Should().HaveCount(1);
+        values[0].Value.Should().Be(1);
+        values[0].Tags["rpc.system"].Should().Be("magiconion");
+        values[0].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
+        values[0].Tags["rpc.method"].Should().Be(nameof(IMagicOnionMetricsTestHub.ThrowAsync));
+        values[0].Tags["error.type"].Should().Be("System.InvalidOperationException");
+    }
+
+    class Receiver : IMagicOnionMetricsTestHubReceiver;
+}
+
+public class MagicOnionMetricsTestHub : StreamingHubBase<IMagicOnionMetricsTestHub, IMagicOnionMetricsTestHubReceiver>, IMagicOnionMetricsTestHub
+{
+    public Task MethodAsync()
+        => Task.CompletedTask;
+    public async Task SleepAsync()
+        => await Task.Delay(100);
+    public async Task ThrowAsync()
+        => throw new InvalidOperationException();
+}
+
+public interface IMagicOnionMetricsTestHub : IStreamingHub<IMagicOnionMetricsTestHub, IMagicOnionMetricsTestHubReceiver>
+{
+    Task MethodAsync();
+    Task SleepAsync();
+    Task ThrowAsync();
+}
+
+public interface IMagicOnionMetricsTestHubReceiver
+{ }
+
+class TestMeterFactory : IMeterFactory
+{
+    public List<Meter> Meters { get; } = new List<Meter>();
+
+    public void Dispose()
+    {
+        foreach (var meter in Meters)
+        {
+            meter.Dispose();
+        }
+        Meters.Clear();
+    }
+
+    public Meter Create(MeterOptions options)
+    {
+        var meter = new Meter(options.Name, options.Version, options.Tags, scope: this);
+        Meters.Add(meter);
+        return meter;
+    }
+}

--- a/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
+++ b/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
@@ -73,7 +73,7 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
         var values = collector.GetMeasurementSnapshot();
 
         values.Should().HaveCount(1);
-        values[0].Value.Should().BeGreaterThanOrEqualTo(100);
+        values[0].Value.Should().BeGreaterThanOrEqualTo(90);
         values[0].Tags["rpc.system"].Should().Be("magiconion");
         values[0].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
         values[0].Tags["rpc.method"].Should().Be(nameof(IMagicOnionMetricsTestHub.SleepAsync));

--- a/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
+++ b/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
@@ -68,6 +68,7 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
         var client = await StreamingHubClient.ConnectAsync<IMagicOnionMetricsTestHub, IMagicOnionMetricsTestHubReceiver>(channel, receiver, serializerProvider: MessagePackMagicOnionSerializerProvider.Default);
 
         await client.SleepAsync();
+        await Task.Delay(100);
 
         var values = collector.GetMeasurementSnapshot();
 
@@ -87,6 +88,7 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
         var client = await StreamingHubClient.ConnectAsync<IMagicOnionMetricsTestHub, IMagicOnionMetricsTestHubReceiver>(channel, receiver, serializerProvider: MessagePackMagicOnionSerializerProvider.Default);
 
         await client.MethodAsync();
+        await Task.Delay(100);
 
         var values = collector.GetMeasurementSnapshot();
 
@@ -112,6 +114,7 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
         }
         catch
         { }
+        await Task.Delay(100);
 
         var values = collector.GetMeasurementSnapshot();
 
@@ -136,6 +139,7 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
         }
         catch
         { }
+        await Task.Delay(100);
 
         var values = collector.GetMeasurementSnapshot();
 


### PR DESCRIPTION
This PR introduces metrics related to StreamingHub using System.Diagnostics.Metrics. 

- see: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics

## Meter: MagicOnion.Server

|Metric|Unit|Tags|
|--|--|--|
|magiconion.server.streaminghub.connections|`{connection}`|`rpc.system`, `rpc.service`|
|magiconion.server.streaminghub.method_duration|`ms`|`rpc.system`, `rpc.service`, `rpc.method`|
|magiconion.server.streaminghub.method_completed|`{request}`|`rpc.system`, `rpc.service`, `rpc.method`, `magiconion.streaminghub.is_error`|
|magiconion.server.streaminghub.exceptions|`{exception}`|`rpc.system`, `rpc.service`, `rpc.method`, `error.type`|

### Tags
|Tag name|Value|
|--|--|
|rpc.system|`magiconion`|
|rpc.service|StreamingHub interface name (e.g. `IGreeterService`)|
|rpc.method|StreamingHub method name (e.g. `HelloAsync`)|
|magiconion.streaminghub.is_error|Whether a StreamingHub method call succeeded or failed.  (e.g. `true` or `false`)|
|error.type|Thrown exception type (e.g. `System.InvalidOperationException`)|