### PR TITLE
Throws RpcException instead of ObjectDisposedException when the client is disconnected.

### DIFF
--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientBase.cs
@@ -357,7 +357,7 @@ namespace MagicOnion.Client
                     }
 #endif
                     await heartbeatManager.DisposeAsync().ConfigureAwait(false);
-                    await DisposeAsyncCore(false).ConfigureAwait(false);
+                    await CleanupAsync(false).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -516,6 +516,7 @@ namespace MagicOnion.Client
         protected ValueTask<TResponse> WriteMessageFireAndForgetValueTaskOfTAsync<TRequest, TResponse>(int methodId, TRequest message)
         {
             ThrowIfDisposed();
+            ThrowIfDisconnected();
 
             var v = BuildRequestMessage(methodId, message);
             _ = writerQueue.Writer.TryWrite(v);
@@ -535,6 +536,7 @@ namespace MagicOnion.Client
         protected ValueTask<TResponse> WriteMessageWithResponseValueTaskOfTAsync<TRequest, TResponse>(int methodId, TRequest message)
         {
             ThrowIfDisposed();
+            ThrowIfDisconnected();
 
             var mid = Interlocked.Increment(ref messageIdSequence);
 
@@ -553,6 +555,7 @@ namespace MagicOnion.Client
         protected ValueTask WriteMessageWithResponseValueTaskAsync<TRequest, TResponse>(int methodId, TRequest message)
         {
             ThrowIfDisposed();
+            ThrowIfDisconnected();
 
             var mid = Interlocked.Increment(ref messageIdSequence);
 
@@ -631,6 +634,14 @@ namespace MagicOnion.Client
             return Task.CompletedTask;
         }
 
+        void ThrowIfDisconnected()
+        {
+            if (waitForDisconnect.Task.IsCompleted)
+            {
+                throw new RpcException(new Status(StatusCode.Unavailable, $"The StreamingHubClient has already been disconnected from the server."));
+            }
+        }
+
         void ThrowIfDisposed()
         {
             if (disposed)
@@ -645,18 +656,19 @@ namespace MagicOnion.Client
         Task<DisconnectionReason> IStreamingHubClient.WaitForDisconnectAsync()
             => waitForDisconnect.Task;
 
-        public Task DisposeAsync()
-        {
-            return DisposeAsyncCore(true);
-        }
-
-        async Task DisposeAsyncCore(bool waitSubscription)
+        public async Task DisposeAsync()
         {
             if (disposed) return;
-            if (writer == null) return;
-
             disposed = true;
 
+            await CleanupAsync(true).ConfigureAwait(false);
+
+            subscriptionCts.Dispose();
+        }
+
+        async Task CleanupAsync(bool waitSubscription)
+        {
+            if (writer == null) return;
             try
             {
                 writerQueue.Writer.Complete();
@@ -666,7 +678,6 @@ namespace MagicOnion.Client
             finally
             {
                 subscriptionCts.Cancel();
-                subscriptionCts.Dispose();
                 try
                 {
                     if (waitSubscription)

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientBase.cs
@@ -175,9 +175,16 @@ namespace MagicOnion.Client
         readonly CancellationTokenSource subscriptionCts = new();
         readonly Dictionary<int, SendOrPostCallback> postCallbackCache = new();
 
-
         int messageIdSequence = 0;
-        bool disposed;
+        State state = State.Uninitialized;
+
+        enum State
+        {
+            Uninitialized,
+            Connected,
+            Disconnected,
+            Disposed,
+        }
 
         readonly Channel<StreamingHubPayload> writerQueue = Channel.CreateUnbounded<StreamingHubPayload>(new UnboundedChannelOptions() { SingleReader = true, SingleWriter = false, AllowSynchronousContinuations = false });
         Task? writerTask;
@@ -291,6 +298,8 @@ namespace MagicOnion.Client
 
         async Task StartSubscribe(SynchronizationContext? syncContext, Task<bool> firstMoveNext, CancellationToken subscriptionToken)
         {
+            state = State.Connected;
+
             var disconnectionReason = new DisconnectionReason(DisconnectionType.CompletedNormally, null);
             writerTask = RunWriterLoopAsync(subscriptionToken);
 
@@ -310,7 +319,7 @@ namespace MagicOnion.Client
                         // log post on main thread.
                         if (syncContext != null)
                         {
-                            syncContext.Post(state => logger.Error((Exception)state!, msg), ex);
+                            syncContext.Post(s => logger.Error((Exception)s!, msg), ex);
                         }
                         else
                         {
@@ -335,7 +344,7 @@ namespace MagicOnion.Client
                 // log post on main thread.
                 if (syncContext != null)
                 {
-                    syncContext.Post(state => logger.Error((Exception)state!, msg), ex);
+                    syncContext.Post(s => logger.Error((Exception)s!, msg), ex);
                 }
                 else
                 {
@@ -346,6 +355,8 @@ namespace MagicOnion.Client
             }
             finally
             {
+                state = State.Disconnected;
+
                 try
                 {
 #if !UNITY_WEBGL
@@ -414,9 +425,9 @@ namespace MagicOnion.Client
 
         SendOrPostCallback CreateBroadcastCallback(int methodId, int consumed)
         {
-            return (state) =>
+            return (s) =>
             {
-                var p = (StreamingHubPayload)state!;
+                var p = (StreamingHubPayload)s!;
                 this.OnBroadcastEvent(methodId, p.Memory.Slice(consumed));
                 StreamingHubPayloadPool.Shared.Return(p);
             };
@@ -547,7 +558,11 @@ namespace MagicOnion.Client
             }
 
             var v = BuildRequestMessage(methodId, mid, message);
-            _ = writerQueue.Writer.TryWrite(v);
+            if (!writerQueue.Writer.TryWrite(v))
+            {
+                // If the channel writer is closed, it is likely that the connection has already been disconnected.
+                ThrowIfDisconnected();
+            }
 
             return new ValueTask<TResponse>(taskSource, taskSource.Version); // wait until server return response(or error). if connection was closed, throws cancellation from DisposeAsyncCore.
         }
@@ -566,7 +581,11 @@ namespace MagicOnion.Client
             }
 
             var v = BuildRequestMessage(methodId, mid, message);
-            _ = writerQueue.Writer.TryWrite(v);
+            if (!writerQueue.Writer.TryWrite(v))
+            {
+                // If the channel writer is closed, it is likely that the connection has already been disconnected.
+                ThrowIfDisconnected();
+            }
 
             return new ValueTask(taskSource, taskSource.Version); // wait until server return response(or error). if connection was closed, throws cancellation from DisposeAsyncCore.
         }
@@ -636,7 +655,7 @@ namespace MagicOnion.Client
 
         void ThrowIfDisconnected()
         {
-            if (waitForDisconnect.Task.IsCompleted)
+            if (state == State.Disconnected)
             {
                 throw new RpcException(new Status(StatusCode.Unavailable, $"The StreamingHubClient has already been disconnected from the server."));
             }
@@ -644,7 +663,7 @@ namespace MagicOnion.Client
 
         void ThrowIfDisposed()
         {
-            if (disposed)
+            if (state == State.Disposed)
             {
                 throw new ObjectDisposedException("StreamingHubClient", $"The StreamingHub has already been disconnected from the server.");
             }
@@ -658,15 +677,15 @@ namespace MagicOnion.Client
 
         public async Task DisposeAsync()
         {
-            if (disposed) return;
-            disposed = true;
+            if (state == State.Disposed) return;
+            state = State.Disposed;
 
             await CleanupAsync(true).ConfigureAwait(false);
 
             subscriptionCts.Dispose();
         }
 
-        async Task CleanupAsync(bool waitSubscription)
+        async ValueTask CleanupAsync(bool waitSubscription)
         {
             if (writer == null) return;
             try

--- a/tests/MagicOnion.Client.Tests/StreamingHubTest.cs
+++ b/tests/MagicOnion.Client.Tests/StreamingHubTest.cs
@@ -673,7 +673,9 @@ public class StreamingHubTest
         var ex = await Record.ExceptionAsync(async () => await client.Parameter_Zero());
 
         // Assert
-        Assert.IsType<ObjectDisposedException>(ex);
+        var ode = Assert.IsType<ObjectDisposedException>(ex);
+        Assert.Equal(nameof(StreamingHubClient), ode.ObjectName);
+        Assert.Contains("StreamingHubClient has already been disconnected from the server.", ex.Message);
     }
 }
 


### PR DESCRIPTION
In this PR, we will change it so that `RpcException(Status=Unavailable)` is thrown instead of `ObjectDisposedException` when the client is disconnected. `ObjectDisposedException` will only be thrown when explicitly disposed.