### PR TITLE
Enable client library trim warnings

### DIFF
--- a/samples/ChatApp/ChatApp.Console/ChatApp.Console.csproj
+++ b/samples/ChatApp/ChatApp.Console/ChatApp.Console.csproj
@@ -5,7 +5,13 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ChatApp.Unity\Assets\Scripts\Generated\MessagePack.Generated.cs" Link="MessagePack.Generated.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\MagicOnion.Client.SourceGenerator\MagicOnion.Client.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/src/MagicOnion.Abstractions/Internal/Box.cs
+++ b/src/MagicOnion.Abstractions/Internal/Box.cs
@@ -18,21 +18,21 @@ namespace MagicOnion.Internal
             Value = value;
         }
 
-        public bool Equals(Box<T> other)
+        public bool Equals(Box<T>? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return EqualityComparer<T>.Default.Equals(Value, other.Value);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return ReferenceEquals(this, obj) || obj is Box<T> other && Equals(other);
         }
 
         public override int GetHashCode()
         {
-            return EqualityComparer<T>.Default.GetHashCode(Value);
+            return EqualityComparer<T>.Default.GetHashCode(Value!);
         }
 
         public static bool operator ==(Box<T> valueA, Box<T> valueB)

--- a/src/MagicOnion.Abstractions/MagicOnion.Abstractions.csproj
+++ b/src/MagicOnion.Abstractions/MagicOnion.Abstractions.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
 
     <LangVersion>$(_LangVersionUnityBaseline)</LangVersion>
     <Nullable>enable</Nullable>
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsTrimmable>
 
     <PackageId>MagicOnion.Abstractions</PackageId>
     <Description>MagicOnion interfaces and abstractions for server and client.

--- a/src/MagicOnion.Abstractions/PublicAPI.Shipped.txt
+++ b/src/MagicOnion.Abstractions/PublicAPI.Shipped.txt
@@ -90,7 +90,7 @@ MagicOnion.IgnoreAttribute
 MagicOnion.IgnoreAttribute.IgnoreAttribute() -> void
 MagicOnion.Internal.Box
 MagicOnion.Internal.Box<T>
-MagicOnion.Internal.Box<T>.Equals(MagicOnion.Internal.Box<T>! other) -> bool
+MagicOnion.Internal.Box<T>.Equals(MagicOnion.Internal.Box<T>? other) -> bool
 MagicOnion.Internal.IAsyncClientStreamingCallWrapper<TRequest, TResponse>
 MagicOnion.Internal.IAsyncClientStreamingCallWrapper<TRequest, TResponse>.RequestStream.get -> Grpc.Core.IClientStreamWriter<TRequest>!
 MagicOnion.Internal.IAsyncClientStreamingCallWrapper<TRequest, TResponse>.ResponseAsync.get -> System.Threading.Tasks.Task<TResponse>!
@@ -155,7 +155,7 @@ MagicOnion.UnaryResult<TResponse>.UnaryResult() -> void
 MagicOnion.UnaryResult<TResponse>.UnaryResult(System.Threading.Tasks.Task<MagicOnion.Client.IResponseContext<TResponse>!>! response) -> void
 MagicOnion.UnaryResult<TResponse>.UnaryResult(System.Threading.Tasks.Task<TResponse>! rawTaskValue) -> void
 MagicOnion.UnaryResult<TResponse>.UnaryResult(TResponse rawValue) -> void
-override MagicOnion.Internal.Box<T>.Equals(object! obj) -> bool
+override MagicOnion.Internal.Box<T>.Equals(object? obj) -> bool
 override MagicOnion.Internal.Box<T>.GetHashCode() -> int
 readonly MagicOnion.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>.Item1 -> T1
 readonly MagicOnion.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>.Item10 -> T10

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Abstractions/Internal/Box.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Abstractions/Internal/Box.cs
@@ -18,21 +18,21 @@ namespace MagicOnion.Internal
             Value = value;
         }
 
-        public bool Equals(Box<T> other)
+        public bool Equals(Box<T>? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return EqualityComparer<T>.Default.Equals(Value, other.Value);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return ReferenceEquals(this, obj) || obj is Box<T> other && Equals(other);
         }
 
         public override int GetHashCode()
         {
-            return EqualityComparer<T>.Default.GetHashCode(Value);
+            return EqualityComparer<T>.Default.GetHashCode(Value!);
         }
 
         public static bool operator ==(Box<T> valueA, Box<T> valueB)

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicClientAssemblyHolder.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicClientAssemblyHolder.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using MagicOnion.Internal.Reflection;
 
 namespace MagicOnion.Client.DynamicClient
 {
+    [RequiresUnreferencedCode(nameof(DynamicClientAssemblyHolder) + " is incompatible with trimming and Native AOT.")]
 #if ENABLE_SAVE_ASSEMBLY
     public
 #else

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicClientBuilder.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicClientBuilder.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
 using Grpc.Core;
 using MagicOnion.Client.Internal;
 using MagicOnion.Serialization;
@@ -20,6 +20,7 @@ namespace MagicOnion.Client.DynamicClient
         }
     }
 
+    [RequiresUnreferencedCode(nameof(DynamicClientBuilder<T>) + " is incompatible with trimming and Native AOT.")]
     internal class DynamicClientBuilder<T> : DynamicClientBuilder
         where T : IService<T>
     {

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicMagicOnionClientFactoryProvider.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicMagicOnionClientFactoryProvider.cs
@@ -18,6 +18,7 @@ namespace MagicOnion.Client.DynamicClient
     /// <summary>
     /// Provides to get a MagicOnionClient factory of the specified service type. The provider is backed by DynamicMagicOnionClientBuilder.
     /// </summary>
+    [RequiresUnreferencedCode(nameof(DynamicMagicOnionClientFactoryProvider) + " is incompatible with trimming and Native AOT.")]
     public class DynamicMagicOnionClientFactoryProvider : IMagicOnionClientFactoryProvider
     {
         public static IMagicOnionClientFactoryProvider Instance { get; } = new DynamicMagicOnionClientFactoryProvider();
@@ -30,6 +31,7 @@ namespace MagicOnion.Client.DynamicClient
             return true;
         }
 
+        [RequiresUnreferencedCode(nameof(DynamicMagicOnionClientFactoryProvider) + "." + nameof(Cache<T>) + " is incompatible with trimming and Native AOT.")]
         static class Cache<T> where T : IService<T>
         {
             public static readonly MagicOnionClientFactoryDelegate<T> Factory

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicStreamingHubClientBuilder.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicStreamingHubClientBuilder.cs
@@ -6,6 +6,7 @@ using MagicOnion.Server.Hubs;
 using MessagePack;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -14,6 +15,7 @@ using System.Threading.Tasks;
 
 namespace MagicOnion.Client.DynamicClient
 {
+    [RequiresUnreferencedCode(nameof(DynamicStreamingHubClientAssemblyHolder) + " is incompatible with trimming and Native AOT.")]
 #if ENABLE_SAVE_ASSEMBLY
     public
 #else
@@ -41,6 +43,7 @@ namespace MagicOnion.Client.DynamicClient
 #endif
     }
 
+    [RequiresUnreferencedCode(nameof(DynamicStreamingHubClientBuilder<TStreamingHub, TReceiver>) + " is incompatible with trimming and Native AOT.")]
 #if ENABLE_SAVE_ASSEMBLY
     public
 #else
@@ -709,6 +712,7 @@ namespace MagicOnion.Client.DynamicClient
             }
         }
 
+        [RequiresUnreferencedCode(nameof(MethodInfoCache) + " is incompatible with trimming and Native AOT.")]
         static class MethodInfoCache
         {
             // ReSharper disable StaticMemberInGenericType

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicStreamingHubClientFactoryProvider.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/DynamicStreamingHubClientFactoryProvider.cs
@@ -15,6 +15,7 @@ namespace MagicOnion.Client.DynamicClient
         }
     }
 
+    [RequiresUnreferencedCode(nameof(DynamicStreamingHubClientFactoryProvider) + " is incompatible with trimming and Native AOT.")]
     public class DynamicStreamingHubClientFactoryProvider : IStreamingHubClientFactoryProvider
     {
         public static IStreamingHubClientFactoryProvider Instance { get; } = new DynamicStreamingHubClientFactoryProvider();
@@ -27,6 +28,7 @@ namespace MagicOnion.Client.DynamicClient
             return true;
         }
 
+        [RequiresUnreferencedCode(nameof(DynamicStreamingHubClientFactoryProvider) + "." + nameof(Cache<TStreamingHub, TReceiver>) + " is incompatible with trimming and Native AOT.")]
         static class Cache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             public static readonly StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/RawMethodInvokerTypes.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/RawMethodInvokerTypes.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using Grpc.Core;
 using MagicOnion.Client.Internal;
 
 namespace MagicOnion.Client.DynamicClient
 {
+    [RequiresUnreferencedCode(nameof(RawMethodInvokerTypes) + " is incompatible with trimming and Native AOT.")]
     internal static class RawMethodInvokerTypes
     {
         static readonly MethodInfo create_RefType_RefType = typeof(RawMethodInvoker).GetMethod(nameof(RawMethodInvoker.Create_RefType_RefType), BindingFlags.Static | BindingFlags.Public)!;

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/ServiceClientDefinition.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/DynamicClient/ServiceClientDefinition.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using MessagePack;
 
 namespace MagicOnion.Client.DynamicClient
 {
+    [RequiresUnreferencedCode(nameof(ServiceClientDefinition) + " is incompatible with trimming and Native AOT.")]
     internal class ServiceClientDefinition
     {
         public Type ServiceInterfaceType { get; }
@@ -20,6 +22,7 @@ namespace MagicOnion.Client.DynamicClient
             Methods = methods;
         }
 
+        [RequiresUnreferencedCode(nameof(MagicOnionServiceMethodInfo) + " is incompatible with trimming and Native AOT.")]
         public class MagicOnionServiceMethodInfo
         {
             public MethodType MethodType { get; }
@@ -69,7 +72,7 @@ namespace MagicOnion.Client.DynamicClient
                 return method;
             }
 
-            private void Verify()
+            void Verify()
             {
                 switch (MethodType)
                 {
@@ -91,7 +94,7 @@ namespace MagicOnion.Client.DynamicClient
                 }
             }
 
-            private static (MethodType MethodType, Type? RequestType, Type ResponseType) GetMethodTypeAndResponseTypeFromMethod(MethodInfo methodInfo)
+            static (MethodType MethodType, Type? RequestType, Type ResponseType) GetMethodTypeAndResponseTypeFromMethod(MethodInfo methodInfo)
             {
                 const string UnsupportedReturnTypeErrorMessage =
                     "The method of a service must return 'UnaryResult<T>', 'Task<ClientStreamingResult<TRequest, TResponse>>', 'Task<ServerStreamingResult<T>>' or 'DuplexStreamingResult<TRequest, TResponse>'.";
@@ -171,7 +174,7 @@ namespace MagicOnion.Client.DynamicClient
             return new ServiceClientDefinition(typeof(T), GetServiceMethods(typeof(T)));
         }
         
-        private static IReadOnlyList<MagicOnionServiceMethodInfo> GetServiceMethods(Type serviceType)
+        static IReadOnlyList<MagicOnionServiceMethodInfo> GetServiceMethods(Type serviceType)
         {
             return serviceType
                 .GetInterfaces()
@@ -209,7 +212,7 @@ namespace MagicOnion.Client.DynamicClient
         /// </summary>
         /// <param name="methodInfo"></param>
         /// <returns></returns>
-        private static Type GetRequestTypeFromMethod(MethodInfo methodInfo)
+        static Type GetRequestTypeFromMethod(MethodInfo methodInfo)
         {
             var parameterTypes = methodInfo.GetParameters().Select(x => x.ParameterType).ToArray();
             switch (parameterTypes.Length)

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/BroadcasterHelper.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/BroadcasterHelper.cs
@@ -1,11 +1,13 @@
 using MagicOnion.Server.Hubs;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
 namespace MagicOnion.Internal
 {
+    [RequiresUnreferencedCode("BroadcastHelper is incompatible with trimming.")]
     internal static class BroadcasterHelper
     {
         internal static Type[] DynamicArgumentTupleTypes { get; } = typeof(DynamicArgumentTuple<,>)

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Polyfil.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Polyfil.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d0740739ff0548f42abb6937a771bcfd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Polyfil/RequiresUnreferencedCodeAttribute.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Polyfil/RequiresUnreferencedCodeAttribute.cs
@@ -1,0 +1,20 @@
+#if !NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+    internal class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        public string Message { get; }
+        public string? Url { get; }
+
+        public RequiresUnreferencedCodeAttribute(string message)
+        {
+            Message = message;
+        }
+    }
+}
+#endif

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Polyfil/RequiresUnreferencedCodeAttribute.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Polyfil/RequiresUnreferencedCodeAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d0a558474e947549a1d7c4f4455c44c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Polyfil/UnconditionalSuppressMessageAttribute.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Polyfil/UnconditionalSuppressMessageAttribute.cs
@@ -1,0 +1,25 @@
+#if !NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    internal class UnconditionalSuppressMessageAttribute : Attribute
+    {
+        public string Category { get; }
+        public string CheckId { get; }
+        public string? Scope { get; set; }
+        public string? Target { get; set; }
+        public string? Justification { get; set; }
+        public string? MessageId { get; set; }
+
+        public UnconditionalSuppressMessageAttribute(string category, string checkId)
+        {
+            Category = category;
+            CheckId = checkId;
+        }
+    }
+}
+#endif

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Polyfil/UnconditionalSuppressMessageAttribute.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Polyfil/UnconditionalSuppressMessageAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 337e745c02c4896408b607de73abe11b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Reflection/DynamicAssembly.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal.Shared/Reflection/DynamicAssembly.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 
 namespace MagicOnion.Internal.Reflection
 {
+    [RequiresUnreferencedCode(nameof(DynamicAssembly) + " is incompatible with trimming and Native AOT.")]
 #if ENABLE_SAVE_ASSEMBLY
     public
 #else

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal/DictionaryExtensions.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/Internal/DictionaryExtensions.cs
@@ -1,3 +1,4 @@
+#if NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -8,7 +9,6 @@ namespace System.Collections.Generic
 {
     internal static class DictionaryExtensions
     {
-#if NETSTANDARD2_0
         public static bool Remove<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, [NotNullWhen(true)] out TValue? value)
         {
             if (dict.TryGetValue(key, out var v))
@@ -21,6 +21,6 @@ namespace System.Collections.Generic
             value = default;
             return false;
         }
-#endif
     }
 }
+#endif

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClientFactoryProvider.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/MagicOnionClientFactoryProvider.cs
@@ -9,6 +9,7 @@ namespace MagicOnion.Client
     /// <summary>
     /// Provides to get a MagicOnionClient factory of the specified service type.
     /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "ClientFactoryProvider is resolved at runtime.")]
     public static class MagicOnionClientFactoryProvider
     {
         /// <summary>

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientFactoryProvider.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/MagicOnion.Client/StreamingHubClientFactoryProvider.cs
@@ -9,6 +9,7 @@ namespace MagicOnion.Client
     /// <summary>
     /// Provides to get a StreamingHubClient factory of the specified service type.
     /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "ClientFactoryProvider is resolved at runtime.")]
     public static class StreamingHubClientFactoryProvider
     {
         /// <summary>

--- a/src/MagicOnion.Client/DynamicClient/DynamicClientAssemblyHolder.cs
+++ b/src/MagicOnion.Client/DynamicClient/DynamicClientAssemblyHolder.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using MagicOnion.Internal.Reflection;
 
 namespace MagicOnion.Client.DynamicClient
 {
+    [RequiresUnreferencedCode(nameof(DynamicClientAssemblyHolder) + " is incompatible with trimming and Native AOT.")]
 #if ENABLE_SAVE_ASSEMBLY
     public
 #else

--- a/src/MagicOnion.Client/DynamicClient/DynamicClientBuilder.cs
+++ b/src/MagicOnion.Client/DynamicClient/DynamicClientBuilder.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
 using Grpc.Core;
 using MagicOnion.Client.Internal;
 using MagicOnion.Serialization;
@@ -20,6 +20,7 @@ namespace MagicOnion.Client.DynamicClient
         }
     }
 
+    [RequiresUnreferencedCode(nameof(DynamicClientBuilder<T>) + " is incompatible with trimming and Native AOT.")]
     internal class DynamicClientBuilder<T> : DynamicClientBuilder
         where T : IService<T>
     {

--- a/src/MagicOnion.Client/DynamicClient/DynamicMagicOnionClientFactoryProvider.cs
+++ b/src/MagicOnion.Client/DynamicClient/DynamicMagicOnionClientFactoryProvider.cs
@@ -18,6 +18,7 @@ namespace MagicOnion.Client.DynamicClient
     /// <summary>
     /// Provides to get a MagicOnionClient factory of the specified service type. The provider is backed by DynamicMagicOnionClientBuilder.
     /// </summary>
+    [RequiresUnreferencedCode(nameof(DynamicMagicOnionClientFactoryProvider) + " is incompatible with trimming and Native AOT.")]
     public class DynamicMagicOnionClientFactoryProvider : IMagicOnionClientFactoryProvider
     {
         public static IMagicOnionClientFactoryProvider Instance { get; } = new DynamicMagicOnionClientFactoryProvider();
@@ -30,6 +31,7 @@ namespace MagicOnion.Client.DynamicClient
             return true;
         }
 
+        [RequiresUnreferencedCode(nameof(DynamicMagicOnionClientFactoryProvider) + "." + nameof(Cache<T>) + " is incompatible with trimming and Native AOT.")]
         static class Cache<T> where T : IService<T>
         {
             public static readonly MagicOnionClientFactoryDelegate<T> Factory

--- a/src/MagicOnion.Client/DynamicClient/DynamicStreamingHubClientBuilder.cs
+++ b/src/MagicOnion.Client/DynamicClient/DynamicStreamingHubClientBuilder.cs
@@ -6,6 +6,7 @@ using MagicOnion.Server.Hubs;
 using MessagePack;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -14,6 +15,7 @@ using System.Threading.Tasks;
 
 namespace MagicOnion.Client.DynamicClient
 {
+    [RequiresUnreferencedCode(nameof(DynamicStreamingHubClientAssemblyHolder) + " is incompatible with trimming and Native AOT.")]
 #if ENABLE_SAVE_ASSEMBLY
     public
 #else
@@ -41,6 +43,7 @@ namespace MagicOnion.Client.DynamicClient
 #endif
     }
 
+    [RequiresUnreferencedCode(nameof(DynamicStreamingHubClientBuilder<TStreamingHub, TReceiver>) + " is incompatible with trimming and Native AOT.")]
 #if ENABLE_SAVE_ASSEMBLY
     public
 #else
@@ -709,6 +712,7 @@ namespace MagicOnion.Client.DynamicClient
             }
         }
 
+        [RequiresUnreferencedCode(nameof(MethodInfoCache) + " is incompatible with trimming and Native AOT.")]
         static class MethodInfoCache
         {
             // ReSharper disable StaticMemberInGenericType

--- a/src/MagicOnion.Client/DynamicClient/DynamicStreamingHubClientFactoryProvider.cs
+++ b/src/MagicOnion.Client/DynamicClient/DynamicStreamingHubClientFactoryProvider.cs
@@ -15,6 +15,7 @@ namespace MagicOnion.Client.DynamicClient
         }
     }
 
+    [RequiresUnreferencedCode(nameof(DynamicStreamingHubClientFactoryProvider) + " is incompatible with trimming and Native AOT.")]
     public class DynamicStreamingHubClientFactoryProvider : IStreamingHubClientFactoryProvider
     {
         public static IStreamingHubClientFactoryProvider Instance { get; } = new DynamicStreamingHubClientFactoryProvider();
@@ -27,6 +28,7 @@ namespace MagicOnion.Client.DynamicClient
             return true;
         }
 
+        [RequiresUnreferencedCode(nameof(DynamicStreamingHubClientFactoryProvider) + "." + nameof(Cache<TStreamingHub, TReceiver>) + " is incompatible with trimming and Native AOT.")]
         static class Cache<TStreamingHub, TReceiver> where TStreamingHub : IStreamingHub<TStreamingHub, TReceiver>
         {
             public static readonly StreamingHubClientFactoryDelegate<TStreamingHub, TReceiver> Factory

--- a/src/MagicOnion.Client/DynamicClient/RawMethodInvokerTypes.cs
+++ b/src/MagicOnion.Client/DynamicClient/RawMethodInvokerTypes.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using Grpc.Core;
 using MagicOnion.Client.Internal;
 
 namespace MagicOnion.Client.DynamicClient
 {
+    [RequiresUnreferencedCode(nameof(RawMethodInvokerTypes) + " is incompatible with trimming and Native AOT.")]
     internal static class RawMethodInvokerTypes
     {
         static readonly MethodInfo create_RefType_RefType = typeof(RawMethodInvoker).GetMethod(nameof(RawMethodInvoker.Create_RefType_RefType), BindingFlags.Static | BindingFlags.Public)!;

--- a/src/MagicOnion.Client/DynamicClient/ServiceClientDefinition.cs
+++ b/src/MagicOnion.Client/DynamicClient/ServiceClientDefinition.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using MessagePack;
 
 namespace MagicOnion.Client.DynamicClient
 {
+    [RequiresUnreferencedCode(nameof(ServiceClientDefinition) + " is incompatible with trimming and Native AOT.")]
     internal class ServiceClientDefinition
     {
         public Type ServiceInterfaceType { get; }
@@ -20,6 +22,7 @@ namespace MagicOnion.Client.DynamicClient
             Methods = methods;
         }
 
+        [RequiresUnreferencedCode(nameof(MagicOnionServiceMethodInfo) + " is incompatible with trimming and Native AOT.")]
         public class MagicOnionServiceMethodInfo
         {
             public MethodType MethodType { get; }
@@ -69,7 +72,7 @@ namespace MagicOnion.Client.DynamicClient
                 return method;
             }
 
-            private void Verify()
+            void Verify()
             {
                 switch (MethodType)
                 {
@@ -91,7 +94,7 @@ namespace MagicOnion.Client.DynamicClient
                 }
             }
 
-            private static (MethodType MethodType, Type? RequestType, Type ResponseType) GetMethodTypeAndResponseTypeFromMethod(MethodInfo methodInfo)
+            static (MethodType MethodType, Type? RequestType, Type ResponseType) GetMethodTypeAndResponseTypeFromMethod(MethodInfo methodInfo)
             {
                 const string UnsupportedReturnTypeErrorMessage =
                     "The method of a service must return 'UnaryResult<T>', 'Task<ClientStreamingResult<TRequest, TResponse>>', 'Task<ServerStreamingResult<T>>' or 'DuplexStreamingResult<TRequest, TResponse>'.";
@@ -171,7 +174,7 @@ namespace MagicOnion.Client.DynamicClient
             return new ServiceClientDefinition(typeof(T), GetServiceMethods(typeof(T)));
         }
         
-        private static IReadOnlyList<MagicOnionServiceMethodInfo> GetServiceMethods(Type serviceType)
+        static IReadOnlyList<MagicOnionServiceMethodInfo> GetServiceMethods(Type serviceType)
         {
             return serviceType
                 .GetInterfaces()
@@ -209,7 +212,7 @@ namespace MagicOnion.Client.DynamicClient
         /// </summary>
         /// <param name="methodInfo"></param>
         /// <returns></returns>
-        private static Type GetRequestTypeFromMethod(MethodInfo methodInfo)
+        static Type GetRequestTypeFromMethod(MethodInfo methodInfo)
         {
             var parameterTypes = methodInfo.GetParameters().Select(x => x.ParameterType).ToArray();
             switch (parameterTypes.Length)

--- a/src/MagicOnion.Client/Internal/DictionaryExtensions.cs
+++ b/src/MagicOnion.Client/Internal/DictionaryExtensions.cs
@@ -1,3 +1,4 @@
+#if NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -8,7 +9,6 @@ namespace System.Collections.Generic
 {
     internal static class DictionaryExtensions
     {
-#if NETSTANDARD2_0
         public static bool Remove<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, [NotNullWhen(true)] out TValue? value)
         {
             if (dict.TryGetValue(key, out var v))
@@ -21,6 +21,6 @@ namespace System.Collections.Generic
             value = default;
             return false;
         }
-#endif
     }
 }
+#endif

--- a/src/MagicOnion.Client/MagicOnion.Client.csproj
+++ b/src/MagicOnion.Client/MagicOnion.Client.csproj
@@ -5,6 +5,7 @@
 
     <LangVersion>$(_LangVersionUnityBaseline)</LangVersion>
     <Nullable>enable</Nullable>
+    <IsTrimmable>true</IsTrimmable>
 
     <!-- NuGet -->
     <PackageId>MagicOnion.Client</PackageId>

--- a/src/MagicOnion.Client/MagicOnionClientFactoryProvider.cs
+++ b/src/MagicOnion.Client/MagicOnionClientFactoryProvider.cs
@@ -9,6 +9,7 @@ namespace MagicOnion.Client
     /// <summary>
     /// Provides to get a MagicOnionClient factory of the specified service type.
     /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "ClientFactoryProvider is resolved at runtime.")]
     public static class MagicOnionClientFactoryProvider
     {
         /// <summary>

--- a/src/MagicOnion.Client/StreamingHubClientFactoryProvider.cs
+++ b/src/MagicOnion.Client/StreamingHubClientFactoryProvider.cs
@@ -9,6 +9,7 @@ namespace MagicOnion.Client
     /// <summary>
     /// Provides to get a StreamingHubClient factory of the specified service type.
     /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "ClientFactoryProvider is resolved at runtime.")]
     public static class StreamingHubClientFactoryProvider
     {
         /// <summary>

--- a/src/MagicOnion.Internal/BroadcasterHelper.cs
+++ b/src/MagicOnion.Internal/BroadcasterHelper.cs
@@ -1,11 +1,13 @@
 using MagicOnion.Server.Hubs;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
 namespace MagicOnion.Internal
 {
+    [RequiresUnreferencedCode("BroadcastHelper is incompatible with trimming.")]
     internal static class BroadcasterHelper
     {
         internal static Type[] DynamicArgumentTupleTypes { get; } = typeof(DynamicArgumentTuple<,>)

--- a/src/MagicOnion.Internal/MagicOnion.Internal.csproj
+++ b/src/MagicOnion.Internal/MagicOnion.Internal.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>

--- a/src/MagicOnion.Internal/Polyfil/RequiresUnreferencedCodeAttribute.cs
+++ b/src/MagicOnion.Internal/Polyfil/RequiresUnreferencedCodeAttribute.cs
@@ -1,0 +1,20 @@
+#if !NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+    internal class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        public string Message { get; }
+        public string? Url { get; }
+
+        public RequiresUnreferencedCodeAttribute(string message)
+        {
+            Message = message;
+        }
+    }
+}
+#endif

--- a/src/MagicOnion.Internal/Polyfil/UnconditionalSuppressMessageAttribute.cs
+++ b/src/MagicOnion.Internal/Polyfil/UnconditionalSuppressMessageAttribute.cs
@@ -1,0 +1,25 @@
+#if !NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    internal class UnconditionalSuppressMessageAttribute : Attribute
+    {
+        public string Category { get; }
+        public string CheckId { get; }
+        public string? Scope { get; set; }
+        public string? Target { get; set; }
+        public string? Justification { get; set; }
+        public string? MessageId { get; set; }
+
+        public UnconditionalSuppressMessageAttribute(string category, string checkId)
+        {
+            Category = category;
+            CheckId = checkId;
+        }
+    }
+}
+#endif

--- a/src/MagicOnion.Internal/Reflection/DynamicAssembly.cs
+++ b/src/MagicOnion.Internal/Reflection/DynamicAssembly.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 
 namespace MagicOnion.Internal.Reflection
 {
+    [RequiresUnreferencedCode(nameof(DynamicAssembly) + " is incompatible with trimming and Native AOT.")]
 #if ENABLE_SAVE_ASSEMBLY
     public
 #else

--- a/src/MagicOnion.Serialization.MessagePack/MagicOnion.Serialization.MessagePack.csproj
+++ b/src/MagicOnion.Serialization.MessagePack/MagicOnion.Serialization.MessagePack.csproj
@@ -2,10 +2,11 @@
 
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsTrimmable>
 
     <!-- NuGet -->
     <PackageId>MagicOnion.Serialization.MessagePack</PackageId>

--- a/tests/MagicOnion.Client.Tests/StreamingHubClientHeartbeatManagerTest.cs
+++ b/tests/MagicOnion.Client.Tests/StreamingHubClientHeartbeatManagerTest.cs
@@ -281,9 +281,9 @@ public class StreamingHubClientHeartbeatManagerTest
         Assert.False(manager.TimeoutToken.IsCancellationRequested);
 
         // Respond to the first message. but it does not respond to subsequent messages.
-        manager.ProcessClientHeartbeatResponse(StreamingHubPayloadPool.Shared.RentOrCreate([0x95 /* Array(5) */, 0x7e /* 0x7e(127) */, 0x0 /* Sequence(0) */, .. ToMessagePackBytes(origin.AddSeconds(1)) /* ClientSentAt * /, 0xc0 /* Nil */, 0xc0 /* Nil */]));
-        manager.ProcessClientHeartbeatResponse(StreamingHubPayloadPool.Shared.RentOrCreate([0x95 /* Array(5) */, 0x7e /* 0x7e(127) */, 0x1 /* Sequence(1) */, .. ToMessagePackBytes(origin.AddSeconds(2)) /* ClientSentAt * /, 0xc0 /* Nil */, 0xc0 /* Nil */]));
-        manager.ProcessClientHeartbeatResponse(StreamingHubPayloadPool.Shared.RentOrCreate([0x95 /* Array(5) */, 0x7e /* 0x7e(127) */, 0x2 /* Sequence(2) */, .. ToMessagePackBytes(origin.AddSeconds(3)) /* ClientSentAt * /, 0xc0 /* Nil */, 0xc0 /* Nil */]));
+        manager.ProcessClientHeartbeatResponse(StreamingHubPayloadPool.Shared.RentOrCreate([0x95 /* Array(5) */, 0x7e /* 0x7e(127) */, 0x0 /* Sequence(0) */, .. ToMessagePackBytes(origin.AddSeconds(1)) /* ClientSentAt */, 0xc0 /* Nil */, 0xc0 /* Nil */]));
+        manager.ProcessClientHeartbeatResponse(StreamingHubPayloadPool.Shared.RentOrCreate([0x95 /* Array(5) */, 0x7e /* 0x7e(127) */, 0x1 /* Sequence(1) */, .. ToMessagePackBytes(origin.AddSeconds(2)) /* ClientSentAt */, 0xc0 /* Nil */, 0xc0 /* Nil */]));
+        manager.ProcessClientHeartbeatResponse(StreamingHubPayloadPool.Shared.RentOrCreate([0x95 /* Array(5) */, 0x7e /* 0x7e(127) */, 0x2 /* Sequence(2) */, .. ToMessagePackBytes(origin.AddSeconds(3)) /* ClientSentAt */, 0xc0 /* Nil */, 0xc0 /* Nil */]));
 
         timeProvider.Advance(TimeSpan.FromMilliseconds(100)); // 3s has elapsed since the first message.
         await Task.Delay(10);


### PR DESCRIPTION
This PR enables client library trim warnings.

Trimming and NativeAOT can be enabled in applications that use MagicOnion.Client.