### PR TITLE
Introduce WaitForDisconnectAsync

### DIFF
--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IStreamingHubClient.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IStreamingHubClient.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+
+namespace MagicOnion.Client
+{
+    /// <summary>
+    /// An interface that indicates that the StreamingHub client is implemented.
+    /// </summary>
+    public interface IStreamingHubClient
+    {
+        /// <summary>
+        /// Wait for the disconnection and return the reason.
+        /// </summary>
+        /// <returns></returns>
+        Task<DisconnectionReason> WaitForDisconnectAsync();
+    }
+
+    /// <summary>
+    /// Provides the reason for the StreamingHub disconnection.
+    /// </summary>
+    public readonly struct DisconnectionReason
+    {
+        /// <summary>
+        /// Gets the type of StreamingHub disconnection.
+        /// </summary>
+        public DisconnectionType Type { get; }
+
+        /// <summary>
+        /// Gets the exception that caused the disconnection.
+        /// </summary>
+        public Exception? Exception { get; }
+
+        public DisconnectionReason(DisconnectionType type, Exception? exception)
+        {
+            Type = type;
+            Exception = exception;
+        }
+    }
+
+    /// <summary>
+    /// Defines the types of StreamingHub disconnection.
+    /// </summary>
+    public enum DisconnectionType
+    {
+        /// <summary>
+        /// Disconnected after completing successfully.
+        /// </summary>
+        CompletedNormally = 0,
+
+        /// <summary>
+        /// Disconnected due to exception while reading messages.
+        /// </summary>
+        Faulted = 1,
+
+        /// <summary>
+        /// Disconnected due to reaching the heartbeat timeout.
+        /// </summary>
+        TimedOut = 2,
+    }
+
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IStreamingHubClient.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/IStreamingHubClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bcc66fb9bbcbf0249865b08593ded376
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientExtensions.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+
+namespace MagicOnion.Client
+{
+    public static class StreamingHubClientExtensions
+    {
+        /// <summary>
+        /// Wait for the disconnection and return the reason.
+        /// </summary>
+        public static Task<DisconnectionReason> WaitForDisconnectAsync<TStreamingHub>(this TStreamingHub hub) where TStreamingHub : IStreamingHubMarker =>
+            CastOrThrow(hub).WaitForDisconnectAsync();
+
+        static IStreamingHubClient CastOrThrow<THub>(THub hub)
+        {
+            if (hub is null)
+            {
+                throw new ArgumentNullException(nameof(hub));
+            }
+            if (hub is IStreamingHubClient client)
+            {
+                return client;
+            }
+            else
+            {
+                throw new InvalidOperationException($"The StreamingHub client '{hub.GetType().FullName}' does not implement IStreamingHubClient interface.");
+            }
+        }
+    }
+}

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientExtensions.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 49a2faebc7e52e5459a94f2c696c07b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client/IStreamingHubClient.cs
+++ b/src/MagicOnion.Client/IStreamingHubClient.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+
+namespace MagicOnion.Client
+{
+    /// <summary>
+    /// An interface that indicates that the StreamingHub client is implemented.
+    /// </summary>
+    public interface IStreamingHubClient
+    {
+        /// <summary>
+        /// Wait for the disconnection and return the reason.
+        /// </summary>
+        /// <returns></returns>
+        Task<DisconnectionReason> WaitForDisconnectAsync();
+    }
+
+    /// <summary>
+    /// Provides the reason for the StreamingHub disconnection.
+    /// </summary>
+    public readonly struct DisconnectionReason
+    {
+        /// <summary>
+        /// Gets the type of StreamingHub disconnection.
+        /// </summary>
+        public DisconnectionType Type { get; }
+
+        /// <summary>
+        /// Gets the exception that caused the disconnection.
+        /// </summary>
+        public Exception? Exception { get; }
+
+        public DisconnectionReason(DisconnectionType type, Exception? exception)
+        {
+            Type = type;
+            Exception = exception;
+        }
+    }
+
+    /// <summary>
+    /// Defines the types of StreamingHub disconnection.
+    /// </summary>
+    public enum DisconnectionType
+    {
+        /// <summary>
+        /// Disconnected after completing successfully.
+        /// </summary>
+        CompletedNormally = 0,
+
+        /// <summary>
+        /// Disconnected due to exception while reading messages.
+        /// </summary>
+        Faulted = 1,
+
+        /// <summary>
+        /// Disconnected due to reaching the heartbeat timeout.
+        /// </summary>
+        TimedOut = 2,
+    }
+
+}

--- a/src/MagicOnion.Client/PublicAPI.Shipped.txt
+++ b/src/MagicOnion.Client/PublicAPI.Shipped.txt
@@ -21,6 +21,15 @@ MagicOnion.Client.ClientHeartbeatEvent
 MagicOnion.Client.ClientHeartbeatEvent.ClientHeartbeatEvent() -> void
 MagicOnion.Client.ClientHeartbeatEvent.ClientHeartbeatEvent(long roundTripTimeMs) -> void
 MagicOnion.Client.ClientHeartbeatEvent.RoundTripTime.get -> System.TimeSpan
+MagicOnion.Client.DisconnectionReason
+MagicOnion.Client.DisconnectionReason.DisconnectionReason() -> void
+MagicOnion.Client.DisconnectionReason.DisconnectionReason(MagicOnion.Client.DisconnectionType type, System.Exception? exception) -> void
+MagicOnion.Client.DisconnectionReason.Exception.get -> System.Exception?
+MagicOnion.Client.DisconnectionReason.Type.get -> MagicOnion.Client.DisconnectionType
+MagicOnion.Client.DisconnectionType
+MagicOnion.Client.DisconnectionType.CompletedNormally = 0 -> MagicOnion.Client.DisconnectionType
+MagicOnion.Client.DisconnectionType.Faulted = 1 -> MagicOnion.Client.DisconnectionType
+MagicOnion.Client.DisconnectionType.TimedOut = 2 -> MagicOnion.Client.DisconnectionType
 MagicOnion.Client.DynamicClient.DynamicMagicOnionClientFactoryProvider
 MagicOnion.Client.DynamicClient.DynamicMagicOnionClientFactoryProvider.TryGetFactory<T>(out MagicOnion.Client.MagicOnionClientFactoryDelegate<T>? factory) -> bool
 MagicOnion.Client.DynamicClient.DynamicNotSupportedMagicOnionClientFactoryProvider
@@ -55,6 +64,8 @@ MagicOnion.Client.Internal.RawMethodInvoker<TRequest, TResponse, TRawRequest, TR
 MagicOnion.Client.Internal.RawMethodInvoker<TRequest, TResponse, TRawRequest, TRawResponse>.RawMethodInvoker(Grpc.Core.MethodType methodType, string! serviceName, string! name, MagicOnion.Serialization.IMagicOnionSerializer! messageSerializer) -> void
 MagicOnion.Client.Internal.RawMethodInvoker<TRequest, TResponse>
 MagicOnion.Client.Internal.RawMethodInvoker<TRequest, TResponse>.RawMethodInvoker() -> void
+MagicOnion.Client.IStreamingHubClient
+MagicOnion.Client.IStreamingHubClient.WaitForDisconnectAsync() -> System.Threading.Tasks.Task<MagicOnion.Client.DisconnectionReason>!
 MagicOnion.Client.IStreamingHubClientFactoryProvider
 MagicOnion.Client.IStreamingHubClientFactoryProvider.TryGetFactory<TStreamingHub, TReceiver>(out MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>? factory) -> bool
 MagicOnion.Client.MagicOnionClient
@@ -124,6 +135,7 @@ MagicOnion.Client.StreamingHubClientBase<TStreamingHub, TReceiver>.WriteMessageF
 MagicOnion.Client.StreamingHubClientBase<TStreamingHub, TReceiver>.WriteMessageWithResponseTaskAsync<TRequest, TResponse>(int methodId, TRequest message) -> System.Threading.Tasks.Task<TResponse>!
 MagicOnion.Client.StreamingHubClientBase<TStreamingHub, TReceiver>.WriteMessageWithResponseValueTaskAsync<TRequest, TResponse>(int methodId, TRequest message) -> System.Threading.Tasks.ValueTask
 MagicOnion.Client.StreamingHubClientBase<TStreamingHub, TReceiver>.WriteMessageWithResponseValueTaskOfTAsync<TRequest, TResponse>(int methodId, TRequest message) -> System.Threading.Tasks.ValueTask<TResponse>
+MagicOnion.Client.StreamingHubClientExtensions
 MagicOnion.Client.StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver>
 MagicOnion.Client.StreamingHubClientFactoryProvider
 MagicOnion.Client.StreamingHubClientOptions
@@ -183,6 +195,7 @@ static MagicOnion.Client.StreamingHubClient.ConnectAsync<TStreamingHub, TReceive
 static MagicOnion.Client.StreamingHubClient.ConnectAsync<TStreamingHub, TReceiver>(Grpc.Core.ChannelBase! channel, TReceiver receiver, string? host = null, Grpc.Core.CallOptions option = default(Grpc.Core.CallOptions), MagicOnion.Serialization.IMagicOnionSerializerProvider? serializerProvider = null, MagicOnion.Client.IStreamingHubClientFactoryProvider? factoryProvider = null, MagicOnion.Client.IMagicOnionClientLogger? logger = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TStreamingHub>!
 static MagicOnion.Client.StreamingHubClient.ConnectAsync<TStreamingHub, TReceiver>(Grpc.Core.CallInvoker! callInvoker, TReceiver receiver, MagicOnion.Client.StreamingHubClientOptions! options, MagicOnion.Client.IStreamingHubClientFactoryProvider? factoryProvider = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TStreamingHub>!
 static MagicOnion.Client.StreamingHubClient.ConnectAsync<TStreamingHub, TReceiver>(Grpc.Core.ChannelBase! channel, TReceiver receiver, MagicOnion.Client.StreamingHubClientOptions! options, MagicOnion.Client.IStreamingHubClientFactoryProvider? factoryProvider = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TStreamingHub>!
+static MagicOnion.Client.StreamingHubClientExtensions.WaitForDisconnectAsync<TStreamingHub>(this TStreamingHub hub) -> System.Threading.Tasks.Task<MagicOnion.Client.DisconnectionReason>!
 static MagicOnion.Client.StreamingHubClientOptions.CreateWithDefault(string? host = null, Grpc.Core.CallOptions callOptions = default(Grpc.Core.CallOptions), MagicOnion.Serialization.IMagicOnionSerializerProvider? serializerProvider = null, MagicOnion.Client.IMagicOnionClientLogger? logger = null) -> MagicOnion.Client.StreamingHubClientOptions!
 static MagicOnion.Client.StreamingHubClientFactoryProvider.Default.get -> MagicOnion.Client.IStreamingHubClientFactoryProvider!
 static MagicOnion.Client.StreamingHubClientFactoryProvider.Default.set -> void

--- a/src/MagicOnion.Client/StreamingHubClientExtensions.cs
+++ b/src/MagicOnion.Client/StreamingHubClientExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+
+namespace MagicOnion.Client
+{
+    public static class StreamingHubClientExtensions
+    {
+        /// <summary>
+        /// Wait for the disconnection and return the reason.
+        /// </summary>
+        public static Task<DisconnectionReason> WaitForDisconnectAsync<TStreamingHub>(this TStreamingHub hub) where TStreamingHub : IStreamingHubMarker =>
+            CastOrThrow(hub).WaitForDisconnectAsync();
+
+        static IStreamingHubClient CastOrThrow<THub>(THub hub)
+        {
+            if (hub is null)
+            {
+                throw new ArgumentNullException(nameof(hub));
+            }
+            if (hub is IStreamingHubClient client)
+            {
+                return client;
+            }
+            else
+            {
+                throw new InvalidOperationException($"The StreamingHub client '{hub.GetType().FullName}' does not implement IStreamingHubClient interface.");
+            }
+        }
+    }
+}

--- a/tests/MagicOnion.Client.Tests/StreamingHubClientTestHelper.cs
+++ b/tests/MagicOnion.Client.Tests/StreamingHubClientTestHelper.cs
@@ -99,6 +99,16 @@ class StreamingHubClientTestHelper<TStreamingHub, TReceiver>
         responseChannel.Writer.TryWrite(BuildResponsePayload(messageId, methodId, response));
     }
 
+    public void ThrowIOException()
+    {
+        responseChannel.Writer.TryComplete(new IOException("Connection reset by peer. (Simulated)"));
+    }
+
+    public void ThrowRpcException()
+    {
+        responseChannel.Writer.TryComplete(new RpcException(new Status(StatusCode.Aborted, "Connection has been closed.", new IOException("Connection reset by peer. (Simulated)"))));
+    }
+
     static StreamingHubPayload BuildResponsePayload<T>(int messageId, int methodId, T response)
     {
         var bufferWriter = new ArrayBufferWriter<byte>();


### PR DESCRIPTION
This PR introduces a new API `WaitForDisconnectAsync` to StreamingHubClient.

`WaitForDisconnectAsync` API is an updated version of the existing `WaitForDisconnected`, and it will be possible to receive the reason. 

Unlike `WaitForDisconnect`, the new API is added as an extension method of the `IStreamingHubMarker` interface. This is to avoid breaking binary compatibility by changing the `IStreamingHub` interface.

## New APIs
```csharp
namespace MagicOnion.Client
{
    public static class StreamingHubClientExtensions
    {
        /// <summary>
        /// Wait for the disconnection and return the reason.
        /// </summary>
        public static Task<DisconnectionReason> WaitForDisconnectAsync<TStreamingHub>(this TStreamingHub hub) where TStreamingHub : IStreamingHubMarker =>
    }

    /// <summary>
    /// Provides the reason for the StreamingHub disconnection.
    /// </summary>
    public readonly struct DisconnectionReason
    {
        /// <summary>
        /// Gets the type of StreamingHub disconnection.
        /// </summary>
        public DisconnectionType Type { get; }
    
        /// <summary>
        /// Gets the exception that caused the disconnection.
        /// </summary>
        public Exception? Exception { get; }
    }
    
    /// <summary>
    /// Defines the types of StreamingHub disconnection.
    /// </summary>
    public enum DisconnectionType
    {
        /// <summary>
        /// Disconnected after completing successfully.
        /// </summary>
        CompletedNormally = 0,
    
        /// <summary>
        /// Disconnected due to exception while reading messages.
        /// </summary>
        Faulted = 1,
    
        /// <summary>
        /// Disconnected due to reaching the heartbeat timeout.
        /// </summary>
        TimedOut = 2,
    }
}
```

## Usage
```csharp
using MagicOnion.Client;

var client = await StreamingHubClient.ConnectAsync<IGreeterHub, IGreeterHubReceiver>(channel, receiver);
_ = WaitForDisconnectEventAsync();

async Task WaitForDisconnectEventAsync()
{
    var reason = await client.WaitForDisconnectAsync();
    if (reason.Type != DisconnectionType.CompletedNormally)
    {
        ...
    }
}

```