### PR TITLE
Reduce allocation on StreamingHubClient broadcast events

### DIFF
--- a/perf/Microbenchmark/Microbenchmark.Client/HubMethodBenchmarks.cs
+++ b/perf/Microbenchmark/Microbenchmark.Client/HubMethodBenchmarks.cs
@@ -1,0 +1,81 @@
+using BenchmarkDotNet.Attributes;
+using MagicOnion.Client.DynamicClient;
+
+namespace Microbenchmark.Client;
+
+[MemoryDiagnoser, RankColumn]
+[ShortRunJob]
+public class HubMethodBenchmarks
+{
+    readonly StreamingHubClientTestHelper<ITestHub, ITestHubReceiver> helper;
+    readonly Task responseTask;
+    readonly ITestHub client;
+
+    static ReadOnlySpan<byte> IntResponse => [0xcd, 0x30, 0x39 /* 12345 (int) */];
+    static ReadOnlySpan<byte> NilResponse => [0xc0 /* Nil */];
+    static ReadOnlySpan<byte> StringResponse => [0xa6, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21 /* "Hello!" (string) */];
+
+    public HubMethodBenchmarks()
+    {
+        this.helper = new StreamingHubClientTestHelper<ITestHub, ITestHubReceiver>(new TestHubReceiver(), DynamicStreamingHubClientFactoryProvider.Instance);
+        this.responseTask = Task.Run(async () =>
+        {
+            while (true)
+            {
+                var req = await helper.ReadRequestNoDeserializeAsync();
+                if (req.MethodId is -2087943100 or 1273874383)
+                {
+                    // Parameter_Zero_Return_ValueType, Parameter_Many_Return_ValueType
+                    helper.WriteResponse(req.MessageId, req.MethodId, IntResponse);
+                }
+                else if (req.MethodId is -1841486598)
+                {
+                    // ValueTask_Parameter_Zero_NoReturn
+                    helper.WriteResponse(req.MessageId, req.MethodId, NilResponse);
+                }
+                else if (req.MethodId is -440496944 or -1110031569)
+                {
+                    // Parameter_Zero_Return_RefType, Parameter_Many_Return_RefType
+                    helper.WriteResponse(req.MessageId, req.MethodId, StringResponse);
+                }
+            }
+        });
+        this.client = helper.ConnectAsync().GetAwaiter().GetResult();
+    }
+
+    [Benchmark]
+    public async Task Void_Parameter_Zero_NoReturn()
+    {
+        client.Void_Parameter_Zero_NoReturn();
+    }
+
+    [Benchmark]
+    public async Task ValueTask_Parameter_Zero_NoReturn()
+    {
+        await client.ValueTask_Parameter_Zero_NoReturn();
+    }
+
+    [Benchmark]
+    public async Task Parameter_Zero_Return_ValueType()
+    {
+        var value = await client.Parameter_Zero_Return_ValueType();
+    }
+
+    [Benchmark]
+    public async Task Parameter_Many_Return_ValueType()
+    {
+        var value = await client.Parameter_Many_Return_ValueType("Hello", 12345, true);
+    }
+
+    [Benchmark]
+    public async Task Parameter_Zero_Return_RefType()
+    {
+        var value = await client.Parameter_Zero_Return_RefType();
+    }
+
+    [Benchmark]
+    public async Task Parameter_Many_Return_RefType()
+    {
+        var value = await client.Parameter_Many_Return_RefType("Hello", 12345, true);
+    }
+}

--- a/perf/Microbenchmark/Microbenchmark.Client/HubReceiverBroadcastBenchmarks.cs
+++ b/perf/Microbenchmark/Microbenchmark.Client/HubReceiverBroadcastBenchmarks.cs
@@ -1,0 +1,65 @@
+using BenchmarkDotNet.Attributes;
+using MagicOnion.Client.DynamicClient;
+
+namespace Microbenchmark.Client;
+
+[MemoryDiagnoser, RankColumn]
+[ShortRunJob]
+public class HubReceiverBroadcastBenchmarks
+{
+    StreamingHubClientTestHelper<ITestHub, ITestHubReceiver> helper = default!;
+    ITestHub client = default!;
+    TestHubReceiver receiver = default!;
+
+    static ReadOnlySpan<byte> BroadcastMessage_Parameter_Zero => [0x92, 0xce, 0x76, 0xe4, 0x37, 0x1b /* 1994667803 */, 0xc0 /* Nil */]; // [MethodId(int), SerializedArgument]
+    static ReadOnlySpan<byte> BroadcastMessage_Parameter_Many => [0x92, 0xce, 0x4c, 0xb8, 0x83, 0xca /* 1287160778 */, 0x93, 0xa6, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21, 0xcd, 0x30, 0x39, 0xc3 /* [ "Hello", 12345, true ] */]; // [MethodId(int), SerializedArgument]
+
+    void Setup()
+    {
+        this.receiver = new TestHubReceiver();
+        this.helper = new StreamingHubClientTestHelper<ITestHub, ITestHubReceiver>(receiver, DynamicStreamingHubClientFactoryProvider.Instance);
+        this.client = helper.ConnectAsync().GetAwaiter().GetResult();
+    }
+
+    [GlobalSetup(Targets = [nameof(Parameter_Zero), nameof(Parameter_Many)])]
+    public void UnsetSynchronizationContext()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+        Setup();
+    }
+
+    [GlobalSetup(Targets = [nameof(Parameter_Zero_With_SynchronizationContext), nameof(Parameter_Many_With_SynchronizationContext)])]
+    public void SetSynchronizationContext()
+    {
+        SynchronizationContext.SetSynchronizationContext(new MySynchronizationContext());
+        Setup();
+    }
+
+    [Benchmark]
+    public void Parameter_Zero()
+    {
+        helper.WriteResponseRaw(BroadcastMessage_Parameter_Zero);
+        receiver.Received.Wait();
+    }
+
+    [Benchmark]
+    public void Parameter_Many()
+    {
+        helper.WriteResponseRaw(BroadcastMessage_Parameter_Many);
+        receiver.Received.Wait();
+    }
+
+    [Benchmark]
+    public void Parameter_Zero_With_SynchronizationContext()
+    {
+        helper.WriteResponseRaw(BroadcastMessage_Parameter_Zero);
+        receiver.Received.Wait();
+    }
+
+    [Benchmark]
+    public void Parameter_Many_With_SynchronizationContext()
+    {
+        helper.WriteResponseRaw(BroadcastMessage_Parameter_Many);
+        receiver.Received.Wait();
+    }
+}

--- a/perf/Microbenchmark/Microbenchmark.Client/Program.cs
+++ b/perf/Microbenchmark/Microbenchmark.Client/Program.cs
@@ -1,89 +1,25 @@
-using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using MagicOnion;
-using MagicOnion.Client.DynamicClient;
 using Microbenchmark.Client;
 
-BenchmarkRunner.Run<Benchmarks>();
+BenchmarkRunner.Run<HubReceiverBroadcastBenchmarks>();
 
-[MemoryDiagnoser, RankColumn]
-[ShortRunJob]
-public class Benchmarks
+class MySynchronizationContext : SynchronizationContext;
+
+class TestHubReceiver : ITestHubReceiver
 {
-    readonly StreamingHubClientTestHelper<ITestHub, ITestHubReceiver> helper;
-    readonly Task responseTask;
-    readonly ITestHub client;
+    public ManualResetEventSlim Received { get; } = new();
 
-    static ReadOnlySpan<byte> IntResponse => [0xcd, 0x30, 0x39 /* 12345 (int) */];
-    static ReadOnlySpan<byte> NilResponse => [0xc0 /* Nil */];
-    static ReadOnlySpan<byte> StringResponse => [0xa6, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21 /* "Hello!" (string) */];
-
-    public Benchmarks()
+    public void Parameter_Zero()
     {
-        this.helper = new StreamingHubClientTestHelper<ITestHub, ITestHubReceiver>(new TestHubReceiver(), DynamicStreamingHubClientFactoryProvider.Instance);
-        this.responseTask = Task.Run(async () =>
-        {
-            while (true)
-            {
-                var req = await helper.ReadRequestNoDeserializeAsync();
-                if (req.MethodId is - 2087943100 or 1273874383)
-                {
-                    // Parameter_Zero_Return_ValueType, Parameter_Many_Return_ValueType
-                    helper.WriteResponse(req.MessageId, req.MethodId, IntResponse);
-                }
-                else if (req.MethodId is -1841486598)
-                {
-                    // ValueTask_Parameter_Zero_NoReturn
-                    helper.WriteResponse(req.MessageId, req.MethodId, NilResponse);
-                }
-                else if (req.MethodId is -440496944 or -1110031569)
-                {
-                    // Parameter_Zero_Return_RefType, Parameter_Many_Return_RefType
-                    helper.WriteResponse(req.MessageId, req.MethodId, StringResponse);
-                }
-            }
-        });
-        this.client = helper.ConnectAsync().GetAwaiter().GetResult();
+        Received.Set();
     }
 
-    [Benchmark]
-    public async Task Void_Parameter_Zero_NoReturn()
+    public void Parameter_Many(string arg0, int arg1, bool arg2)
     {
-        client.Void_Parameter_Zero_NoReturn();
-    }
-
-    [Benchmark]
-    public async Task ValueTask_Parameter_Zero_NoReturn()
-    {
-        await client.ValueTask_Parameter_Zero_NoReturn();
-    }
-
-    [Benchmark]
-    public async Task Parameter_Zero_Return_ValueType()
-    {
-        var value = await client.Parameter_Zero_Return_ValueType();
-    }
-
-    [Benchmark]
-    public async Task Parameter_Many_Return_ValueType()
-    {
-        var value = await client.Parameter_Many_Return_ValueType("Hello", 12345, true);
-    }
-
-    [Benchmark]
-    public async Task Parameter_Zero_Return_RefType()
-    {
-        var value = await client.Parameter_Zero_Return_RefType();
-    }
-
-    [Benchmark]
-    public async Task Parameter_Many_Return_RefType()
-    {
-        var value = await client.Parameter_Many_Return_RefType("Hello", 12345, true);
+        Received.Set();
     }
 }
-
-class TestHubReceiver : ITestHubReceiver;
 
 public interface ITestHub : IStreamingHub<ITestHub, ITestHubReceiver>
 {
@@ -98,5 +34,6 @@ public interface ITestHub : IStreamingHub<ITestHub, ITestHubReceiver>
 
 public interface ITestHubReceiver
 {
-
+    void Parameter_Zero();
+    void Parameter_Many(string arg0, int arg1, bool arg2);
 }

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/StreamingHubClientMessageReader.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/StreamingHubClientMessageReader.cs
@@ -32,6 +32,11 @@ namespace MagicOnion.Internal
             };
         }
 
+        public (int MethodId, int Cosumed) ReadBroadcastMessageMethodId()
+        {
+            return (reader.ReadInt32(), (int)reader.Consumed);
+        }
+
         public (int MethodId, ReadOnlyMemory<byte> Body) ReadBroadcastMessage()
         {
             var methodId = reader.ReadInt32();

--- a/src/MagicOnion.Internal/StreamingHubClientMessageReader.cs
+++ b/src/MagicOnion.Internal/StreamingHubClientMessageReader.cs
@@ -32,6 +32,11 @@ namespace MagicOnion.Internal
             };
         }
 
+        public (int MethodId, int Cosumed) ReadBroadcastMessageMethodId()
+        {
+            return (reader.ReadInt32(), (int)reader.Consumed);
+        }
+
         public (int MethodId, ReadOnlyMemory<byte> Body) ReadBroadcastMessage()
         {
             var methodId = reader.ReadInt32();


### PR DESCRIPTION
## Before
```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3737/23H2/2023Update/SunValley3)
13th Gen Intel Core i7-13700KF, 1 CPU, 24 logical and 16 physical cores
.NET SDK 8.0.300
  [Host]   : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
  ShortRun : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1
WarmupCount=3

| Method                                     | Mean     | Error     | StdDev   | Rank | Gen0   | Gen1   | Gen2   | Allocated |
|------------------------------------------- |---------:|----------:|---------:|-----:|-------:|-------:|-------:|----------:|
| Parameter_Zero                             | 281.8 ns |  50.35 ns |  2.76 ns |    1 |      - |      - |      - |       4 B |
| Parameter_Many                             | 354.9 ns |  40.72 ns |  2.23 ns |    2 | 0.0029 | 0.0014 |      - |      47 B |
| Parameter_Zero_With_SynchronizationContext | 397.5 ns | 710.39 ns | 38.94 ns |    3 | 0.0057 | 0.0019 |      - |      97 B |
| Parameter_Many_With_SynchronizationContext | 420.9 ns | 251.29 ns | 13.77 ns |    4 | 0.0110 | 0.0048 | 0.0014 |     156 B |
```

## After
```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3737/23H2/2023Update/SunValley3)
13th Gen Intel Core i7-13700KF, 1 CPU, 24 logical and 16 physical cores
.NET SDK 8.0.300
  [Host]   : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
  ShortRun : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1
WarmupCount=3

| Method                                     | Mean     | Error     | StdDev   | Rank | Gen0   | Gen1   | Allocated |
|------------------------------------------- |---------:|----------:|---------:|-----:|-------:|-------:|----------:|
| Parameter_Zero                             | 256.8 ns |  57.96 ns |  3.18 ns |    1 |      - |      - |       2 B |
| Parameter_Many                             | 339.3 ns | 202.94 ns | 11.12 ns |    2 | 0.0029 | 0.0019 |      50 B |
| Parameter_Zero_With_SynchronizationContext | 372.1 ns | 209.20 ns | 11.47 ns |    3 | 0.0029 | 0.0010 |      49 B |
| Parameter_Many_With_SynchronizationContext | 372.8 ns | 192.16 ns | 10.53 ns |    3 | 0.0057 | 0.0010 |      91 B |