### PR TITLE
Fix method signature of MemoryPackFormatter for UNITY_2021_3_OR_NEWER

### DIFF
--- a/src/MagicOnion.Serialization.MemoryPack/DynamicArgumentTupleMemoryPackFormatter.cs
+++ b/src/MagicOnion.Serialization.MemoryPack/DynamicArgumentTupleMemoryPackFormatter.cs
@@ -37,7 +37,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?> value)
 #endif
@@ -76,7 +76,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?> value)
 #endif
@@ -117,7 +117,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?> value)
 #endif
@@ -160,7 +160,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?> value)
 #endif
@@ -205,7 +205,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?> value)
 #endif
@@ -252,7 +252,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?> value)
 #endif
@@ -301,7 +301,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> value)
 #endif
@@ -352,7 +352,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> value)
 #endif
@@ -405,7 +405,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> value)
 #endif
@@ -460,7 +460,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> value)
 #endif
@@ -517,7 +517,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> value)
 #endif
@@ -576,7 +576,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, T13?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, T13?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, T13?> value)
 #endif
@@ -637,7 +637,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, T13?, T14?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, T13?, T14?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, T13?, T14?> value)
 #endif
@@ -700,7 +700,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, T13?, T14?, T15?> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, T13?, T14?, T15?> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, T13?, T14?, T15?> value)
 #endif

--- a/src/MagicOnion.Serialization.MemoryPack/DynamicArgumentTupleMemoryPackFormatter.tt
+++ b/src/MagicOnion.Serialization.MemoryPack/DynamicArgumentTupleMemoryPackFormatter.tt
@@ -36,7 +36,7 @@ namespace MagicOnion.Serialization.MemoryPack
     {
         [global::MagicOnion.Serialization.MemoryPack.Preserve]
 #if UNITY_2021_3_OR_NEWER
-        public override void Serialize(ref MemoryPackWriter writer, ref DynamicArgumentTuple<<#= dynamicArgumentTupleGenericArgs #>> value)
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref DynamicArgumentTuple<<#= dynamicArgumentTupleGenericArgs #>> value)
 #else
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref DynamicArgumentTuple<<#= dynamicArgumentTupleGenericArgs #>> value)
 #endif


### PR DESCRIPTION
Syntax error when using MemoryPack as serialization library in MagicOnion.
MagicOnion : 6.1.2
MemoryPack: 1.21.1