### PR TITLE
ci: change upload-artifact & download-artifact to Cysharp/Actions

### DIFF
--- a/.github/workflows/build-canary.yml
+++ b/.github/workflows/build-canary.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           name: nuget
           path: ./publish/
+          retention-days: 1
 
   canary-push:
     needs: [canary-build]

--- a/.github/workflows/build-canary.yml
+++ b/.github/workflows/build-canary.yml
@@ -30,7 +30,7 @@ jobs:
       - run: dotnet build -c ${{ env.BUILD_CONFIG }} ./MagicOnion.sln
       # pack
       - run: dotnet pack -c ${{ env.BUILD_CONFIG }} ./MagicOnion.Packaging.slnf --include-symbols --include-source --no-build -p:VersionSuffix=${MAGICONION_VERSION} -o ./publish
-      - uses: actions/upload-artifact@v4
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget
           path: ./publish/
@@ -50,7 +50,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PUBLIC }}
           VSS_NUGET_EXTERNAL_FEED_ENDPOINTS_PUBLIC_CANARY: "op://GitHubActionsPublic/VSS_NUGET_EXTERNAL_FEED_ENDPOINTS_PUBLIC_CANARY/credential"
-      - uses: actions/download-artifact@v4
+      - uses: Cysharp/Actions/.github/actions/download-artifact@main
       # Upload to NuGet
       - run: echo "VSS_NUGET_EXTERNAL_FEED_ENDPOINTS=${FEED_ENDPOINTS}" >> $GITHUB_ENV
         env:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -94,3 +94,4 @@ jobs:
         with:
           name: MagicOnion.Client.Unity.${{ matrix.unity }}.unitypackage
           path: ./src/MagicOnion.Client.Unity/MagicOnion.Client.Unity.unitypackage
+          retention-days: 1

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -90,7 +90,7 @@ jobs:
           directory: src/MagicOnion.Client.Unity
 
       # Store artifacts.
-      - uses: actions/upload-artifact@v4
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: MagicOnion.Client.Unity.${{ matrix.unity }}.unitypackage
           path: ./src/MagicOnion.Client.Unity/MagicOnion.Client.Unity.unitypackage

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           name: nuget
           path: ./publish/
+          retention-days: 1
 
   build-unity:
     needs: [update-packagejson]
@@ -88,6 +89,7 @@ jobs:
         with:
           name: MagicOnion.Client.Unity.unitypackage
           path: ./src/MagicOnion.Client.Unity/MagicOnion.Client.Unity.unitypackage
+          retention-days: 1
 
   # release
   create-release:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -37,7 +37,7 @@ jobs:
       # pack nuget
       - run: dotnet pack -c Release ./MagicOnion.Packaging.slnf  --include-symbols --include-source --no-build -o ./publish
       - run: cd ./publish/ && ls . | grep -P 'MagicOnion\.\d+\.\d+\.\d+\.snupkg' | xargs rm
-      - uses: actions/upload-artifact@v4
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget
           path: ./publish/
@@ -84,7 +84,7 @@ jobs:
           directory: src/MagicOnion.Client.Unity
 
       # Store artifacts.
-      - uses: actions/upload-artifact@v4
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: MagicOnion.Client.Unity.unitypackage
           path: ./src/MagicOnion.Client.Unity/MagicOnion.Client.Unity.unitypackage


### PR DESCRIPTION
## tl;dr;

To handle actions/upload-artifact & download-artifact version consistency, manage actions version via Central Maanged Cysharp/Actions.
