### PR TITLE
chore: Run benchmark with specific Client/Server NuGet version

### DIFF
--- a/.github/scripts/benchmark-client-run.sh
+++ b/.github/scripts/benchmark-client-run.sh
@@ -114,6 +114,11 @@ echo "::group::dotnet publish"
     print "List current files under $(pwd)"
     ls -l
 
+    print "Remove all files under $publish_dir"
+    if [[ -d "./$publish_dir" ]]; then
+      rm -rf "./$publish_dir"
+    fi
+
     print "dotnet publish $build_csproj $_BUILD_ARGS"
     dotnet publish -c "$build_config" -p:PublishSingleFile=true --runtime linux-x64 --self-contained false "$build_csproj" -o "$publish_dir" $_BUILD_ARGS
 

--- a/.github/scripts/benchmark-client-run.sh
+++ b/.github/scripts/benchmark-client-run.sh
@@ -8,17 +8,17 @@ set -euo pipefail
 # $ echo $?
 
 function usage {
-    echo "usage: $(basename $0) --args <string> [options]"
+    echo "usage: $(basename $0) --run-args <string> [options]"
     echo "Required:"
-    echo "  --args          string      Arguments to pass when running the built binary (default: \"\")"
+    echo "  --run-args          string      Arguments to pass when running the built binary (default: \"\")"
     echo "Options:"
-    echo "  --help                      Show this help message"
+    echo "  --help                          Show this help message"
 }
 
 while [ $# -gt 0 ]; do
   case $1 in
     # required
-    --args) _ARGS=$2; shift 2; ;;
+    --run-args) _RUN_ARGS=$2; shift 2; ;;
     # optional
     --help) usage; exit 1; ;;
     *) shift ;;
@@ -38,7 +38,7 @@ function error {
 
 # parameter setup
 title "Arguments:"
-print "--args=${_ARGS:=""}"
+print "--run-args=${_RUN_ARGS:=""}"
 
 title "Constants:"
 print "  * repo=${repo:="MagicOnion"}"
@@ -121,8 +121,8 @@ echo "::group::dotnet publish"
 echo "::endgroup::"
 
 # run dotnet app
-title "Run $full_process_path $_ARGS"
+title "Run $full_process_path $_RUN_ARGS"
 pushd "$output_dir" > /dev/null
   # run foreground
-  "./$binary_name" $_ARGS
+  "./$binary_name" $_RUN_ARGS
 popd > /dev/null

--- a/.github/scripts/benchmark-client-run.sh
+++ b/.github/scripts/benchmark-client-run.sh
@@ -25,55 +25,64 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-function print() {
+function print {
+  echo "$(date "+%Y-%m-%d %H:%M:%S") INFO(${FUNCNAME[1]:-unknown}): $*"
+}
+function title {
   echo ""
-  echo "$*"
+  echo "$(date "+%Y-%m-%d %H:%M:%S") INFO(${FUNCNAME[1]:-unknown}): # $*"
+}
+function error {
+  echo "$(date "+%Y-%m-%d %H:%M:%S") ERROR(${FUNCNAME[1]:-unknown}): # $*" >&2
 }
 
 # parameter setup
-repo="MagicOnion"
-build_config="Release"
-args="${_ARGS:=""}"
-build_csproj="perf/BenchmarkApp/PerformanceTest.Client/PerformanceTest.Client.csproj"
-env_settings=""
+title "Arguments:"
+print "--args=${_ARGS:=""}"
 
-binary_name=$(basename "$(dirname "$build_csproj")")
-publish_dir="artifacts/$binary_name"
-clone_path="$HOME/github/$repo"
-output_dir="$clone_path/$publish_dir"
-full_process_path="$output_dir/$binary_name"
+title "Constants:"
+print "  * repo=${repo:="MagicOnion"}"
+print "  * build_config=${build_config:="Release"}"
+print "  * build_csproj=${build_csproj:="perf/BenchmarkApp/PerformanceTest.Client/PerformanceTest.Client.csproj"}"
+print "  * env_settings=${env_settings:=""}"
+print "  * binary_name=${binary_name:=$(basename "$(dirname "$build_csproj")")}"
+print "  * publish_dir=${publish_dir:="artifacts/$binary_name"}"
+print "  * clone_path=${clone_path:="$HOME/github/$repo"}"
+print "  * output_dir=${output_dir:="$clone_path/$publish_dir"}"
+print "  * full_process_path=${full_process_path:="$output_dir/$binary_name"}"
 
-# show machine name
-print "MACHINE_NAME: $(hostname)"
+# machine name
+title "Show this machine name"
+print "  * MACHINE_NAME=$(hostname)"
 
 # is dotnet installed?
-print "# Show installed dotnet sdk versions"
-echo "dotnet sdk versions (list): $(dotnet --list-sdks)"
-echo "dotnet sdk version (default): $(dotnet --version)"
+title "Show installed dotnet sdk versions"
+print "  * dotnet sdk versions (list): $(dotnet --list-sdks)"
+print "  * dotnet sdk version (default): $(dotnet --version)"
 
 # is already clones?
-print "# Check if already cloned $repo"
+title "Check if already cloned $repo"
 if [[ ! -d "$clone_path" ]]; then
-  echop "Failed to find $clone_path, not yet git cloned?"
+  error "Failed to find $clone_path, not yet git cloned?"
   exit 1
 fi
 
 # get branch name and set to environment variables
-print "# Set branch name as Environment variable"
-pushd "$clone_path"
-  print "  ## get current git branch name"
+title "Set branch name as Environment variable"
+pushd "$clone_path" > /dev/null
+  print "Get current git branch name"
   git_branch=$(git rev-parse --abbrev-ref HEAD)
   if [ -z "$git_branch" ]; then
-    echo "Failed to get branch name, exiting..."
+    error "Failed to get branch name, exiting..."
     exit 1
   fi
 
-  print "  ## set branch name to environment variables $git_branch"
+  print "Set branch name to environment variables $git_branch"
   export BRANCH_NAME="$git_branch"
-popd
+popd > /dev/null
 
 # setup env
-print "# Setup environment"
+title "Setup environment"
 IFS=';' read -ra env_array <<< "$env_settings"
 for item in "${env_array[@]}"; do
   if [[ -n "$item" ]]; then
@@ -82,33 +91,33 @@ for item in "${env_array[@]}"; do
 done
 
 # dotnet publish
-print "# dotnet publish $build_csproj"
-pushd "$clone_path"
-  print "  ## list current files under $(pwd)"
+title "dotnet publish $build_csproj"
+pushd "$clone_path" > /dev/null
+  print "List current files under $(pwd)"
   ls -l
 
-  print "  ## dotnet publish $build_csproj"
+  print "dotnet publish $build_csproj"
   dotnet publish -c "$build_config" -p:PublishSingleFile=true --runtime linux-x64 --self-contained false "$build_csproj" -o "$publish_dir"
 
-  print "  ## list published files under $publish_dir"
+  print "List published files under $publish_dir"
   ls "$publish_dir"
 
-  print "  ## add +x permission to published file $full_process_path"
+  print "Add +x permission to published file $full_process_path"
   chmod +x "$full_process_path"
-popd
+popd > /dev/null
 
 # process check
-print "# Checking process $binary_name already runnning, kill if exists"
+title "Checking process $binary_name already runnning, kill if exists"
 ps -eo pid,cmd | while read -r pid cmd; do
   if echo "$cmd" | grep -E "^./$binary_name" >/dev/null 2>&1; then
-    echo "Found & killing process $pid ($cmd)"
+    print "Found & killing process $pid ($cmd)"
     kill "$pid"
   fi
 done
 
 # run dotnet app
-print "# Run $full_process_path $args"
-pushd "$output_dir"
+title "Run $full_process_path $_ARGS"
+pushd "$output_dir" > /dev/null
   # run foreground
-  "./$binary_name" $args
-popd
+  "./$binary_name" $_ARGS
+popd > /dev/null

--- a/.github/scripts/benchmark-client-run.sh
+++ b/.github/scripts/benchmark-client-run.sh
@@ -13,6 +13,7 @@ usage: $(basename $0) --run-args <string> [options]
 Required:
   --run-args          string      Arguments to pass when running the built binary (default: \"\")
 Options:
+  --build-args        string      Arguments to pass when building the project (default: \"\")
   --help                          Show this help message
 EOF
 }
@@ -22,6 +23,7 @@ while [ $# -gt 0 ]; do
     # required
     --run-args) _RUN_ARGS=$2; shift 2; ;;
     # optional
+    --build-args) _BUILD_ARGS=$2; shift 2; ;;
     --help) usage; exit 1; ;;
     *) shift ;;
   esac
@@ -41,6 +43,7 @@ function error {
 # parameter setup
 title "Arguments:"
 print "--run-args=${_RUN_ARGS:=""}"
+print "--build-args=${_BUILD_ARGS:=""}"
 
 title "Constants:"
 print "  * repo=${repo:="MagicOnion"}"
@@ -111,8 +114,8 @@ echo "::group::dotnet publish"
     print "List current files under $(pwd)"
     ls -l
 
-    print "dotnet publish $build_csproj"
-    dotnet publish -c "$build_config" -p:PublishSingleFile=true --runtime linux-x64 --self-contained false "$build_csproj" -o "$publish_dir"
+    print "dotnet publish $build_csproj $_BUILD_ARGS"
+    dotnet publish -c "$build_config" -p:PublishSingleFile=true --runtime linux-x64 --self-contained false "$build_csproj" -o "$publish_dir" $_BUILD_ARGS
 
     print "List published files under $publish_dir"
     ls "$publish_dir"

--- a/.github/scripts/benchmark-client-run.sh
+++ b/.github/scripts/benchmark-client-run.sh
@@ -8,11 +8,13 @@ set -euo pipefail
 # $ echo $?
 
 function usage {
-    echo "usage: $(basename $0) --run-args <string> [options]"
-    echo "Required:"
-    echo "  --run-args          string      Arguments to pass when running the built binary (default: \"\")"
-    echo "Options:"
-    echo "  --help                          Show this help message"
+  cat <<EOF
+usage: $(basename $0) --run-args <string> [options]
+Required:
+  --run-args          string      Arguments to pass when running the built binary (default: \"\")
+Options:
+  --help                          Show this help message
+EOF
 }
 
 while [ $# -gt 0 ]; do

--- a/.github/scripts/benchmark-server-run.sh
+++ b/.github/scripts/benchmark-server-run.sh
@@ -8,17 +8,17 @@ set -euo pipefail
 # $ echo $?
 
 function usage {
-    echo "usage: $(basename $0) [options]"
+    echo "usage: $(basename $0) --run-args <string> [options]"
     echo "Required:"
-    echo "  --args          string      Arguments to pass when running the built binary (default: \"\")"
+    echo "  --run-args          string      Arguments to pass when running the built binary (default: \"\")"
     echo "Options:"
-    echo "  --help                      Show this help message"
+    echo "  --help                          Show this help message"
 }
 
 while [ $# -gt 0 ]; do
   case $1 in
     # required
-    --args) _ARGS=$2; shift 2; ;;
+    --run-args) _RUN_ARGS=$2; shift 2; ;;
     # optional
     --help) usage; exit 1; ;;
     *) shift ;;
@@ -37,7 +37,7 @@ function error {
 }
 # parameter setup
 title "Arguments:"
-print "--args=${_ARGS:=""}"
+print "--run-args=${_RUN_ARGS:=""}"
 
 title "Constants:"
 print "  * repo=${repo:="MagicOnion"}"
@@ -122,12 +122,12 @@ echo "::group::dotnet publish"
 echo "::endgroup::"
 
 # run dotnet app
-title "Run $full_process_path $_ARGS"
+title "Run $full_process_path $_RUN_ARGS"
 pushd "$output_dir" > /dev/null
   touch "${stdoutfile}"
   # use nohup to run background https://stackoverflow.com/questions/29142/getting-ssh-to-execute-a-command-in-the-background-on-target-machine
   # shellcheck disable=SC2086
-  nohup "./$binary_name" $_ARGS > "${stdoutfile}" 2> "${stderrfile}" < /dev/null &
+  nohup "./$binary_name" $_RUN_ARGS > "${stdoutfile}" 2> "${stderrfile}" < /dev/null &
 
   # wait 10s will be enough to start the server or not
   sleep 10s

--- a/.github/scripts/benchmark-server-run.sh
+++ b/.github/scripts/benchmark-server-run.sh
@@ -115,6 +115,11 @@ echo "::group::dotnet publish"
     print "List current files under $(pwd)"
     ls -l
 
+    print "Remove all files under $publish_dir"
+    if [[ -d "./$publish_dir" ]]; then
+      rm -rf "./$publish_dir"
+    fi
+
     print "dotnet publish $build_csproj $_BUILD_ARGS"
     dotnet publish -c "$build_config" -p:PublishSingleFile=true --runtime linux-x64 --self-contained false "$build_csproj" -o "$publish_dir" $_BUILD_ARGS
 

--- a/.github/scripts/benchmark-server-run.sh
+++ b/.github/scripts/benchmark-server-run.sh
@@ -13,6 +13,7 @@ usage: $(basename $0) --run-args <string> [options]
 Required:
   --run-args          string      Arguments to pass when running the built binary (default: \"\")
 Options:
+  --build-args        string      Arguments to pass when building the project (default: \"\")
   --help                          Show this help message
 EOF
 }
@@ -22,6 +23,7 @@ while [ $# -gt 0 ]; do
     # required
     --run-args) _RUN_ARGS=$2; shift 2; ;;
     # optional
+    --build-args) _BUILD_ARGS=$2; shift 2; ;;
     --help) usage; exit 1; ;;
     *) shift ;;
   esac
@@ -40,6 +42,7 @@ function error {
 # parameter setup
 title "Arguments:"
 print "--run-args=${_RUN_ARGS:=""}"
+print "--build-args=${_BUILD_ARGS:=""}"
 
 title "Constants:"
 print "  * repo=${repo:="MagicOnion"}"
@@ -112,8 +115,8 @@ echo "::group::dotnet publish"
     print "List current files under $(pwd)"
     ls -l
 
-    print "dotnet publish $build_csproj"
-    dotnet publish -c "$build_config" -p:PublishSingleFile=true --runtime linux-x64 --self-contained false "$build_csproj" -o "$publish_dir"
+    print "dotnet publish $build_csproj $_BUILD_ARGS"
+    dotnet publish -c "$build_config" -p:PublishSingleFile=true --runtime linux-x64 --self-contained false "$build_csproj" -o "$publish_dir" $_BUILD_ARGS
 
     print "List published files under $publish_dir"
     ls "$publish_dir"

--- a/.github/scripts/benchmark-server-run.sh
+++ b/.github/scripts/benchmark-server-run.sh
@@ -61,60 +61,65 @@ title "Show installed dotnet sdk versions"
 print "  * dotnet sdk versions (list): $(dotnet --list-sdks)"
 print "  * dotnet sdk version (default): $(dotnet --version)"
 
-# is already clones?
-title "Check if already cloned $repo"
-if [[ ! -d "$clone_path" ]]; then
-  error "Failed to find $clone_path, not yet git cloned?"
-  exit 1
-fi
-
-# get branch name and set to environment variables
-title "Set branch name as Environment variable"
-pushd "$clone_path" > /dev/null
-  print "Get current git branch name"
-  git_branch=$(git rev-parse --abbrev-ref HEAD)
-  if [ -z "$git_branch" ]; then
-    error "Failed to get branch name, exiting..."
+echo "::group::Is already cloned?"
+  title "Check if already cloned $repo"
+  if [[ ! -d "$clone_path" ]]; then
+    error "Failed to find $clone_path, not yet git cloned?"
     exit 1
   fi
+echo "::endgroup::"
 
-  print "Set branch name to environment variables $git_branch"
-  export BRANCH_NAME="$git_branch"
-popd > /dev/null
+echo "::group::Get branch name and set to environment variables"
+  title "Set branch name as Environment variable"
+  pushd "$clone_path" > /dev/null
+    print "Get current git branch name"
+    git_branch=$(git rev-parse --abbrev-ref HEAD)
+    if [ -z "$git_branch" ]; then
+      error "Failed to get branch name, exiting..."
+      exit 1
+    fi
 
-# setup env
-title "Setup environment"
-IFS=';' read -ra env_array <<< "$env_settings"
-for item in "${env_array[@]}"; do
-  if [ -n "$item" ]; then
-    export "$item"
-  fi
-done
+    print "Set branch name to environment variables $git_branch"
+    export BRANCH_NAME="$git_branch"
+  popd > /dev/null
+echo "::endgroup::"
 
-# process check
-title "Checking process $binary_name already runnning, kill if exists"
-ps -eo pid,cmd | while read -r pid cmd; do
-  if echo "$cmd" | grep -E "^./$binary_name" >/dev/null 2>&1; then
-    print "Found & killing process $pid ($cmd)"
-    kill "$pid"
-  fi
-done
+echo "::group::Setup environment variables"
+  title "Setup environment"
+  IFS=';' read -ra env_array <<< "$env_settings"
+  for item in "${env_array[@]}"; do
+    if [ -n "$item" ]; then
+      export "$item"
+    fi
+  done
+echo "::endgroup::"
 
-# dotnet publish
-title "dotnet publish $build_csproj"
-pushd "$clone_path" > /dev/null
-  print "List current files under $(pwd)"
-  ls -l
+echo "::group::Kill existing process"
+  title "Checking process $binary_name already runnning, kill if exists"
+  ps -eo pid,cmd | while read -r pid cmd; do
+    if echo "$cmd" | grep -E "^./$binary_name" >/dev/null 2>&1; then
+      print "Found & killing process $pid ($cmd)"
+      kill "$pid"
+    fi
+  done
+echo "::endgroup::"
 
-  print "dotnet publish $build_csproj"
-  dotnet publish -c "$build_config" -p:PublishSingleFile=true --runtime linux-x64 --self-contained false "$build_csproj" -o "$publish_dir"
+echo "::group::dotnet publish"
+  title "dotnet publish $build_csproj"
+  pushd "$clone_path" > /dev/null
+    print "List current files under $(pwd)"
+    ls -l
 
-  print "List published files under $publish_dir"
-  ls "$publish_dir"
+    print "dotnet publish $build_csproj"
+    dotnet publish -c "$build_config" -p:PublishSingleFile=true --runtime linux-x64 --self-contained false "$build_csproj" -o "$publish_dir"
 
-  print "Add +x permission to published file $full_process_path"
-  chmod +x "$full_process_path"
-popd > /dev/null
+    print "List published files under $publish_dir"
+    ls "$publish_dir"
+
+    print "Add +x permission to published file $full_process_path"
+    chmod +x "$full_process_path"
+  popd > /dev/null
+echo "::endgroup::"
 
 # run dotnet app
 title "Run $full_process_path $_ARGS"

--- a/.github/scripts/benchmark-server-run.sh
+++ b/.github/scripts/benchmark-server-run.sh
@@ -8,11 +8,13 @@ set -euo pipefail
 # $ echo $?
 
 function usage {
-    echo "usage: $(basename $0) --run-args <string> [options]"
-    echo "Required:"
-    echo "  --run-args          string      Arguments to pass when running the built binary (default: \"\")"
-    echo "Options:"
-    echo "  --help                          Show this help message"
+  cat <<EOF
+usage: $(basename $0) --run-args <string> [options]
+Required:
+  --run-args          string      Arguments to pass when running the built binary (default: \"\")
+Options:
+  --help                          Show this help message
+EOF
 }
 
 while [ $# -gt 0 ]; do

--- a/.github/scripts/benchmark-server-stop.sh
+++ b/.github/scripts/benchmark-server-stop.sh
@@ -8,9 +8,11 @@ set -euo pipefail
 # $ echo $?
 
 function usage {
-    echo "usage: $(basename $0) [options]"
-    echo "Options:"
-    echo "  --help                      Show this help message"
+  cat <<EOF
+usage: $(basename $0) [options]
+Options:
+  --help                      Show this help message
+EOF
 }
 
 while [ $# -gt 0 ]; do

--- a/.github/scripts/benchmark-server-stop.sh
+++ b/.github/scripts/benchmark-server-stop.sh
@@ -21,19 +21,23 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-function print() {
+function print {
+  echo "$(date "+%Y-%m-%d %H:%M:%S") INFO(${FUNCNAME[1]:-unknown}): $*"
+}
+function title {
   echo ""
-  echo "$*"
+  echo "$(date "+%Y-%m-%d %H:%M:%S") INFO(${FUNCNAME[1]:-unknown}): # $*"
 }
 
 # parameter setup
-binary_name="PerformanceTest.Server"
+title "Constants:"
+print "  * binary_name=${binary_name:=PerformanceTest.Server}"
 
 # stop process
-print "# Stopping process $binary_name if exists"
+title "Stopping process $binary_name if exists"
 ps -eo pid,cmd | while read -r pid cmd; do
   if echo "$cmd" | grep -E "^./$binary_name" >/dev/null 2>&1; then
-    echo "Found & killing process $pid ($cmd)"
+    print "Found & killing process $pid ($cmd)"
     kill "$pid"
   fi
 done

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,6 +24,12 @@ on:
           - workflow_dispatch_messagepack_h2
           - workflow_dispatch_messagepack_h2c
           - workflow_dispatch_messagepack_h3
+          - workflow_dispatch_messagepack_h2_nugetclient
+          - workflow_dispatch_messagepack_h2_nugetserver
+          - workflow_dispatch_messagepack_h2c_nugetclient
+          - workflow_dispatch_messagepack_h2c_nugetserver
+          - workflow_dispatch_messagepack_h3_nugetclient
+          - workflow_dispatch_messagepack_h3_nugetserver
           - issue
           - schedule
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,9 @@
     <MicrosoftCodeAnalysisVersion>4.3.1</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisVersionUnity>3.9.0</MicrosoftCodeAnalysisVersionUnity>
     <MulticasterVersion>0.1.12</MulticasterVersion>
+    <!-- for perf -->
+    <ConsoleAppFrameworkVersion>4.2.2</ConsoleAppFrameworkVersion>
+    <JetBrainsProfilerApiVersion>1.4.3</JetBrainsProfilerApiVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
@@ -51,8 +54,8 @@
   </ItemGroup>
   <!-- for samples/perf -->
   <ItemGroup>
-    <PackageVersion Include="ConsoleAppFramework" Version="4.2.2" />
-    <PackageVersion Include="JetBrains.Profiler.Api" Version="1.4.3" />
+    <PackageVersion Include="ConsoleAppFramework" Version="$(ConsoleAppFrameworkVersion)" />
+    <PackageVersion Include="JetBrains.Profiler.Api" Version="$(JetBrainsProfilerApiVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/perf/BenchmarkApp/PerformanceTest.Client/PerformanceTest.Client.csproj
+++ b/perf/BenchmarkApp/PerformanceTest.Client/PerformanceTest.Client.csproj
@@ -12,7 +12,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Condition="'$(UseNuGetClient)' != ''">
-    <PackageReference Include="ConsoleAppFramework" Version="$(ConsoleAppFrameworkVersion)"/>
+    <PackageReference Include="ConsoleAppFramework" Version="$(ConsoleAppFrameworkVersion)" />
     <PackageReference Include="MagicOnion.Client" Version="$(UseNuGetClient)" />
     <PackageReference Include="MagicOnion.Serialization.MemoryPack" Version="$(UseNuGetClient)-preview" />
   </ItemGroup>
@@ -23,6 +23,12 @@
   <ItemGroup Condition="'$(UseNuGetClient)' == ''">
     <ProjectReference Include="..\..\..\src\MagicOnion.Client\MagicOnion.Client.csproj" />
     <ProjectReference Include="..\..\..\src\MagicOnion.Serialization.MemoryPack\MagicOnion.Serialization.MemoryPack.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="PerformanceTest.Shared.MagicOnionIsLatestAttirbute">
+      <_Parameter1>$(UseNuGetClient)</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/perf/BenchmarkApp/PerformanceTest.Client/PerformanceTest.Client.csproj
+++ b/perf/BenchmarkApp/PerformanceTest.Client/PerformanceTest.Client.csproj
@@ -8,16 +8,21 @@
     <DefineConstants>CLIENT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="ConsoleAppFramework" />
-  </ItemGroup>
-
+  <PropertyGroup Condition="'$(UseNuGetClient)' != ''">
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
   <ItemGroup Condition="'$(UseNuGetClient)' != ''">
+    <PackageReference Include="ConsoleAppFramework" Version="$(ConsoleAppFrameworkVersion)"/>
     <PackageReference Include="MagicOnion.Client" Version="$(UseNuGetClient)" />
+    <PackageReference Include="MagicOnion.Serialization.MemoryPack" Version="$(UseNuGetClient)-preview" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseNuGetClient)' == ''">
+    <PackageReference Include="ConsoleAppFramework" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNuGetClient)' == ''">
     <ProjectReference Include="..\..\..\src\MagicOnion.Client\MagicOnion.Client.csproj" />
+    <ProjectReference Include="..\..\..\src\MagicOnion.Serialization.MemoryPack\MagicOnion.Serialization.MemoryPack.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,10 +30,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Compile Include="..\PerformanceTest.Shared\**\*.cs" Exclude="**\obj\**;**\bin\**" LinkBase="Shared" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\MagicOnion.Serialization.MemoryPack\MagicOnion.Serialization.MemoryPack.csproj" />
   </ItemGroup>
 
 </Project>

--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -273,6 +273,7 @@ void PrintStartupInformation(TextWriter? writer = null)
 {
     writer ??= Console.Out;
 
+    writer.WriteLine($"Benchmarker {ApplicationInformation.Current.BenchmarkerVersion}");
     writer.WriteLine($"MagicOnion {ApplicationInformation.Current.MagicOnionVersion}");
     writer.WriteLine($"grpc-dotnet {ApplicationInformation.Current.GrpcNetVersion}");
     writer.WriteLine($"MessagePack {ApplicationInformation.Current.MessagePackVersion}");

--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -73,6 +73,7 @@ async Task Main(
     WriteLog("Gathering the server information...");
     {
         serverInfo = await controlServiceClient.GetServerInformationAsync();
+        WriteLog($"Benchmarker {serverInfo.BenchmarkerVersion}");
         WriteLog($"MagicOnion {serverInfo.MagicOnionVersion}");
         WriteLog($"grpc-dotnet {serverInfo.GrpcNetVersion}");
         WriteLog($"{nameof(ApplicationInformation.OSDescription)}: {serverInfo.OSDescription}");
@@ -112,6 +113,7 @@ async Task Main(
         PrintStartupInformation(writer);
         writer.WriteLine($"========================================");
         writer.WriteLine($"Server Information:");
+        writer.WriteLine($"Benchmarker {serverInfo.BenchmarkerVersion}");
         writer.WriteLine($"MagicOnion {serverInfo.MagicOnionVersion}");
         writer.WriteLine($"grpc-dotnet {serverInfo.GrpcNetVersion}");
         writer.WriteLine($"MessagePack {serverInfo.MessagePackVersion}");

--- a/perf/BenchmarkApp/PerformanceTest.Server/PerfTestControlService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerfTestControlService.cs
@@ -11,6 +11,7 @@ public class PerfTestControlService : ServiceBase<IPerfTestControlService>, IPer
     {
         return UnaryResult.FromResult(new ServerInformation(
             Environment.MachineName,
+            ApplicationInformation.Current.BenchmarkerVersion,
             ApplicationInformation.Current.MagicOnionVersion,
             ApplicationInformation.Current.GrpcNetVersion,
             ApplicationInformation.Current.MessagePackVersion,

--- a/perf/BenchmarkApp/PerformanceTest.Server/PerfTestControlService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerfTestControlService.cs
@@ -2,6 +2,7 @@ using JetBrains.Profiler.Api;
 using MagicOnion;
 using MagicOnion.Server;
 using PerformanceTest.Shared;
+using PerformanceTest.Shared.Reporting;
 
 namespace PerformanceTest.Server;
 
@@ -25,6 +26,15 @@ public class PerfTestControlService : ServiceBase<IPerfTestControlService>, IPer
             ApplicationInformation.Current.IsServerGC,
             ApplicationInformation.Current.ProcessorCount,
             ApplicationInformation.Current.IsAttached));
+    }
+
+    public UnaryResult<string> ExchangeMagicOnionVersionTagAsync(string? clientMagicOnionVersion)
+    {
+        var versionTag = $"{clientMagicOnionVersion}x{ApplicationInformation.Current.TagMagicOnionVersion}";
+
+        // keep in server
+        DatadogMetricsRecorder.MagicOnionVersions = versionTag;
+        return UnaryResult.FromResult(versionTag);
     }
 
     public UnaryResult SetMemoryProfilerCollectAllocationsAsync(bool enable)

--- a/perf/BenchmarkApp/PerformanceTest.Server/PerfTestControlService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerfTestControlService.cs
@@ -13,6 +13,7 @@ public class PerfTestControlService : ServiceBase<IPerfTestControlService>, IPer
         return UnaryResult.FromResult(new ServerInformation(
             Environment.MachineName,
             ApplicationInformation.Current.BenchmarkerVersion,
+            ApplicationInformation.Current.IsLatestMagicOnion,
             ApplicationInformation.Current.MagicOnionVersion,
             ApplicationInformation.Current.GrpcNetVersion,
             ApplicationInformation.Current.MessagePackVersion,
@@ -28,13 +29,16 @@ public class PerfTestControlService : ServiceBase<IPerfTestControlService>, IPer
             ApplicationInformation.Current.IsAttached));
     }
 
-    public UnaryResult<string> ExchangeMagicOnionVersionTagAsync(string? clientMagicOnionVersion)
+    public UnaryResult<(string serverMagicOnionVersion, bool enableLatestTag)> ExchangeMagicOnionVersionTagAsync(string? clientMagicOnionVersion, bool isLatestMagicOnionVersion)
     {
         var versionTag = $"{clientMagicOnionVersion}x{ApplicationInformation.Current.TagMagicOnionVersion}";
+        // Both Server and Client is latest
+        var isLatestTagEnabled = ApplicationInformation.Current.IsLatestMagicOnion && isLatestMagicOnionVersion;
 
         // keep in server
         DatadogMetricsRecorder.MagicOnionVersions = versionTag;
-        return UnaryResult.FromResult(versionTag);
+        DatadogMetricsRecorder.EnableLatestTag = isLatestTagEnabled;
+        return UnaryResult.FromResult((versionTag, isLatestTagEnabled));
     }
 
     public UnaryResult SetMemoryProfilerCollectAllocationsAsync(bool enable)

--- a/perf/BenchmarkApp/PerformanceTest.Server/PerfTestService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerfTestService.cs
@@ -12,6 +12,7 @@ public class PerfTestService : ServiceBase<IPerfTestService>, IPerfTestService
         return UnaryResult.FromResult(new ServerInformation(
             Environment.MachineName,
             ApplicationInformation.Current.BenchmarkerVersion,
+            ApplicationInformation.Current.IsLatestMagicOnion,
             ApplicationInformation.Current.MagicOnionVersion,
             ApplicationInformation.Current.GrpcNetVersion,
             ApplicationInformation.Current.MessagePackVersion,

--- a/perf/BenchmarkApp/PerformanceTest.Server/PerfTestService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerfTestService.cs
@@ -11,6 +11,7 @@ public class PerfTestService : ServiceBase<IPerfTestService>, IPerfTestService
     {
         return UnaryResult.FromResult(new ServerInformation(
             Environment.MachineName,
+            ApplicationInformation.Current.BenchmarkerVersion,
             ApplicationInformation.Current.MagicOnionVersion,
             ApplicationInformation.Current.GrpcNetVersion,
             ApplicationInformation.Current.MessagePackVersion,

--- a/perf/BenchmarkApp/PerformanceTest.Server/PerformanceTest.Server.csproj
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerformanceTest.Server.csproj
@@ -28,6 +28,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="PerformanceTest.Shared.MagicOnionIsLatestAttirbute">
+      <_Parameter1>$(UseNuGetServer)</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\PerformanceTest.Shared\Certs\*.*" LinkBase="Certs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/perf/BenchmarkApp/PerformanceTest.Server/PerformanceTest.Server.csproj
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerformanceTest.Server.csproj
@@ -7,9 +7,24 @@
     <DefineConstants>SERVER;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
+  <PropertyGroup Condition="'$(UseNuGetServer)' != ''">
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(UseNuGetServer)' != ''">
+    <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcVersion)"/>
+    <PackageReference Include="JetBrains.Profiler.Api" Version="$(JetBrainsProfilerApiVersion)"/>
+    <PackageReference Include="MagicOnion.Serialization.MemoryPack" Version="$(UseNuGetServer)-preview" />
+    <PackageReference Include="MagicOnion.Server" Version="$(UseNuGetServer)" />
+    <PackageReference Include="Multicaster" Version="$(MulticasterVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseNuGetServer)' == ''">
     <PackageReference Include="Grpc.AspNetCore" />
     <PackageReference Include="JetBrains.Profiler.Api" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNuGetServer)' == ''">
+    <ProjectReference Include="..\..\..\src\MagicOnion.Serialization.MemoryPack\MagicOnion.Serialization.MemoryPack.csproj" />
+    <ProjectReference Include="..\..\..\src\MagicOnion.Server\MagicOnion.Server.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -17,11 +32,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Compile Include="..\PerformanceTest.Shared\**\*.cs" Exclude="**\obj\**;**\bin\**" LinkBase="Shared" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\MagicOnion.Serialization.MemoryPack\MagicOnion.Serialization.MemoryPack.csproj" />
-    <ProjectReference Include="..\..\..\src\MagicOnion.Server\MagicOnion.Server.csproj" />
   </ItemGroup>
 
 </Project>

--- a/perf/BenchmarkApp/PerformanceTest.Server/ProfileService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/ProfileService.cs
@@ -41,14 +41,15 @@ static class DatadogMetricsRecorderExtensions
     /// <param name="result"></param>
     public static async Task PutServerBenchmarkMetricsAsync(this DatadogMetricsRecorder recorder, ApplicationInformation applicationInfo, HardwarePerformanceResult result)
     {
-        var tags = MetricsTagCache.Get((recorder.TagBranch, recorder.TagLegend, recorder.TagStreams, recorder.TagProtocol, recorder.TagSerialization, applicationInfo), static x => [
+        var tags = MetricsTagCache.Get((recorder.TagBranch, recorder.TagLegend, recorder.TagStreams, recorder.TagProtocol, recorder.TagSerialization, recorder.TagMagicOnion, applicationInfo), static x => [
             $"legend:{x.TagLegend}{x.TagStreams}",
             $"branch:{x.TagBranch}",
-            $"streams:{x.TagStreams}",
+            $"magiconion:{x.TagMagicOnion}",
             $"protocol:{x.TagProtocol}",
             $"process_arch:{x.applicationInfo.ProcessArchitecture}",
             $"process_count:{x.applicationInfo.ProcessorCount}",
             $"serialization:{x.TagSerialization}",
+            $"streams:{x.TagStreams}",
         ]);
 
         // Don't want to await each put. Let's send it to queue and await when benchmark ends.

--- a/perf/BenchmarkApp/PerformanceTest.Server/ProfileService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/ProfileService.cs
@@ -41,24 +41,37 @@ static class DatadogMetricsRecorderExtensions
     /// <param name="result"></param>
     public static async Task PutServerBenchmarkMetricsAsync(this DatadogMetricsRecorder recorder, ApplicationInformation applicationInfo, HardwarePerformanceResult result)
     {
-        var tags = MetricsTagCache.Get((recorder.TagBranch, recorder.TagLegend, recorder.TagStreams, recorder.TagProtocol, recorder.TagSerialization, recorder.TagMagicOnion, applicationInfo), static x => [
-            $"legend:{x.TagLegend}{x.TagStreams}",
-            $"branch:{x.TagBranch}",
-            $"magiconion:{x.TagMagicOnion}",
-            $"protocol:{x.TagProtocol}",
-            $"process_arch:{x.applicationInfo.ProcessArchitecture}",
-            $"process_count:{x.applicationInfo.ProcessorCount}",
-            $"serialization:{x.TagSerialization}",
-            $"streams:{x.TagStreams}",
-        ]);
+        if (string.IsNullOrEmpty(recorder.TagMagicOnion))
+            return;
 
-        // Don't want to await each put. Let's send it to queue and await when benchmark ends.
-        recorder.Record(recorder.SendAsync("benchmark.magiconion.server.cpu_usage_max", result.MaxCpuUsagePercent, DatadogMetricsType.Gauge, tags, "percent"));
-        recorder.Record(recorder.SendAsync("benchmark.magiconion.server.cpu_usage_avg", result.AvgCpuUsagePercent, DatadogMetricsType.Gauge, tags, "percent"));
-        recorder.Record(recorder.SendAsync("benchmark.magiconion.server.memory_usage_max", result.MaxMemoryUsageMB, DatadogMetricsType.Gauge, tags, "megabyte"));
-        recorder.Record(recorder.SendAsync("benchmark.magiconion.server.memory_usage_avg", result.AvgMemoryUsageMB, DatadogMetricsType.Gauge, tags, "megabyte"));
+        Post(recorder, applicationInfo, result, false);
+        if (DatadogMetricsRecorder.EnableLatestTag)
+        {
+            Post(recorder, applicationInfo, result, true);
+        }
 
         // wait until send complete
         await recorder.WaitSaveAsync();
+
+        static void Post(DatadogMetricsRecorder recorder, ApplicationInformation applicationInfo, HardwarePerformanceResult result, bool isMagicOnionLatest)
+        {
+            var magicOnionTag = isMagicOnionLatest ? recorder.TagLatestMagicOnion : recorder.TagMagicOnion;
+            var tags = MetricsTagCache.Get((recorder.TagBranch, recorder.TagLegend, recorder.TagStreams, recorder.TagProtocol, recorder.TagSerialization, magicOnionTag, applicationInfo), static x => [
+                $"legend:{x.TagLegend}{x.TagStreams}",
+                $"branch:{x.TagBranch}",
+                $"magiconion:{x.magicOnionTag}",
+                $"protocol:{x.TagProtocol}",
+                $"process_arch:{x.applicationInfo.ProcessArchitecture}",
+                $"process_count:{x.applicationInfo.ProcessorCount}",
+                $"serialization:{x.TagSerialization}",
+                $"streams:{x.TagStreams}",
+            ]);
+
+            // Don't want to await each put. Let's send it to queue and await when benchmark ends.
+            recorder.Record(recorder.SendAsync("benchmark.magiconion.server.cpu_usage_max", result.MaxCpuUsagePercent, DatadogMetricsType.Gauge, tags, "percent"));
+            recorder.Record(recorder.SendAsync("benchmark.magiconion.server.cpu_usage_avg", result.AvgCpuUsagePercent, DatadogMetricsType.Gauge, tags, "percent"));
+            recorder.Record(recorder.SendAsync("benchmark.magiconion.server.memory_usage_max", result.MaxMemoryUsageMB, DatadogMetricsType.Gauge, tags, "megabyte"));
+            recorder.Record(recorder.SendAsync("benchmark.magiconion.server.memory_usage_avg", result.AvgMemoryUsageMB, DatadogMetricsType.Gauge, tags, "megabyte"));
+        }
     }
 }

--- a/perf/BenchmarkApp/PerformanceTest.Server/StartupService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/StartupService.cs
@@ -20,6 +20,7 @@ class StartupService : IHostedService
 
     private void PrintStartupInformation()
     {
+        Console.WriteLine($"Benchmarker {ApplicationInformation.Current.BenchmarkerVersion}");
         Console.WriteLine($"MagicOnion {ApplicationInformation.Current.MagicOnionVersion}");
         Console.WriteLine($"grpc-dotnet {ApplicationInformation.Current.GrpcNetVersion}");
         Console.WriteLine($"MessagePack {ApplicationInformation.Current.MessagePackVersion}");

--- a/perf/BenchmarkApp/PerformanceTest.Server/StartupService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/StartupService.cs
@@ -25,6 +25,7 @@ class StartupService : IHostedService
         Console.WriteLine($"grpc-dotnet {ApplicationInformation.Current.GrpcNetVersion}");
         Console.WriteLine($"MessagePack {ApplicationInformation.Current.MessagePackVersion}");
         Console.WriteLine($"MemoryPack {ApplicationInformation.Current.MemoryPackVersion}");
+        Console.WriteLine($"IsLatestMagicOnion {ApplicationInformation.Current.IsLatestMagicOnion}");
         Console.WriteLine();
 
         Console.WriteLine($"Listening on:");

--- a/perf/BenchmarkApp/PerformanceTest.Shared/ApplicationInformation.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/ApplicationInformation.cs
@@ -9,6 +9,8 @@ public class ApplicationInformation
 {
     public static ApplicationInformation Current { get; } = new ApplicationInformation();
 
+    public bool IsLatestMagicOnion { get; } = typeof(ApplicationInformation).Assembly.GetCustomAttribute<MagicOnionIsLatestAttirbute>()?.IsLatest ?? true; // set from csproj
+
     public string? BenchmarkerVersion { get; } = typeof(ApplicationInformation).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
 #if SERVER

--- a/perf/BenchmarkApp/PerformanceTest.Shared/ApplicationInformation.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/ApplicationInformation.cs
@@ -9,13 +9,19 @@ public class ApplicationInformation
 {
     public static ApplicationInformation Current { get; } = new ApplicationInformation();
 
+    public string? TagBenchmarkerVersion { get; } = RemoveHashFromVersion(typeof(ApplicationInformation).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
+    public string? BenchmarkerVersion { get; } = typeof(ApplicationInformation).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
 #if SERVER
+    public string? TagMagicOnionVersion { get; } = RemoveHashFromVersion(typeof(MagicOnion.Server.MagicOnionEngine).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
     public string? MagicOnionVersion { get; } = typeof(MagicOnion.Server.MagicOnionEngine).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
     public string? GrpcNetVersion { get; } = typeof(Grpc.AspNetCore.Server.GrpcServiceOptions).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 #elif CLIENT
+    public string? TagMagicOnionVersion { get; } = RemoveHashFromVersion(typeof(MagicOnion.Client.MagicOnionClient).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
     public string? MagicOnionVersion { get; } = typeof(MagicOnion.Client.MagicOnionClient).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
     public string? GrpcNetVersion { get; } = typeof(Grpc.Net.Client.GrpcChannel).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 #else
+    public string? TagMagicOnionVersion { get; } = RemoveHashFromVersion(typeof(MagicOnion.UnaryResult).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
     public string? MagicOnionVersion { get; } = typeof(MagicOnion.UnaryResult).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
     public string? GrpcNetVersion { get; } = default;
 #endif
@@ -37,6 +43,21 @@ public class ApplicationInformation
     public bool IsServerGC { get; } = GCSettings.IsServerGC;
     public int ProcessorCount { get; } = Environment.ProcessorCount;
     public bool IsAttached { get; } = Debugger.IsAttached;
+
+    /// <summary>
+    /// Reduct `+HASH` suffix from InformationalVersion.
+    /// <br/> Example1: 1.0.0+1234567890abcdefg -> 1.0.0
+    /// <br/> Example2: 1.0.0 -> 1.0.0
+    /// </summary>
+    /// <param name="version"></param>
+    /// <returns></returns>
+    private static string? RemoveHashFromVersion(string? version)
+    {
+        if (string.IsNullOrEmpty(version)) return version;
+        var span = version.AsSpan();
+        var position = span.IndexOf('+');
+        return position == -1 ? version : span[..position].ToString();
+    }
 
     public class CpuInformation
     {

--- a/perf/BenchmarkApp/PerformanceTest.Shared/ApplicationInformation.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/ApplicationInformation.cs
@@ -9,7 +9,6 @@ public class ApplicationInformation
 {
     public static ApplicationInformation Current { get; } = new ApplicationInformation();
 
-    public string? TagBenchmarkerVersion { get; } = RemoveHashFromVersion(typeof(ApplicationInformation).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
     public string? BenchmarkerVersion { get; } = typeof(ApplicationInformation).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
 #if SERVER

--- a/perf/BenchmarkApp/PerformanceTest.Shared/IPerfTestControlService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/IPerfTestControlService.cs
@@ -8,6 +8,7 @@ namespace PerformanceTest.Shared;
 public interface IPerfTestControlService : IService<IPerfTestControlService>
 {
     UnaryResult<ServerInformation> GetServerInformationAsync();
+    UnaryResult<string> ExchangeMagicOnionVersionTagAsync(string? clientMagicOnionVersion);
 
     UnaryResult SetMemoryProfilerCollectAllocationsAsync(bool enable);
     UnaryResult CreateMemoryProfilerSnapshotAsync(string name);

--- a/perf/BenchmarkApp/PerformanceTest.Shared/IPerfTestControlService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/IPerfTestControlService.cs
@@ -8,7 +8,7 @@ namespace PerformanceTest.Shared;
 public interface IPerfTestControlService : IService<IPerfTestControlService>
 {
     UnaryResult<ServerInformation> GetServerInformationAsync();
-    UnaryResult<string> ExchangeMagicOnionVersionTagAsync(string? clientMagicOnionVersion);
+    UnaryResult<(string serverMagicOnionVersion, bool enableLatestTag)> ExchangeMagicOnionVersionTagAsync(string? clientMagicOnionVersion, bool isLatestMagicOnionVersion);
 
     UnaryResult SetMemoryProfilerCollectAllocationsAsync(bool enable);
     UnaryResult CreateMemoryProfilerSnapshotAsync(string name);
@@ -20,6 +20,7 @@ public partial class ServerInformation
 {
     public string MachineName { get; set; }
     public string? BenchmarkerVersion { get; set; }
+    public bool? IsLatestMagicOnion { get; }
     public string? MagicOnionVersion { get; }
     public string? GrpcNetVersion { get; }
     public string? MessagePackVersion { get; }
@@ -34,10 +35,11 @@ public partial class ServerInformation
     public int ProcessorCount { get; }
     public bool IsAttached { get; }
 
-    public ServerInformation(string machineName, string? benchmarkerVersion, string? magicOnionVersion, string? grpcNetVersion, string? messagePackVersion, string? memoryPackVersion, bool isReleaseBuild, string frameworkDescription, string osDescription, Architecture osArchitecture, Architecture processArchitecture, string cpuModelName, bool isServerGC, int processorCount, bool isAttached)
+    public ServerInformation(string machineName, string? benchmarkerVersion, bool? isLatestMagicOnion, string? magicOnionVersion, string? grpcNetVersion, string? messagePackVersion, string? memoryPackVersion, bool isReleaseBuild, string frameworkDescription, string osDescription, Architecture osArchitecture, Architecture processArchitecture, string cpuModelName, bool isServerGC, int processorCount, bool isAttached)
     {
         MachineName = machineName;
         BenchmarkerVersion = benchmarkerVersion;
+        IsLatestMagicOnion = isLatestMagicOnion;
         MagicOnionVersion = magicOnionVersion;
         GrpcNetVersion = grpcNetVersion;
         MessagePackVersion = messagePackVersion;

--- a/perf/BenchmarkApp/PerformanceTest.Shared/IPerfTestControlService.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/IPerfTestControlService.cs
@@ -18,6 +18,7 @@ public interface IPerfTestControlService : IService<IPerfTestControlService>
 public partial class ServerInformation
 {
     public string MachineName { get; set; }
+    public string? BenchmarkerVersion { get; set; }
     public string? MagicOnionVersion { get; }
     public string? GrpcNetVersion { get; }
     public string? MessagePackVersion { get; }
@@ -32,9 +33,10 @@ public partial class ServerInformation
     public int ProcessorCount { get; }
     public bool IsAttached { get; }
 
-    public ServerInformation(string machineName, string? magicOnionVersion, string? grpcNetVersion, string? messagePackVersion, string? memoryPackVersion, bool isReleaseBuild, string frameworkDescription, string osDescription, Architecture osArchitecture, Architecture processArchitecture, string cpuModelName, bool isServerGC, int processorCount, bool isAttached)
+    public ServerInformation(string machineName, string? benchmarkerVersion, string? magicOnionVersion, string? grpcNetVersion, string? messagePackVersion, string? memoryPackVersion, bool isReleaseBuild, string frameworkDescription, string osDescription, Architecture osArchitecture, Architecture processArchitecture, string cpuModelName, bool isServerGC, int processorCount, bool isAttached)
     {
         MachineName = machineName;
+        BenchmarkerVersion = benchmarkerVersion;
         MagicOnionVersion = magicOnionVersion;
         GrpcNetVersion = grpcNetVersion;
         MessagePackVersion = messagePackVersion;

--- a/perf/BenchmarkApp/PerformanceTest.Shared/MagicOnionIsLatestAttirbute.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/MagicOnionIsLatestAttirbute.cs
@@ -1,0 +1,6 @@
+namespace PerformanceTest.Shared;
+
+public class MagicOnionIsLatestAttirbute(string isLatest) : Attribute
+{
+    public bool IsLatest { get; } = string.IsNullOrWhiteSpace(isLatest);
+}

--- a/perf/BenchmarkApp/PerformanceTest.Shared/Reporting/DatadogMetricsRecorder.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/Reporting/DatadogMetricsRecorder.cs
@@ -9,6 +9,7 @@ public class DatadogMetricsRecorder
 {
     // format should be `CLIENTxSERVER` Versions.
     public static string MagicOnionVersions = "";
+    public static bool EnableLatestTag = false;
 
     public string TagBranch { get; }
     public string TagLegend { get; }
@@ -16,6 +17,8 @@ public class DatadogMetricsRecorder
     public string TagProtocol { get; }
     public string TagSerialization { get; }
     public string TagMagicOnion => MagicOnionVersions;
+    public string TagLatestMagicOnion { get; } = "latestxlatest";
+
     private readonly JsonSerializerOptions jsonSerializerOptions;
     private readonly TimeProvider timeProvider;
     private readonly HttpClient client;

--- a/perf/BenchmarkApp/PerformanceTest.Shared/Reporting/DatadogMetricsRecorder.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/Reporting/DatadogMetricsRecorder.cs
@@ -7,11 +7,15 @@ namespace PerformanceTest.Shared.Reporting;
 
 public class DatadogMetricsRecorder
 {
+    // format should be `CLIENTxSERVER` Versions.
+    public static string MagicOnionVersions = "";
+
     public string TagBranch { get; }
     public string TagLegend { get; }
     public string TagStreams { get; }
     public string TagProtocol { get; }
     public string TagSerialization { get; }
+    public string TagMagicOnion => MagicOnionVersions;
     private readonly JsonSerializerOptions jsonSerializerOptions;
     private readonly TimeProvider timeProvider;
     private readonly HttpClient client;

--- a/perf/BenchmarkApp/configs/issue.yaml
+++ b/perf/BenchmarkApp/configs/issue.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/issue.yaml
+++ b/perf/BenchmarkApp/configs/issue.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsClient }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/schedule.yaml
+++ b/perf/BenchmarkApp/configs/schedule.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ build-args }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsClient }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ build-args }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   ##### MessagePack #####
@@ -168,3 +168,67 @@ jobs:
     channels: 28
     streams: 70
     serialization: memorypack
+  ##### Fixed ClientVersion #####
+  # h2c
+  - tags: legend:messagepack-h2c-linux,streams:1x1,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 1
+    streams: 1
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:1x28,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 28
+    streams: 1
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:28x1,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 1
+    streams: 28
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:70x1,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 1
+    streams: 70
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:70x28,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 28
+    streams: 70
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  ##### Fixed ServerVersion #####
+  # h2c
+  - tags: legend:messagepack-h2c-linux,streams:1x1,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 1
+    streams: 1
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:1x28,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 28
+    streams: 1
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:28x1,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 1
+    streams: 28
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:70x1,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 1
+    streams: 70
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:70x28,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 28
+    streams: 70
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4

--- a/perf/BenchmarkApp/configs/schedule.yaml
+++ b/perf/BenchmarkApp/configs/schedule.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   ##### MessagePack #####

--- a/perf/BenchmarkApp/configs/schedule.yaml
+++ b/perf/BenchmarkApp/configs/schedule.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ build-args }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ build-args }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   ##### MessagePack #####

--- a/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsClient }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2c.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2c.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2c.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h2c.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsClient }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h3.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_h3.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_nugetclient.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_nugetclient.yaml
@@ -1,6 +1,6 @@
 # template: https://github.com/Cysharp/Actions/tree/main/.github/scripts/_template_benchmark_config.yaml
 # config2args script: https://github.com/Cysharp/Actions/tree/main/.github/scripts/benchmark_config2args.sh
-apt-tools: "libmsquic"
+apt-tools: ""
 dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
@@ -11,23 +11,27 @@ benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c
-  - tags: legend:memorypack-h3-linux,streams:1x1,protocol:h3,serialization:memorypack
-    protocol: h3
+  - tags: legend:memorypack-h2c-linux,streams:1x1,protocol:h2c,serialization:memorypack
+    protocol: h2c
     channels: 1
     streams: 1
     serialization: memorypack
-  - tags: legend:memorypack-h3-linux,streams:1x28,protocol:h3,serialization:memorypack
-    protocol: h3
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:memorypack-h2c-linux,streams:1x28,protocol:h2c,serialization:memorypack
+    protocol: h2c
     channels: 28
     streams: 1
     serialization: memorypack
-  - tags: legend:memorypack-h3-linux,streams:70x1,protocol:h3,serialization:memorypack
-    protocol: h3
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:memorypack-h2c-linux,streams:70x1,protocol:h2c,serialization:memorypack
+    protocol: h2c
     channels: 1
     streams: 70
     serialization: memorypack
-  - tags: legend:memorypack-h3-linux,streams:70x28,protocol:h3,serialization:memorypack
-    protocol: h3
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:memorypack-h2c-linux,streams:70x28,protocol:h2c,serialization:memorypack
+    protocol: h2c
     channels: 28
     streams: 70
     serialization: memorypack
+    buildArgsClient: --p:UseNuGetClient=6.1.4

--- a/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_nugetserver.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_memorypack_nugetserver.yaml
@@ -1,6 +1,6 @@
 # template: https://github.com/Cysharp/Actions/tree/main/.github/scripts/_template_benchmark_config.yaml
 # config2args script: https://github.com/Cysharp/Actions/tree/main/.github/scripts/benchmark_config2args.sh
-apt-tools: "libmsquic"
+apt-tools: ""
 dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
@@ -11,23 +11,27 @@ benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c
-  - tags: legend:memorypack-h3-linux,streams:1x1,protocol:h3,serialization:memorypack
-    protocol: h3
+  - tags: legend:memorypack-h2c-linux,streams:1x1,protocol:h2c,serialization:memorypack
+    protocol: h2c
     channels: 1
     streams: 1
     serialization: memorypack
-  - tags: legend:memorypack-h3-linux,streams:1x28,protocol:h3,serialization:memorypack
-    protocol: h3
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:memorypack-h2c-linux,streams:1x28,protocol:h2c,serialization:memorypack
+    protocol: h2c
     channels: 28
     streams: 1
     serialization: memorypack
-  - tags: legend:memorypack-h3-linux,streams:70x1,protocol:h3,serialization:memorypack
-    protocol: h3
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:memorypack-h2c-linux,streams:70x1,protocol:h2c,serialization:memorypack
+    protocol: h2c
     channels: 1
     streams: 70
     serialization: memorypack
-  - tags: legend:memorypack-h3-linux,streams:70x28,protocol:h3,serialization:memorypack
-    protocol: h3
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:memorypack-h2c-linux,streams:70x28,protocol:h2c,serialization:memorypack
+    protocol: h2c
     channels: 28
     streams: 70
     serialization: memorypack
+    buildArgsServer: --p:UseNuGetServer=6.1.4

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsClient }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2_nugetclient.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2_nugetclient.yaml
@@ -10,28 +10,28 @@ benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
 benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
-  # h2c
-  - tags: legend:memorypack-h2c-linux,streams:1x1,protocol:h2c,serialization:memorypack
-    protocol: h2c
+  # h2
+  - tags: legend:messagepack-h2-linux,streams:1x1,protocol:h2,serialization:messagepack
+    protocol: h2
     channels: 1
     streams: 1
-    serialization: memorypack
-    buildArgsServer: --p:UseNuGetServer=6.1.4
-  - tags: legend:memorypack-h2c-linux,streams:1x28,protocol:h2c,serialization:memorypack
-    protocol: h2c
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h2-linux,streams:1x28,protocol:h2,serialization:messagepack
+    protocol: h2
     channels: 28
     streams: 1
-    serialization: memorypack
-    buildArgsServer: --p:UseNuGetServer=6.1.4
-  - tags: legend:memorypack-h2c-linux,streams:70x1,protocol:h2c,serialization:memorypack
-    protocol: h2c
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h2-linux,streams:70x1,protocol:h2,serialization:messagepack
+    protocol: h2
     channels: 1
     streams: 70
-    serialization: memorypack
-    buildArgsServer: --p:UseNuGetServer=6.1.4
-  - tags: legend:memorypack-h2c-linux,streams:70x28,protocol:h2c,serialization:memorypack
-    protocol: h2c
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h2-linux,streams:70x28,protocol:h2,serialization:messagepack
+    protocol: h2
     channels: 28
     streams: 70
-    serialization: memorypack
-    buildArgsServer: --p:UseNuGetServer=6.1.4
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2_nugetserver.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2_nugetserver.yaml
@@ -1,0 +1,37 @@
+# template: https://github.com/Cysharp/Actions/tree/main/.github/scripts/_template_benchmark_config.yaml
+# config2args script: https://github.com/Cysharp/Actions/tree/main/.github/scripts/benchmark_config2args.sh
+apt-tools: ""
+dotnet-version: 8.0
+benchmark-expire-min: 15
+benchmark-timeout-min: 10
+benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsClient }}"'
+benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
+benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
+jobs:
+  # h2
+  - tags: legend:messagepack-h2-linux,streams:1x1,protocol:h2,serialization:messagepack
+    protocol: h2
+    channels: 1
+    streams: 1
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h2-linux,streams:1x28,protocol:h2,serialization:messagepack
+    protocol: h2
+    channels: 28
+    streams: 1
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h2-linux,streams:70x1,protocol:h2,serialization:messagepack
+    protocol: h2
+    channels: 1
+    streams: 70
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h2-linux,streams:70x28,protocol:h2,serialization:messagepack
+    protocol: h2
+    channels: 28
+    streams: 70
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2c.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2c.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2c.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2c.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsClient }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2c_nugetclient.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2c_nugetclient.yaml
@@ -1,0 +1,37 @@
+# template: https://github.com/Cysharp/Actions/tree/main/.github/scripts/_template_benchmark_config.yaml
+# config2args script: https://github.com/Cysharp/Actions/tree/main/.github/scripts/benchmark_config2args.sh
+apt-tools: ""
+dotnet-version: 8.0
+benchmark-expire-min: 15
+benchmark-timeout-min: 10
+benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsClient }}"'
+benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
+benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
+jobs:
+  # h2c
+  - tags: legend:messagepack-h2c-linux,streams:1x1,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 1
+    streams: 1
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:1x28,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 28
+    streams: 1
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:70x1,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 1
+    streams: 70
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:70x28,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 28
+    streams: 70
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2c_nugetserver.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h2c_nugetserver.yaml
@@ -1,0 +1,37 @@
+# template: https://github.com/Cysharp/Actions/tree/main/.github/scripts/_template_benchmark_config.yaml
+# config2args script: https://github.com/Cysharp/Actions/tree/main/.github/scripts/benchmark_config2args.sh
+apt-tools: ""
+dotnet-version: 8.0
+benchmark-expire-min: 15
+benchmark-timeout-min: 10
+benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsClient }}"'
+benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
+benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
+jobs:
+  # h2c
+  - tags: legend:messagepack-h2c-linux,streams:1x1,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 1
+    streams: 1
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:1x28,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 28
+    streams: 1
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:70x1,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 1
+    streams: 70
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h2c-linux,streams:70x28,protocol:h2c,serialization:messagepack
+    protocol: h2c
+    channels: 28
+    streams: 70
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3.yaml
@@ -5,9 +5,9 @@ dotnet-version: 8.0
 benchmark-expire-min: 15
 benchmark-timeout-min: 10
 benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
-benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsClient }}"'
 benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
-benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}"'
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
   # h2c

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3_nugetclient.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3_nugetclient.yaml
@@ -1,0 +1,37 @@
+# template: https://github.com/Cysharp/Actions/tree/main/.github/scripts/_template_benchmark_config.yaml
+# config2args script: https://github.com/Cysharp/Actions/tree/main/.github/scripts/benchmark_config2args.sh
+apt-tools: ""
+dotnet-version: 8.0
+benchmark-expire-min: 15
+benchmark-timeout-min: 10
+benchmark-client-run-script-path: ".github/scripts/benchmark-client-run.sh"
+benchmark-client-run-script-args: '--run-args "-u http://${BENCHMARK_SERVER_NAME}:5000 --protocol {{ protocol }} -s CI --rounds 3 --channels {{ channels }} --streams {{ streams }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsClient }}"'
+benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
+benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
+benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
+jobs:
+  # h3
+  - tags: legend:messagepack-h3-linux,streams:1x1,protocol:h3,serialization:messagepack
+    protocol: h3
+    channels: 1
+    streams: 1
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h3-linux,streams:1x28,protocol:h3,serialization:messagepack
+    protocol: h3
+    channels: 28
+    streams: 1
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h3-linux,streams:70x1,protocol:h3,serialization:messagepack
+    protocol: h3
+    channels: 1
+    streams: 70
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4
+  - tags: legend:messagepack-h3-linux,streams:70x28,protocol:h3,serialization:messagepack
+    protocol: h3
+    channels: 28
+    streams: 70
+    serialization: messagepack
+    buildArgsClient: --p:UseNuGetClient=6.1.4

--- a/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3_nugetserver.yaml
+++ b/perf/BenchmarkApp/configs/workflow_dispatch_messagepack_h3_nugetserver.yaml
@@ -10,28 +10,28 @@ benchmark-server-run-script-path: ".github/scripts/benchmark-server-run.sh"
 benchmark-server-run-script-args: '--run-args "-u http://0.0.0.0:5000 --protocol {{ protocol }} --serialization {{ serialization }} --validate true --tags {{ tags }}" --build-args "{{ buildArgsServer }}"'
 benchmark-server-stop-script-path: ".github/scripts/benchmark-server-stop.sh"
 jobs:
-  # h2c
-  - tags: legend:memorypack-h2c-linux,streams:1x1,protocol:h2c,serialization:memorypack
-    protocol: h2c
+  # h3
+  - tags: legend:messagepack-h3-linux,streams:1x1,protocol:h3,serialization:messagepack
+    protocol: h3
     channels: 1
     streams: 1
-    serialization: memorypack
-    buildArgsClient: --p:UseNuGetClient=6.1.4
-  - tags: legend:memorypack-h2c-linux,streams:1x28,protocol:h2c,serialization:memorypack
-    protocol: h2c
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h3-linux,streams:1x28,protocol:h3,serialization:messagepack
+    protocol: h3
     channels: 28
     streams: 1
-    serialization: memorypack
-    buildArgsClient: --p:UseNuGetClient=6.1.4
-  - tags: legend:memorypack-h2c-linux,streams:70x1,protocol:h2c,serialization:memorypack
-    protocol: h2c
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h3-linux,streams:70x1,protocol:h3,serialization:messagepack
+    protocol: h3
     channels: 1
     streams: 70
-    serialization: memorypack
-    buildArgsClient: --p:UseNuGetClient=6.1.4
-  - tags: legend:memorypack-h2c-linux,streams:70x28,protocol:h2c,serialization:memorypack
-    protocol: h2c
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4
+  - tags: legend:messagepack-h3-linux,streams:70x28,protocol:h3,serialization:messagepack
+    protocol: h3
     channels: 28
     streams: 70
-    serialization: memorypack
-    buildArgsClient: --p:UseNuGetClient=6.1.4
+    serialization: messagepack
+    buildArgsServer: --p:UseNuGetServer=6.1.4


### PR DESCRIPTION
## tl;dr;
This PR introduces running benchmarks with a specific MagicOnion NuGet package. This enables benchmarks to run with consistent versioning, including a mix of a fixed client version and the latest server version.
Fixing the client (or server) version allows you to easily determine if your changes improve server (or client) performance, and vice versa.