### PR TITLE
chore: Benchmark minor change

### DIFF
--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -216,7 +216,7 @@ async Task<PerformanceResult> RunScenarioAsync(ScenarioType scenario, ScenarioCo
         }
     }
 
-    WriteLog($"ThreadCount current: {ThreadPool.ThreadCount}");
+    WriteLog($"Thread Count Current... {ThreadPool.ThreadCount}");
 
     await controlService.CreateMemoryProfilerSnapshotAsync("Before Warmup");
     WriteLog($"Warming up...");
@@ -262,6 +262,8 @@ async Task<PerformanceResult> RunScenarioAsync(ScenarioType scenario, ScenarioCo
     WriteLog($"Avg CPU Usage: {result.hardware.AvgCpuUsagePercent:0.000} %");
     WriteLog($"Max Memory Usage: {result.hardware.MaxMemoryUsageMB} MB");
     WriteLog($"Avg Memory Usage: {result.hardware.AvgMemoryUsageMB} MB");
+
+    WriteLog($"Thread Count: {ThreadPool.ThreadCount}");
 
     return result;
 }

--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -121,6 +121,7 @@ async Task Main(
         writer.WriteLine($"OSDescription: {serverInfo.OSDescription}");
         writer.WriteLine($"OSArchitecture: {serverInfo.OSArchitecture}");
         writer.WriteLine($"ProcessArchitecture : {serverInfo.ProcessArchitecture}");
+        writer.WriteLine($"CpuModelName : {serverInfo.CpuModelName}");
         writer.WriteLine($"IsServerGC: {serverInfo.IsServerGC}");
         writer.WriteLine($"ProcessorCount: {serverInfo.ProcessorCount}");
         writer.WriteLine($"========================================");
@@ -284,6 +285,7 @@ void PrintStartupInformation(TextWriter? writer = null)
     writer.WriteLine($"{nameof(RuntimeInformation.OSDescription)}: {ApplicationInformation.Current.OSDescription}");
     writer.WriteLine($"{nameof(RuntimeInformation.OSArchitecture)}: {ApplicationInformation.Current.OSArchitecture}");
     writer.WriteLine($"{nameof(RuntimeInformation.ProcessArchitecture)}: {ApplicationInformation.Current.ProcessArchitecture}");
+    writer.WriteLine($"{nameof(ApplicationInformation.Current.CpuModelName)}: {ApplicationInformation.Current.CpuModelName}");
     writer.WriteLine($"{nameof(GCSettings.IsServerGC)}: {ApplicationInformation.Current.IsServerGC}");
     writer.WriteLine($"{nameof(ApplicationInformation.Current.ProcessorCount)}: {ApplicationInformation.Current.ProcessorCount}");
     writer.WriteLine($"{nameof(Debugger)}.{nameof(Debugger.IsAttached)}: {ApplicationInformation.Current.IsAttached}");

--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -234,7 +234,7 @@ async Task<PerformanceResult> RunScenarioAsync(ScenarioType scenario, ScenarioCo
     await controlService.CreateMemoryProfilerSnapshotAsync("Completed");
 
     WriteLog("Cleaning up...");
-    foreach (var s in scenarios.Chunk(tasks.Count / 3))
+    foreach (var s in scenarios.Chunk(Math.Clamp(scenarios.Count / 3, 1, scenarios.Count)))
     {
         WriteLog($"...Cleaning up ({cleanIndex++})");
         try

--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -234,7 +234,7 @@ async Task<PerformanceResult> RunScenarioAsync(ScenarioType scenario, ScenarioCo
     await controlService.CreateMemoryProfilerSnapshotAsync("Completed");
 
     WriteLog("Cleaning up...");
-    foreach (var s in scenarios.Chunk(scenarios.Count / 3))
+    foreach (var s in scenarios.Chunk(tasks.Count / 3))
     {
         WriteLog($"...Cleaning up ({cleanIndex++})");
         try

--- a/perf/BenchmarkApp/PerformanceTest.Client/Properties/launchSettings.json
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Properties/launchSettings.json
@@ -2,71 +2,87 @@
   "profiles": {
     "PerformanceTest.Client (h2c CI 1x1)": {
       "commandName": "Project",
-      "commandLineArgs": "-u http://localhost:5000 --protocol h2c -s CI --channels 1 --streams 1"
+      "commandLineArgs": "-u http://localhost:5000 --protocol h2c -s CI --rounds 3 --channels 1 --streams 1"
     },
     "PerformanceTest.Client (h2c CI 1x28)": {
       "commandName": "Project",
-      "commandLineArgs": "-u http://localhost:5000 --protocol h2c -s CI --channels 28 --streams 1"
+      "commandLineArgs": "-u http://localhost:5000 --protocol h2c -s CI --rounds 3 --channels 28 --streams 1"
     },
     "PerformanceTest.Client (h2c CI 70x1)": {
       "commandName": "Project",
-      "commandLineArgs": "-u http://localhost:5000 --protocol h2c -s CI --channels 1 --streams 70"
+      "commandLineArgs": "-u http://localhost:5000 --protocol h2c -s CI --rounds 3 --channels 1 --streams 70"
     },
     "PerformanceTest.Client (h2c CI 70x28)": {
       "commandName": "Project",
-      "commandLineArgs": "-u http://localhost:5000 --protocol h2c -s CI --channels 28 --streams 70"
+      "commandLineArgs": "-u http://localhost:5000 --protocol h2c -s CI --rounds 3 --channels 28 --streams 70"
     },
     "PerformanceTest.Client (h2 CI 1x1)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 5 --channels 1 --streams 1"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 3 --channels 1 --streams 1"
     },
     "PerformanceTest.Client (h2 CI 1x28)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 5 --channels 28 --streams 1"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 3 --channels 28 --streams 1"
     },
     "PerformanceTest.Client (h2 CI 3x28)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 5 --channels 28 --streams 3"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 3 --channels 28 --streams 3"
     },
     "PerformanceTest.Client (h2 CI 70x1)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 5 --channels 1 --streams 70"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 3 --channels 1 --streams 70"
     },
     "PerformanceTest.Client (h2 CI 70x28)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 5 --channels 28 --streams 70"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 3 --channels 28 --streams 70"
     },
     "PerformanceTest.Client (h3 CI 1x1)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --channels 1 --streams 1"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --rounds 3 --channels 1 --streams 1"
     },
     "PerformanceTest.Client (h3 CI 1x28)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --channels 28 --streams 1"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --rounds 3 --channels 28 --streams 1"
     },
     "PerformanceTest.Client (h3 CI 70x1)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --channels 1 --streams 70"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --rounds 3 --channels 1 --streams 70"
     },
     "PerformanceTest.Client (h3 CI 70x28)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --channels 28 --streams 70"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --rounds 3 --channels 28 --streams 70"
     },
     "PerformanceTest.Client (h2+auth CI 1x1)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --channels 1 --streams 1 --clientauth true"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 3 --channels 1 --streams 1 --clientauth true"
     },
     "PerformanceTest.Client (h2+auth CI 1x28)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --channels 28 --streams 1 --clientauth true"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 3 --channels 28 --streams 1 --clientauth true"
     },
     "PerformanceTest.Client (h2+auth CI 70x1)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --channels 1 --streams 70 --clientauth true"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 3 --channels 1 --streams 70 --clientauth true"
     },
     "PerformanceTest.Client (h2+auth CI 70x28)": {
       "commandName": "Project",
-      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --channels 28 --streams 70 --clientauth true"
+      "commandLineArgs": "-u https://localhost:5000 --protocol h2 -s CI --rounds 3 --channels 28 --streams 70 --clientauth true"
+    },
+    "PerformanceTest.Client (h3+auth CI 1x1)": {
+      "commandName": "Project",
+      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --rounds 3 --channels 1 --streams 1 --clientauth true"
+    },
+    "PerformanceTest.Client (h3+auth CI 1x28)": {
+      "commandName": "Project",
+      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --rounds 3 --channels 28 --streams 1 --clientauth true"
+    },
+    "PerformanceTest.Client (h3+auth CI 70x1)": {
+      "commandName": "Project",
+      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --rounds 3 --channels 1 --streams 70 --clientauth true"
+    },
+    "PerformanceTest.Client (h3+auth CI 70x28)": {
+      "commandName": "Project",
+      "commandLineArgs": "-u https://localhost:5000 --protocol h3 -s CI --rounds 3 --channels 28 --streams 70 --clientauth true"
     },
     "PerformanceTest.Client (PingpongStreamingHub 1x1)": {
       "commandName": "Project",

--- a/perf/BenchmarkApp/PerformanceTest.Client/ScenarioType.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/ScenarioType.cs
@@ -1,7 +1,8 @@
 public enum ScenarioType
 {
     All,
-    CI, // Run Unary, StreamingHub, PingpongStreamingHub
+    CI, // Run Unary, StreamingHub
+    CIFull, // Run Unary, StreamingHub, PingpongStreamingHub
 
     Unary,
     UnaryComplex,

--- a/perf/BenchmarkApp/PerformanceTest.Client/StreamingHubScenario.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/StreamingHubScenario.cs
@@ -26,7 +26,7 @@ public class StreamingHubScenario : IScenario, IPerfTestHubReceiver
 
     public async Task CompleteAsync()
     {
-       await this.client.DisposeAsync();
+        await this.client.DisposeAsync();
     }
 }
 

--- a/perf/BenchmarkApp/PerformanceTest.Server/PerfTestControlService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerfTestControlService.cs
@@ -20,6 +20,7 @@ public class PerfTestControlService : ServiceBase<IPerfTestControlService>, IPer
             ApplicationInformation.Current.OSDescription,
             ApplicationInformation.Current.OSArchitecture,
             ApplicationInformation.Current.ProcessArchitecture,
+            ApplicationInformation.Current.CpuModelName,
             ApplicationInformation.Current.IsServerGC,
             ApplicationInformation.Current.ProcessorCount,
             ApplicationInformation.Current.IsAttached));

--- a/perf/BenchmarkApp/PerformanceTest.Server/PerfTestService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerfTestService.cs
@@ -20,6 +20,7 @@ public class PerfTestService : ServiceBase<IPerfTestService>, IPerfTestService
             ApplicationInformation.Current.OSDescription,
             ApplicationInformation.Current.OSArchitecture,
             ApplicationInformation.Current.ProcessArchitecture,
+            ApplicationInformation.Current.CpuModelName,
             ApplicationInformation.Current.IsServerGC,
             ApplicationInformation.Current.ProcessorCount,
             ApplicationInformation.Current.IsAttached));

--- a/perf/BenchmarkApp/PerformanceTest.Server/StartupService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/StartupService.cs
@@ -36,6 +36,7 @@ class StartupService : IHostedService
         Console.WriteLine($"{nameof(RuntimeInformation.OSDescription)}: {ApplicationInformation.Current.OSDescription}");
         Console.WriteLine($"{nameof(RuntimeInformation.OSArchitecture)}: {ApplicationInformation.Current.OSArchitecture}");
         Console.WriteLine($"{nameof(RuntimeInformation.ProcessArchitecture)}: {ApplicationInformation.Current.ProcessArchitecture}");
+        Console.WriteLine($"{nameof(ApplicationInformation.Current.CpuModelName)}: {ApplicationInformation.Current.CpuModelName}");
         Console.WriteLine($"{nameof(GCSettings.IsServerGC)}: {ApplicationInformation.Current.IsServerGC}");
         Console.WriteLine($"{nameof(Environment.ProcessorCount)}: {ApplicationInformation.Current.ProcessorCount}");
         Console.WriteLine($"{nameof(Debugger)}.{nameof(Debugger.IsAttached)}: {ApplicationInformation.Current.IsAttached}");

--- a/perf/BenchmarkApp/PerformanceTest.Shared/ApplicationInformation.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/ApplicationInformation.cs
@@ -33,7 +33,90 @@ public class ApplicationInformation
     public string OSDescription { get; } = RuntimeInformation.OSDescription;
     public Architecture OSArchitecture { get; } = RuntimeInformation.OSArchitecture;
     public Architecture ProcessArchitecture { get; } = RuntimeInformation.ProcessArchitecture;
+    public string CpuModelName { get; } = CpuInformation.Current.ModelName;
     public bool IsServerGC { get; } = GCSettings.IsServerGC;
     public int ProcessorCount { get; } = Environment.ProcessorCount;
     public bool IsAttached { get; } = Debugger.IsAttached;
+
+    public class CpuInformation
+    {
+        public static CpuInformation Current { get; } = new CpuInformation();
+        public string ModelName { get; private set; } = "";
+
+        private CpuInformation()
+        {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.X64 && System.Runtime.Intrinsics.X86.X86Base.IsSupported)
+            {
+                // Linux x86_64 & Windows x86_64...
+                ModelName = GetX86CpuModelName();
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                // Linux Arm64 will be here...
+                ModelName = GetLinuxModelName();
+            }
+            else
+            {
+                // Windows Arm64 is not supported...
+                ModelName = "Unsupported OS";
+            }
+        }
+
+        private string GetX86CpuModelName()
+        {
+            var regs = new int[4 * 3]; // 0x80000002, 0x80000003, 0x80000004 with 4 registers
+
+            // Calling __cpuid with 0x80000000 as the InfoType argument and gets the number of valid extended IDs.
+            var extendedId = System.Runtime.Intrinsics.X86.X86Base.CpuId(unchecked((int)0x80000000), 0).Eax;
+
+            // Get the information associated with each extended ID.
+            if ((uint)extendedId >= 0x80000004)
+            {
+                int p = 0;
+                for (uint i = 0x80000002; i <= 0x80000004; ++i)
+                {
+                    var (Eax, Ebx, Ecx, Edx) = System.Runtime.Intrinsics.X86.X86Base.CpuId((int)i, 0);
+                    regs[p + 0] = Eax;
+                    regs[p + 1] = Ebx;
+                    regs[p + 2] = Ecx;
+                    regs[p + 3] = Edx;
+                    p += 4; // advance
+                }
+                return ConvertToString(regs);
+            }
+
+            return $"Unknown CPU Architecture (extendedId: {extendedId})";
+
+            static string ConvertToString(int[] regs)
+            {
+                var sb = new System.Text.StringBuilder();
+                foreach (int reg in regs)
+                {
+                    var bytes = BitConverter.GetBytes(reg);
+                    sb.Append(System.Text.Encoding.ASCII.GetString(bytes));
+                }
+                return sb.ToString().Trim();
+            }
+        }
+
+        private string GetLinuxModelName()
+        {
+            var cpuInfo = File.ReadAllText("/proc/cpuinfo");
+            var lines = cpuInfo.Split('\n');
+            foreach (var line in lines)
+            {
+                if (!line.StartsWith("model name"))
+                {
+                    continue;
+                }
+                var parts = line.Split(':');
+                if (parts.Length > 1)
+                {
+                    var modelName = parts[1].Trim();
+                    return modelName;
+                }
+            }
+            return "Unknown";
+        }
+    }
 }

--- a/perf/BenchmarkApp/PerformanceTest.Shared/IPerfTestControlService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/IPerfTestControlService.cs
@@ -27,11 +27,12 @@ public partial class ServerInformation
     public string OSDescription { get; }
     public Architecture OSArchitecture { get; }
     public Architecture ProcessArchitecture { get; }
+    public string CpuModelName { get; }
     public bool IsServerGC { get; }
     public int ProcessorCount { get; }
     public bool IsAttached { get; }
 
-    public ServerInformation(string machineName, string? magicOnionVersion, string? grpcNetVersion, string? messagePackVersion, string? memoryPackVersion, bool isReleaseBuild, string frameworkDescription, string osDescription, Architecture osArchitecture, Architecture processArchitecture, bool isServerGC, int processorCount, bool isAttached)
+    public ServerInformation(string machineName, string? magicOnionVersion, string? grpcNetVersion, string? messagePackVersion, string? memoryPackVersion, bool isReleaseBuild, string frameworkDescription, string osDescription, Architecture osArchitecture, Architecture processArchitecture, string cpuModelName, bool isServerGC, int processorCount, bool isAttached)
     {
         MachineName = machineName;
         MagicOnionVersion = magicOnionVersion;
@@ -43,6 +44,7 @@ public partial class ServerInformation
         OSDescription = osDescription;
         OSArchitecture = osArchitecture;
         ProcessArchitecture = processArchitecture;
+        CpuModelName = cpuModelName;
         IsServerGC = isServerGC;
         ProcessorCount = processorCount;
         IsAttached = isAttached;

--- a/perf/BenchmarkApp/configs/issue.yaml
+++ b/perf/BenchmarkApp/configs/issue.yaml
@@ -5,7 +5,7 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 5 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
 benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"

--- a/perf/BenchmarkApp/configs/schedule.yaml
+++ b/perf/BenchmarkApp/configs/schedule.yaml
@@ -58,11 +58,11 @@ jobs:
     channels: 1
     streams: 70
     serialization: messagepack
-  # - tags: legend:messagepack-h2-linux,streams:70x28,protocol:h2,serialization:messagepack
-  #   protocol: h2
-  #   channels: 28
-  #   streams: 70
-  #   serialization: messagepack
+  - tags: legend:messagepack-h2-linux,streams:70x28,protocol:h2,serialization:messagepack
+    protocol: h2
+    channels: 28
+    streams: 70
+    serialization: messagepack
   # h3
   - tags: legend:messagepack-h3-linux,streams:1x1,protocol:h3,serialization:messagepack
     protocol: h3
@@ -84,11 +84,11 @@ jobs:
     channels: 1
     streams: 70
     serialization: messagepack
-  # - tags: legend:messagepack-h3-linux,streams:70x28,protocol:h3,serialization:messagepack
-  #   protocol: h3
-  #   channels: 28
-  #   streams: 70
-  #   serialization: messagepack
+  - tags: legend:messagepack-h3-linux,streams:70x28,protocol:h3,serialization:messagepack
+    protocol: h3
+    channels: 28
+    streams: 70
+    serialization: messagepack
   ##### MemoryPack #####
   # h2c
   - tags: legend:memorypack-h2c-linux,streams:1x1,protocol:h2c,serialization:memorypack
@@ -137,11 +137,11 @@ jobs:
     channels: 1
     streams: 70
     serialization: memorypack
-  # - tags: legend:memorypack-h2-linux,streams:70x28,protocol:h2,serialization:memorypack
-  #   protocol: h2
-  #   channels: 28
-  #   streams: 70
-  #   serialization: memorypack
+  - tags: legend:memorypack-h2-linux,streams:70x28,protocol:h2,serialization:memorypack
+    protocol: h2
+    channels: 28
+    streams: 70
+    serialization: memorypack
   # h3
   - tags: legend:memorypack-h3-linux,streams:1x1,protocol:h3,serialization:memorypack
     protocol: h3
@@ -163,8 +163,8 @@ jobs:
     channels: 1
     streams: 70
     serialization: memorypack
-  # - tags: legend:memorypack-h3-linux,streams:70x28,protocol:h3,serialization:memorypack
-  #   protocol: h3
-  #   channels: 28
-  #   streams: 70
-  #   serialization: memorypack
+  - tags: legend:memorypack-h3-linux,streams:70x28,protocol:h3,serialization:memorypack
+    protocol: h3
+    channels: 28
+    streams: 70
+    serialization: memorypack

--- a/perf/BenchmarkApp/configs/schedule.yaml
+++ b/perf/BenchmarkApp/configs/schedule.yaml
@@ -63,6 +63,32 @@ jobs:
   #   channels: 28
   #   streams: 70
   #   serialization: messagepack
+  # h3
+  - tags: legend:messagepack-h3-linux,streams:1x1,protocol:h3,serialization:messagepack
+    protocol: h3
+    channels: 1
+    streams: 1
+    serialization: messagepack
+  - tags: legend:messagepack-h3-linux,streams:1x28,protocol:h3,serialization:messagepack
+    protocol: h3
+    channels: 28
+    streams: 1
+    serialization: messagepack
+  - tags: legend:messagepack-h3-linux,streams:28x1,protocol:h3,serialization:messagepack
+    protocol: h3
+    channels: 1
+    streams: 28
+    serialization: messagepack
+  - tags: legend:messagepack-h3-linux,streams:70x1,protocol:h3,serialization:messagepack
+    protocol: h3
+    channels: 1
+    streams: 70
+    serialization: messagepack
+  # - tags: legend:messagepack-h3-linux,streams:70x28,protocol:h3,serialization:messagepack
+  #   protocol: h3
+  #   channels: 28
+  #   streams: 70
+  #   serialization: messagepack
   ##### MemoryPack #####
   # h2c
   - tags: legend:memorypack-h2c-linux,streams:1x1,protocol:h2c,serialization:memorypack
@@ -113,6 +139,32 @@ jobs:
     serialization: memorypack
   # - tags: legend:memorypack-h2-linux,streams:70x28,protocol:h2,serialization:memorypack
   #   protocol: h2
+  #   channels: 28
+  #   streams: 70
+  #   serialization: memorypack
+  # h3
+  - tags: legend:memorypack-h3-linux,streams:1x1,protocol:h3,serialization:memorypack
+    protocol: h3
+    channels: 1
+    streams: 1
+    serialization: memorypack
+  - tags: legend:memorypack-h3-linux,streams:1x28,protocol:h3,serialization:memorypack
+    protocol: h3
+    channels: 28
+    streams: 1
+    serialization: memorypack
+  - tags: legend:memorypack-h3-linux,streams:28x1,protocol:h3,serialization:memorypack
+    protocol: h3
+    channels: 1
+    streams: 28
+    serialization: memorypack
+  - tags: legend:memorypack-h3-linux,streams:70x1,protocol:h3,serialization:memorypack
+    protocol: h3
+    channels: 1
+    streams: 70
+    serialization: memorypack
+  # - tags: legend:memorypack-h3-linux,streams:70x28,protocol:h3,serialization:memorypack
+  #   protocol: h3
   #   channels: 28
   #   streams: 70
   #   serialization: memorypack

--- a/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2.yaml
@@ -5,7 +5,7 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 5 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
 benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
@@ -26,8 +26,8 @@ jobs:
     channels: 1
     streams: 70
     serialization: memorypack
-  # - tags: legend:memorypack-h2-linux,streams:70x28,protocol:h2,serialization:memorypack
-  #   protocol: h2
-  #   channels: 28
-  #   streams: 70
-  #   serialization: memorypack
+  - tags: legend:memorypack-h2-linux,streams:70x28,protocol:h2,serialization:memorypack
+    protocol: h2
+    channels: 28
+    streams: 70
+    serialization: memorypack

--- a/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2c.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2c.yaml
@@ -5,7 +5,7 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 5 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
 benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"

--- a/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h3.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h3.yaml
@@ -26,8 +26,8 @@ jobs:
     channels: 1
     streams: 70
     serialization: memorypack
-  # - tags: legend:memorypack-h3-linux,streams:70x28,protocol:h3,serialization:memorypack
-  #   protocol: h3
-  #   channels: 28
-  #   streams: 70
-  #   serialization: memorypack
+  - tags: legend:memorypack-h3-linux,streams:70x28,protocol:h3,serialization:memorypack
+    protocol: h3
+    channels: 28
+    streams: 70
+    serialization: memorypack

--- a/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h3.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h3.yaml
@@ -5,7 +5,7 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 5 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
 benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2.yaml
@@ -5,7 +5,7 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 5 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
 benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2.yaml
@@ -26,8 +26,8 @@ jobs:
     channels: 1
     streams: 70
     serialization: messagepack
-  # - tags: legend:messagepack-h2-linux,streams:70x28,protocol:h2,serialization:messagepack
-  #   protocol: h2
-  #   channels: 28
-  #   streams: 70
-  #   serialization: messagepack
+  - tags: legend:messagepack-h2-linux,streams:70x28,protocol:h2,serialization:messagepack
+    protocol: h2
+    channels: 28
+    streams: 70
+    serialization: messagepack

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2c.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2c.yaml
@@ -5,7 +5,7 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 5 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
 benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3.yaml
@@ -26,8 +26,8 @@ jobs:
     channels: 1
     streams: 70
     serialization: messagepack
-  # - tags: legend:messagepack-h3-linux,streams:70x28,protocol:h3,serialization:messagepack
-  #   protocol: h3
-  #   channels: 28
-  #   streams: 70
-  #   serialization: messagepack
+  - tags: legend:messagepack-h3-linux,streams:70x28,protocol:h3,serialization:messagepack
+    protocol: h3
+    channels: 28
+    streams: 70
+    serialization: messagepack

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3.yaml
@@ -5,7 +5,7 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 5 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
 benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"


### PR DESCRIPTION
## tl;dr;

* Remove PingpongStreaming from CI scenario. (CI runs Unary and StreamingHub)
* Change Cleanup for 1/3 bases
* Decrease Rounds from 5 to 3
* Show CpuModelName on Startup (no tagging at this time)