### PR TITLE
ci: remove Ver. prefix for release 

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -86,6 +86,7 @@ jobs:
       nuget-push: true
       release-upload: true
       release-asset-path: ./MagicOnion.Client.Unity.unitypackage/MagicOnion.Client.Unity.unitypackage
+      release-format: '{0}'
     secrets: inherit
 
   cleanup:


### PR DESCRIPTION
Follow current release name style.

![image](https://github.com/Cysharp/MagicOnion/assets/3856350/caa4eb48-d6b2-4f40-9207-3cb437d811d3)
