### PR TITLE
ci: include Directory.Build.props as release version update file

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,7 +16,9 @@ jobs:
   update-packagejson:
     uses: Cysharp/Actions/.github/workflows/update-packagejson.yaml@main
     with:
-      file-path: ./src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/package.json
+      file-path: |
+        ./src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/package.json
+        ./Directory.Build.props
       tag: ${{ inputs.tag }}
       dry-run: ${{ inputs.dry-run }}
       push-tag: false


### PR DESCRIPTION
## tl;dr;

Eliminate manual update commit https://github.com/Cysharp/MagicOnion/commit/68f51d1dd4a378a9702a5e7c3743cf0eacf5f6b6 

> [!TIP]
> Cysharp/Actions update-packagejson now supports Directory.build.props version string update.
> ref: https://github.com/Cysharp/Actions/pull/55

## DryRun result

Directory.Build.props is included in version updates.

https://github.com/Cysharp/MagicOnion/actions/runs/8517691369/job/23328663457#step:4:138

https://github.com/Cysharp/MagicOnion/commit/ef21f9c0858d8b14e0c06f57e1a07dc5edfdc5e8

![image](https://github.com/Cysharp/MagicOnion/assets/3856350/48fa6812-ac45-4f97-b8b5-14f8bb28e993)
