### PR TITLE
Fix compilation error at build time

### DIFF
--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Unity/GrpcChannelx.cs
@@ -117,7 +117,7 @@ namespace MagicOnion
 #if UNITY_EDITOR || MAGICONION_ENABLE_CHANNEL_DIAGNOSTICS
             return new ChannelStats.WrappedCallInvoker(((IGrpcChannelxDiagnosticsInfo)this).Stats, channel.CreateCallInvoker());
 #else
-            return _channel.CreateCallInvoker();
+            return channel.CreateCallInvoker();
 #endif
         }
 
@@ -138,7 +138,7 @@ namespace MagicOnion
         {
             ThrowIfDisposed();
 #if MAGICONION_USE_GRPC_CCORE
-            if (_channel is Channel grpcCChannel)
+            if (channel is Channel grpcCChannel)
             {
                 await grpcCChannel.ConnectAsync(deadline);
             }


### PR DESCRIPTION
The project using MagicOnion v6.0.0 failed to build.
`_channel` has been renamed to `channel` in https://github.com/Cysharp/MagicOnion/commit/df1d749b412fdd22451fa971f3b02ef789cdd7be, but two variables remain unchanged.
