### PR TITLE
ci: provide benchmark name & extend timeout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,6 +37,7 @@ jobs:
       branch: ${{ needs.prepare.outputs.branch }}
       dotnet-version: "8.0"
       environment: benchmark
+      benchmark-name: "magiconion-${{ github.event.issue.number || github.run_number }}"
       client-benchmark-script-path: ".github/scripts/run-benchmark-client.sh"
       client-benchmark-script-args: "--args \"-u http://${BENCHMARK_SERVER_NAME}:5000 -s streaminghub --channels 1 --streams 1\""
       server-benchmark-script-path: ".github/scripts/run-benchmark-server.sh"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,6 +38,7 @@ jobs:
       dotnet-version: "8.0"
       environment: benchmark
       benchmark-name: "magiconion-${{ github.event.issue.number || github.run_number }}"
+      benchmark-timeout: 18 # 10min (env prepare) + 8min (clone & benchmark)
       client-benchmark-script-path: ".github/scripts/run-benchmark-client.sh"
       client-benchmark-script-args: "--args \"-u http://${BENCHMARK_SERVER_NAME}:5000 -s streaminghub --channels 1 --streams 1\""
       server-benchmark-script-path: ".github/scripts/run-benchmark-server.sh"


### PR DESCRIPTION
## tl;dr;

* Add name to benchmark environment, this enables magiconion to run multiple benchmark at once.
* Explicitly specify benchmark timeout from 15 -> 18min. 15min too match JUST time benchmark complete, let's add additional spare time.