### PR TITLE
OnRequestBegin/OnRequestEnd -> OnMethodInvoke

### DIFF
--- a/src/MagicOnion.Client.SourceGenerator/CodeGen/StaticStreamingHubClientGenerator.cs
+++ b/src/MagicOnion.Client.SourceGenerator/CodeGen/StaticStreamingHubClientGenerator.cs
@@ -118,38 +118,24 @@ public class StaticStreamingHubClientGenerator
         if (ctx.EnableStreamingHubDiagnosticHandler)
         {
             ctx.Writer.AppendLineWithFormat($$"""
-                            async global::System.Threading.Tasks.Task<TResponse> WriteMessageWithResponseDiagnosticAsync<TRequest, TResponse>(int methodId, TRequest message, [global::System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = default!)
+                            global::System.Threading.Tasks.Task<TResponse> WriteMessageWithResponseDiagnosticAsync<TRequest, TResponse>(int methodId, TRequest message, [global::System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = default!)
                             {
-                                var requestId = global::System.Guid.NewGuid();
-                                diagnosticHandler?.OnRequestBegin(this, requestId, callerMemberName, message, isFireAndForget: false);
-                                try
+                                if (diagnosticHandler is null)
                                 {
-                                    var result = await base.WriteMessageWithResponseAsync<TRequest, TResponse>(methodId, message).ConfigureAwait(false);
-                                    diagnosticHandler?.OnRequestEnd(this, requestId, callerMemberName, result, default);
-                                    return result;
+                                    return base.WriteMessageWithResponseAsync<TRequest, TResponse>(methodId, message);
                                 }
-                                catch (global::System.Exception e)
-                                {
-                                    diagnosticHandler?.OnRequestEnd(this, requestId, callerMemberName, default(TResponse), e);
-                                    throw;
-                                }
+
+                                return diagnosticHandler.OnMethodInvoke(this, methodId, callerMemberName, message, isFireAndForget: true, base.WriteMessageWithResponseAsync<TRequest, TResponse>);
                             }
-                            
-                            async global::System.Threading.Tasks.Task<TResponse> WriteMessageFireAndForgetDiagnosticAsync<TRequest, TResponse>(int methodId, TRequest message, [global::System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = default!)
+
+                            global::System.Threading.Tasks.Task<TResponse> WriteMessageFireAndForgetDiagnosticAsync<TRequest, TResponse>(int methodId, TRequest message, [global::System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = default!)
                             {
-                                var requestId = global::System.Guid.NewGuid();
-                                diagnosticHandler?.OnRequestBegin(this, requestId, callerMemberName, message, isFireAndForget: true);
-                                try
+                                if (diagnosticHandler is null)
                                 {
-                                    var result = await base.WriteMessageFireAndForgetAsync<TRequest, TResponse>(methodId, message).ConfigureAwait(false);
-                                    diagnosticHandler?.OnRequestEnd(this, requestId, callerMemberName, result, default);
-                                    return result;
+                                    return base.WriteMessageFireAndForgetAsync<TRequest, TResponse>(methodId, message);
                                 }
-                                catch (global::System.Exception e)
-                                {
-                                    diagnosticHandler?.OnRequestEnd(this, requestId, callerMemberName, default(TResponse), e);
-                                    throw;
-                                }
+
+                                return diagnosticHandler.OnMethodInvoke(this, methodId, callerMemberName, message, isFireAndForget: true, base.WriteMessageFireAndForgetAsync<TRequest, TResponse>);
                             }
             """);
             ctx.Writer.AppendLine();
@@ -193,7 +179,7 @@ public class StaticStreamingHubClientGenerator
 
                                 public FireAndForgetClient({{ctx.Hub.GetClientFullName()}} parent)
                                     => this.parent = parent;
-            
+
                                 public {{ctx.Hub.ServiceType.FullName}} FireAndForget() => this;
                                 public global::System.Threading.Tasks.Task DisposeAsync() => throw new global::System.NotSupportedException();
                                 public global::System.Threading.Tasks.Task WaitForDisconnect() => throw new global::System.NotSupportedException();

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IStreamingHubDiagnosticHandler.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IStreamingHubDiagnosticHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace MagicOnion.Client
 {
@@ -7,29 +8,21 @@ namespace MagicOnion.Client
     /// </summary>
     public interface IStreamingHubDiagnosticHandler
     {
+        public delegate Task<TResponse> InvokeMethodDelegate<TRequest, TResponse>(int methodId, TRequest value);
+
         /// <summary>
         /// The callback method at the beginning of a Hub method request. This API may change in the future.
         /// </summary>
         /// <typeparam name="THub"></typeparam>
         /// <typeparam name="TRequest"></typeparam>
+        /// <typeparam name="TResponse"></typeparam>
         /// <param name="hubInstance"></param>
-        /// <param name="requestId"></param>
+        /// <param name="methodId"></param>
         /// <param name="methodName"></param>
         /// <param name="request"></param>
         /// <param name="isFireAndForget"></param>
-        void OnRequestBegin<THub, TRequest>(THub hubInstance, Guid requestId, string methodName, TRequest request, bool isFireAndForget);
-
-        /// <summary>
-        /// [Preview] The callback method at the end of a Hub method request. This API may change in the future.
-        /// </summary>
-        /// <typeparam name="THub"></typeparam>
-        /// <typeparam name="TResponse"></typeparam>
-        /// <param name="hubInstance"></param>
-        /// <param name="requestId"></param>
-        /// <param name="methodName"></param>
-        /// <param name="response"></param>
-        /// <param name="exception"></param>
-        void OnRequestEnd<THub, TResponse>(THub hubInstance, Guid requestId, string methodName, TResponse response, Exception? exception);
+        /// <param name="invokeMethod"></param>
+        Task<TResponse> OnMethodInvoke<THub, TRequest, TResponse>(THub hubInstance, int methodId, string methodName, TRequest request, bool isFireAndForget, InvokeMethodDelegate<TRequest, TResponse> invokeMethod);
 
         /// <summary>
         /// [Preview] The callback method when a method of HubReceiver is invoked. This API may change in the future.

--- a/src/MagicOnion.Client/IStreamingHubDiagnosticHandler.cs
+++ b/src/MagicOnion.Client/IStreamingHubDiagnosticHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace MagicOnion.Client
 {
@@ -7,29 +8,21 @@ namespace MagicOnion.Client
     /// </summary>
     public interface IStreamingHubDiagnosticHandler
     {
+        public delegate Task<TResponse> InvokeMethodDelegate<TRequest, TResponse>(int methodId, TRequest value);
+
         /// <summary>
         /// The callback method at the beginning of a Hub method request. This API may change in the future.
         /// </summary>
         /// <typeparam name="THub"></typeparam>
         /// <typeparam name="TRequest"></typeparam>
+        /// <typeparam name="TResponse"></typeparam>
         /// <param name="hubInstance"></param>
-        /// <param name="requestId"></param>
+        /// <param name="methodId"></param>
         /// <param name="methodName"></param>
         /// <param name="request"></param>
         /// <param name="isFireAndForget"></param>
-        void OnRequestBegin<THub, TRequest>(THub hubInstance, Guid requestId, string methodName, TRequest request, bool isFireAndForget);
-
-        /// <summary>
-        /// [Preview] The callback method at the end of a Hub method request. This API may change in the future.
-        /// </summary>
-        /// <typeparam name="THub"></typeparam>
-        /// <typeparam name="TResponse"></typeparam>
-        /// <param name="hubInstance"></param>
-        /// <param name="requestId"></param>
-        /// <param name="methodName"></param>
-        /// <param name="response"></param>
-        /// <param name="exception"></param>
-        void OnRequestEnd<THub, TResponse>(THub hubInstance, Guid requestId, string methodName, TResponse response, Exception? exception);
+        /// <param name="invokeMethod"></param>
+        Task<TResponse> OnMethodInvoke<THub, TRequest, TResponse>(THub hubInstance, int methodId, string methodName, TRequest request, bool isFireAndForget, InvokeMethodDelegate<TRequest, TResponse> invokeMethod);
 
         /// <summary>
         /// [Preview] The callback method when a method of HubReceiver is invoked. This API may change in the future.

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubDiagnosticHandlerTest/Generate/0003_TempProject_MyHubClient.g.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Resources/GenerateStreamingHubDiagnosticHandlerTest/Generate/0003_TempProject_MyHubClient.g.cs
@@ -22,38 +22,24 @@ namespace TempProject
                     this.diagnosticHandler = diagnosticHandler;
                 }
 
-                async global::System.Threading.Tasks.Task<TResponse> WriteMessageWithResponseDiagnosticAsync<TRequest, TResponse>(int methodId, TRequest message, [global::System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = default!)
+                global::System.Threading.Tasks.Task<TResponse> WriteMessageWithResponseDiagnosticAsync<TRequest, TResponse>(int methodId, TRequest message, [global::System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = default!)
                 {
-                    var requestId = global::System.Guid.NewGuid();
-                    diagnosticHandler?.OnRequestBegin(this, requestId, callerMemberName, message, isFireAndForget: false);
-                    try
+                    if (diagnosticHandler is null)
                     {
-                        var result = await base.WriteMessageWithResponseAsync<TRequest, TResponse>(methodId, message).ConfigureAwait(false);
-                        diagnosticHandler?.OnRequestEnd(this, requestId, callerMemberName, result, default);
-                        return result;
+                        return base.WriteMessageWithResponseAsync<TRequest, TResponse>(methodId, message);
                     }
-                    catch (global::System.Exception e)
-                    {
-                        diagnosticHandler?.OnRequestEnd(this, requestId, callerMemberName, default(TResponse), e);
-                        throw;
-                    }
+
+                    return diagnosticHandler.OnMethodInvoke(this, methodId, callerMemberName, message, isFireAndForget: true, base.WriteMessageWithResponseAsync<TRequest, TResponse>);
                 }
-                
-                async global::System.Threading.Tasks.Task<TResponse> WriteMessageFireAndForgetDiagnosticAsync<TRequest, TResponse>(int methodId, TRequest message, [global::System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = default!)
+
+                global::System.Threading.Tasks.Task<TResponse> WriteMessageFireAndForgetDiagnosticAsync<TRequest, TResponse>(int methodId, TRequest message, [global::System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = default!)
                 {
-                    var requestId = global::System.Guid.NewGuid();
-                    diagnosticHandler?.OnRequestBegin(this, requestId, callerMemberName, message, isFireAndForget: true);
-                    try
+                    if (diagnosticHandler is null)
                     {
-                        var result = await base.WriteMessageFireAndForgetAsync<TRequest, TResponse>(methodId, message).ConfigureAwait(false);
-                        diagnosticHandler?.OnRequestEnd(this, requestId, callerMemberName, result, default);
-                        return result;
+                        return base.WriteMessageFireAndForgetAsync<TRequest, TResponse>(methodId, message);
                     }
-                    catch (global::System.Exception e)
-                    {
-                        diagnosticHandler?.OnRequestEnd(this, requestId, callerMemberName, default(TResponse), e);
-                        throw;
-                    }
+
+                    return diagnosticHandler.OnMethodInvoke(this, methodId, callerMemberName, message, isFireAndForget: true, base.WriteMessageFireAndForgetAsync<TRequest, TResponse>);
                 }
 
                 public global::System.Threading.Tasks.Task MethodA()


### PR DESCRIPTION
This PR combines two methods into a single method that can be interrupted in processing.
`IStreamingHubDiagnosticHandler` implementation must call invokeMethod.

```diff
namespace MagicOnion.Client;

public interface IStreamingHubDiagnosticHandler
{
+    public delegate Task<TResponse> InvokeMethodDelegate<TRequest, TResponse>(int methodId, TRequest value);

+    Task<TResponse> OnMethodInvoke<THub, TRequest, TResponse>(THub hubInstance, int methodId, string methodName, TRequest request, bool isFireAndForget, InvokeMethodDelegate<TRequest, TResponse> invokeMethod);

-    void OnRequestBegin<THub, TRequest>(THub hubInstance, Guid requestId, string methodName, TRequest request, bool isFireAndForget);
-    void OnRequestEnd<THub, TResponse>(THub hubInstance, Guid requestId, string methodName, TResponse response, Exception? exception);

    void OnBroadcastEvent<THub, T>(THub hubInstance, string methodName, T value);
}
```