### PR TITLE
ci: add depndabot.yaml to update github-actions,

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,6 +1,0 @@
-version: 1
-
-update_configs:
-  - package_manager: "dotnet:nuget"
-    directory: "/"
-    update_schedule: "live"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+# ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly" # Check for updates to GitHub Actions every week


### PR DESCRIPTION
## tl;dr;

Automate suggestion for update GitHub Actions.

## Motivation

Important actions are centrally managed on Cysharp/Actions, however few pieces of direct actions usage is managed by own repo.

Let's use dependabot to manage repo's actions version update strategy.