### PR TITLE
ci: Cysharp/Actions/.github/workflows/create-release.yaml

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,71 +6,20 @@ on:
       tag:
         description: "tag: git tag you want create. (sample 1.0.0)"
         required: true
-      dry_run:
-        description: "dry_run: true will never create relase/nuget."
+      dry-run:
+        description: "dry-run: true will never create relase/nuget."
         required: true
-        default: "false"
-
-env:
-  GIT_TAG: ${{ github.event.inputs.tag }}
-  DRY_RUN: ${{ github.event.inputs.dry_run }}
-  DRY_RUN_BRANCH_PREFIX: "test_release"
-  BUILD_CONFIG: Release
+        default: false
+        type: boolean
 
 jobs:
   update-packagejson:
-    runs-on: ubuntu-latest
-    env:
-      TARGET_FILE: ./src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/package.json
-    outputs:
-      sha: ${{ steps.commit.outputs.sha }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Output package.json (Before)
-        run: cat ${{ env.TARGET_FILE}}
-
-      - name: Update package.json to version ${{ env.GIT_TAG }}
-        run: sed -i -e "s/\(\"version\":\) \"\(.*\)\",/\1 \"${{ env.GIT_TAG }}\",/" ${{ env.TARGET_FILE }}
-
-      - name: Check update
-        id: check_update
-        run: |
-          cat ${{ env.TARGET_FILE}}
-          git diff --exit-code || echo "::set-output name=changed::1"
-
-      - name: Commit files
-        id: commit
-        if: steps.check_update.outputs.changed == '1'
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git commit -m "feat: Update package.json to ${{ env.GIT_TAG }}" -a
-          echo "::set-output name=sha::$(git rev-parse HEAD)"
-
-      - name: Check sha
-        run: echo "SHA ${SHA}"
-        env:
-          SHA: ${{ steps.commit.outputs.sha }}
-
-      - name: Create Tag
-        if: steps.check_update.outputs.changed == '1'
-        run: git tag ${{ env.GIT_TAG }}
-
-      - name: Push changes
-        if: env.DRY_RUN == 'false' && steps.check_update.outputs.changed == '1'
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
-          tags: true
-
-      - name: Push changes (dry_run)
-        if: env.DRY_RUN == 'true' && steps.check_update.outputs.changed == '1'
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ env.DRY_RUN_BRANCH_PREFIX }}-${{ env.GIT_TAG }}
-          tags: false
+    uses: Cysharp/Actions/.github/workflows/update-packagejson.yaml@main
+    with:
+      file-path: ./src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/package.json
+      tag: ${{ inputs.tag }}
+      dry-run: ${{ inputs.dry-run }}
+      push-tag: false
 
   build-dotnet:
     needs: [update-packagejson]
@@ -82,9 +31,9 @@ jobs:
         with:
           ref: ${{ needs.update-packagejson.outputs.sha }}
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-      - run: dotnet build -c ${{ env.BUILD_CONFIG }} ./MagicOnion.sln
+      - run: dotnet build -c Release ./MagicOnion.sln
       # pack nuget
-      - run: dotnet pack -c ${{ env.BUILD_CONFIG }} ./MagicOnion.Packaging.slnf  --include-symbols --include-source --no-build -o ./publish
+      - run: dotnet pack -c Release ./MagicOnion.Packaging.slnf  --include-symbols --include-source --no-build -o ./publish
       - uses: actions/upload-artifact@v1
         with:
           name: nuget
@@ -109,7 +58,7 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_PACKAGE_VERSION: ${{ env.GIT_TAG }}
+          UNITY_PACKAGE_VERSION: ${{ inputs.tag }}
         with:
           projectPath: src/MagicOnion.Client.Unity
           unityVersion: ${{ matrix.unity }}
@@ -126,47 +75,22 @@ jobs:
           name: MagicOnion.Client.Unity.unitypackage
           path: ./src/MagicOnion.Client.Unity/MagicOnion.Client.Unity.unitypackage
 
+  # release
   create-release:
-    if: github.event.inputs.dry_run == 'false'
-    needs:
-      [update-packagejson, build-dotnet, build-unity]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ needs.update-packagejson.outputs.sha }}
-      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-      # Create Release
-      - uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.GIT_TAG }}
-          release_name: ${{ env.GIT_TAG }}
-          commitish: ${{ needs.update-packagejson.outputs.sha }}
-          draft: true
-          prerelease: false
-      - uses: actions/download-artifact@v2-preview
-      # Upload to NuGet
-      - run: dotnet nuget push "./nuget/*.nupkg" --skip-duplicate -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
-      # Upload to Releases(unitypackage)
-      - uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./MagicOnion.Client.Unity.unitypackage/MagicOnion.Client.Unity.unitypackage
-          asset_name: MagicOnion.Client.Unity.unitypackage
-          asset_content_type: application/octet-stream
+    needs: [update-packagejson, build-dotnet, build-unity]
+    uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
+    with:
+      commit-id: ${{ needs.update-packagejson.outputs.sha }}
+      dry-run: ${{ inputs.dry-run }}
+      tag: ${{ inputs.tag }}
+      nuget-push: true
+      release-upload: true
+      release-asset-path: ./MagicOnion.Client.Unity.unitypackage/MagicOnion.Client.Unity.unitypackage
+    secrets: inherit
 
   cleanup:
-    if: github.event.inputs.dry_run == 'true'
-    needs: [build-dotnet, build-unity]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete branch
-        uses: dawidd6/action-delete-branch@v3
-        with:
-          github_token: ${{ github.token }}
-          branches: ${{ env.DRY_RUN_BRANCH_PREFIX }}-${{ env.GIT_TAG }}
+    if: ${{ needs.update-packagejson.outputs.is-branch-created == 'true' }}
+    needs: [build-dotnet, update-packagejson, build-unity]
+    uses: Cysharp/Actions/.github/workflows/clean-packagejson-branch.yaml@main
+    with:
+      branch: ${{ needs.update-packagejson.outputs.branch-name }}


### PR DESCRIPTION
## tl;dr;

Replace create-release with `Cysharp/Actions/.github/workflows/create-release.yaml`.

This brings central managed release flow control.

see: https://github.com/Cysharp/MagicOnion/actions/runs/7814173114