### PR TITLE
chore: Benchmark client enable EnableMultipleHttp2Connections 

### DIFF
--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -439,6 +439,7 @@ public class ScenarioConfiguration
         {
             UseProxy = false,
             AllowAutoRedirect = false,
+            EnableMultipleHttp2Connections = true,
         };
 
         // allow server's self cert


### PR DESCRIPTION
## tl;dr;

As grpc-dotnet automatically enable it.

https://github.com/grpc/grpc-dotnet/blob/490894cdedb34b43c32dc576d5745c41223764b6/src/Shared/HttpHandlerFactory.cs#L36

> [!NOTE]
> grpc-dotnet benchmark not enable this property. https://github.com/grpc/grpc-dotnet/blob/540e87bf70aff8bbe395e4c7d499a8dd64e89551/perf/benchmarkapps/GrpcClient/Program.cs#L472-L474