### PR TITLE
Move GenerateSerializerType into MagicOnionClientGenerationAttribute

### DIFF
--- a/src/MagicOnion.Client.SourceGenerator/MagicOnionClientSourceGenerator.Emitter.cs
+++ b/src/MagicOnion.Client.SourceGenerator/MagicOnionClientSourceGenerator.Emitter.cs
@@ -38,34 +38,34 @@ public partial class MagicOnionClientSourceGenerator
                         /// <summary>
                         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
                         /// </summary>
-                        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+                        public global::MagicOnion.Client.{{MagicOnionClientGenerationAttributeName}}.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.{{MagicOnionClientGenerationAttributeName}}.GenerateSerializerType.MessagePack;
 
                         /// <summary>
                         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
                         /// </summary>
                         public string MessagePackFormatterNamespace { get; set; } = "MessagePack.Formatters";
-                
+
                         /// <summary>
                         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
                         /// </summary>
                         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-                        
+
                         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
                         public global::System.Type[] TypesContainedInTargetAssembly { get; }
-                
+
                         /// <param name="typesContainedInTargetAssembly">Types contained in the scan target assembly</param>
                         public {{MagicOnionClientGenerationAttributeName}}(params global::System.Type[] typesContainedInTargetAssembly)
                         {
                             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
                         }
-                    }
 
-                    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-                    internal enum GenerateSerializerType
-                    {
-                        MessagePack = 0,
-                        MemoryPack = 1,
+                        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+                        internal enum GenerateSerializerType
+                        {
+                            MessagePack = 0,
+                            MemoryPack = 1,
+                        }
                     }
                 }
                 """);

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/GenerateMemoryPackTest.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/GenerateMemoryPackTest.cs
@@ -22,7 +22,7 @@ public class GenerateMemoryPackTest
         [MemoryPackable]
         public class MyGenericObject<T> {}
         
-        [MagicOnionClientGeneration(typeof(IGreeterService), Serializer = GenerateSerializerType.MemoryPack)]
+        [MagicOnionClientGeneration(typeof(IGreeterService), Serializer = MagicOnionClientGenerationAttribute.GenerateSerializerType.MemoryPack)]
         partial class MagicOnionInitializer {}
         """;
 

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/GeneratorOptionsTest.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/GeneratorOptionsTest.cs
@@ -94,7 +94,7 @@ public class GeneratorOptionsTest
             UnaryResult<string> HelloAsync(string name, int age);
         }
 
-        [MagicOnionClientGeneration(typeof(IGreeterService), Serializer = GenerateSerializerType.MemoryPack)]
+        [MagicOnionClientGeneration(typeof(IGreeterService), Serializer = MagicOnionClientGenerationAttribute.GenerateSerializerType.MemoryPack)]
         partial class MagicOnionInitializer {}
         """;
 

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateEnumFormatterTest/GenerateEnumFormatter_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateEnumFormatterTest/GenerateEnumFormatter_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateEnumFormatterTest/GenerateEnumFormatter_Parameter/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateEnumFormatterTest/GenerateEnumFormatter_Parameter/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateEnumFormatterTest/GenerateEnumFormatter_Parameter_Nullable/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateEnumFormatterTest/GenerateEnumFormatter_Parameter_Nullable/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateEnumFormatterTest/GenerateEnumFormatter_Return/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateEnumFormatterTest/GenerateEnumFormatter_Return/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateEnumFormatterTest/GenerateEnumFormatter_Return_Nullable/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateEnumFormatterTest/GenerateEnumFormatter_Return_Nullable/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_ArrayFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_ArrayFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_ArrayFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_ArrayFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_ListFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_ListFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_ListFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_ListFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_MultipleTypeArgs/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_MultipleTypeArgs/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_Nested_Array/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_Nested_Array/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_Nested_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/HubReceiver_Nested_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_ArrayFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_ArrayFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_ArrayFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_ArrayFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_ListFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_ListFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_ListFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_ListFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_MultipleTypeArgs/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_MultipleTypeArgs/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_Nested_Array/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_Nested_Array/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_Nested_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Parameters_Nested_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_ArrayFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_ArrayFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_ArrayFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_ArrayFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_ListFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_ListFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_ListFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_ListFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_MultipleTypeArgs/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_MultipleTypeArgs/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_Nested_Array/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_Nested_Array/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_Nested_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsStreamingHubTest/Return_Nested_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/KnownFormatters/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/KnownFormatters/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_ArrayFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_ArrayFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_ArrayFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_ArrayFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_ListFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_ListFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_ListFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_ListFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_Nested_Array/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_Nested_Array/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_Nested_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Parameters_Nested_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_ArrayFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_ArrayFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_ArrayFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_ArrayFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_ListFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_ListFormatter_KnownType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_ListFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_ListFormatter_UserType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_MultipleTypeArgs/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_MultipleTypeArgs/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_Nested/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_Nested_Array/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_Nested_Array/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_Nested_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateGenericsTest/Return_Nested_Enum/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateMemoryPackTest/Generic/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateMemoryPackTest/Generic/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateNullableTest/NullableReferenceType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateNullableTest/NullableReferenceType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateNullableTest/NullableValueType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateNullableTest/NullableValueType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateRawStreamingTest/StreamingResult/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateRawStreamingTest/StreamingResult/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Invalid_Return_NonGenerics/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Invalid_Return_NonGenerics/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Invalid_Return_NonSupportedUnaryResultOfT/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Invalid_Return_NonSupportedUnaryResultOfT/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Invalid_Return_RawStreaming_NonTask/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Invalid_Return_RawStreaming_NonTask/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Invalid_Return_TaskOfUnaryResultOfT/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Invalid_Return_TaskOfUnaryResultOfT/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Return_StreamingResult/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Return_StreamingResult/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Return_UnaryResultNonGeneric/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Return_UnaryResultNonGeneric/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Return_UnaryResultOfRefType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Return_UnaryResultOfRefType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Return_UnaryResultOfT/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Return_UnaryResultOfT/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Return_UnaryResultOfValueType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateServiceTest/Return_UnaryResultOfValueType/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubDiagnosticHandlerTest/Generate/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubDiagnosticHandlerTest/Generate/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Complex/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Complex/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/HubReceiver_Parameter_Many/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/HubReceiver_Parameter_Many/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/HubReceiver_Parameter_One/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/HubReceiver_Parameter_One/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/HubReceiver_Parameter_Zero/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/HubReceiver_Parameter_Zero/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/InterfaceInheritance/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/InterfaceInheritance/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/InterfaceInheritance_Receiver/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/InterfaceInheritance_Receiver/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Invalid_HubReceiver_ReturnsNotVoid/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Invalid_HubReceiver_ReturnsNotVoid/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Invalid_Return_Void/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Invalid_Return_Void/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Parameter_Many/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Parameter_Many/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Parameter_One/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Parameter_One/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Parameter_Zero/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Parameter_Zero/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Return_Task/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Return_Task/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Return_TaskOfT/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Return_TaskOfT/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Return_ValueTask/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Return_ValueTask/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Return_ValueTaskOfT/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubTest/Return_ValueTaskOfT/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateTest/Generate/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateTest/Generate/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateTest/Generate_Namespace/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateTest/Generate_Namespace/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateTest/ImplicitUsings_PropertyGroup_Enable/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateTest/ImplicitUsings_PropertyGroup_Enable/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateTest/NoGenerate/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateTest/NoGenerate/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateTest/NotPartial/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateTest/NotPartial/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateWithIfDirectiveTest/Skip_Generation_Service_Interface/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateWithIfDirectiveTest/Skip_Generation_Service_Interface/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateWithIfDirectiveTest/Skip_Generation_StreamingHub_Interface/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateWithIfDirectiveTest/Skip_Generation_StreamingHub_Interface/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GeneratorOptionsTest/Default/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GeneratorOptionsTest/Default/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GeneratorOptionsTest/DisableAutoRegistration/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GeneratorOptionsTest/DisableAutoRegistration/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GeneratorOptionsTest/MessagePackFormatterNamespace/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GeneratorOptionsTest/MessagePackFormatterNamespace/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GeneratorOptionsTest/Serializer_MemoryPack/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GeneratorOptionsTest/Serializer_MemoryPack/0000_MagicOnionClientSourceGeneratorAttributes.g.cs
@@ -17,7 +17,7 @@ namespace MagicOnion.Client
         /// <summary>
         /// Gets or set the serializer used for message serialization. The default value is <see cref="GenerateSerializerType.MessagePack"/>.
         /// </summary>
-        public global::MagicOnion.Client.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.GenerateSerializerType.MessagePack;
+        public global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType Serializer { get; set; } = global::MagicOnion.Client.MagicOnionClientGenerationAttribute.GenerateSerializerType.MessagePack;
 
         /// <summary>
         /// Gets or set the namespace of pre-generated MessagePackFormatters. The default value is <c>MessagePack.Formatters</c>.
@@ -28,7 +28,7 @@ namespace MagicOnion.Client
         /// Gets or set whether to enable the StreamingHandler diagnostic handler. This is for debugging purpose. The default value is <see langword="false" />.
         /// </summary>
         public bool EnableStreamingHubDiagnosticHandler { get; set; } = false;
-        
+
         public string GenerateFileHintNamePrefix { get; set; } = string.Empty;
 
         public global::System.Type[] TypesContainedInTargetAssembly { get; }
@@ -38,12 +38,12 @@ namespace MagicOnion.Client
         {
             TypesContainedInTargetAssembly = typesContainedInTargetAssembly;
         }
-    }
 
-    // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
-    internal enum GenerateSerializerType
-    {
-        MessagePack = 0,
-        MemoryPack = 1,
+        // This enum must be mirror of `SerializerType` (MagicOnionClientSourceGenerator)
+        internal enum GenerateSerializerType
+        {
+            MessagePack = 0,
+            MemoryPack = 1,
+        }
     }
 }

--- a/tests/MagicOnion.Serialization.MemoryPack.Tests/MagicOnionGeneratedClientInitializer.cs
+++ b/tests/MagicOnion.Serialization.MemoryPack.Tests/MagicOnionGeneratedClientInitializer.cs
@@ -2,6 +2,6 @@ using MagicOnion.Client;
 
 namespace MagicOnion.Serialization.MemoryPack.Tests;
 
-[MagicOnionClientGeneration(typeof(MagicOnionGeneratedClientInitializer), Serializer = GenerateSerializerType.MemoryPack)]
+[MagicOnionClientGeneration(typeof(MagicOnionGeneratedClientInitializer), Serializer = MagicOnionClientGenerationAttribute.GenerateSerializerType.MemoryPack)]
 public partial class MagicOnionGeneratedClientInitializer
 {}


### PR DESCRIPTION
Fixes #738

`GenerateSerializerType` remains after compiling, which causes conflicts with `InternalsVisibleTo`.
Accordingly, `GenerateSerializerType` has been moved under `MagicOnionClientGenerationAttribute`, which is a breaking change.

## Before
```csharp
[MagicOnionClientGeneration(typeof(IGreeterService), Serializer = GenerateSerializerType.MemoryPack)]
partial class MagicOnionInitializer {}
```

## After
```csharp
[MagicOnionClientGeneration(typeof(IGreeterService), Serializer = MagicOnionClientGenerationAttribute.GenerateSerializerType.MemoryPack)]
partial class MagicOnionInitializer {}
```