### PR TITLE
Drop .NET 6 support

### DIFF
--- a/src/MagicOnion.Client/MagicOnion.Client.csproj
+++ b/src/MagicOnion.Client/MagicOnion.Client.csproj
@@ -5,7 +5,7 @@
 
     <LangVersion>$(_LangVersionUnityBaseline)</LangVersion>
     <Nullable>enable</Nullable>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsTrimmable>
 
     <!-- NuGet -->
     <PackageId>MagicOnion.Client</PackageId>

--- a/src/MagicOnion.Client/MagicOnion.Client.csproj
+++ b/src/MagicOnion.Client/MagicOnion.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
 
     <LangVersion>$(_LangVersionUnityBaseline)</LangVersion>
     <Nullable>enable</Nullable>
@@ -18,9 +18,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Threading.Channels" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Bcl.TimeProvider" />
   </ItemGroup>
 

--- a/src/MagicOnion.Internal/MagicOnion.Internal.csproj
+++ b/src/MagicOnion.Internal/MagicOnion.Internal.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
 
     <LangVersion>$(_LangVersionUnityBaseline)</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/MagicOnion.Serialization.MemoryPack/MagicOnion.Serialization.MemoryPack.csproj
+++ b/src/MagicOnion.Serialization.MemoryPack/MagicOnion.Serialization.MemoryPack.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/MagicOnion.Server.Redis/MagicOnion.Server.Redis.csproj
+++ b/src/MagicOnion.Server.Redis/MagicOnion.Server.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/MagicOnion.Server/MagicOnion.Server.csproj
+++ b/src/MagicOnion.Server/MagicOnion.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -22,11 +22,6 @@
     <PackageReference Include="Grpc.AspNetCore.Server" />
     <PackageReference Include="Grpc.Core.Api" />
     <PackageReference Include="Multicaster" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MagicOnion.Shared/MagicOnion.Shared.csproj
+++ b/src/MagicOnion.Shared/MagicOnion.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
 
     <LangVersion>$(_LangVersionUnityBaseline)</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/MagicOnion/MagicOnion.csproj
+++ b/src/MagicOnion/MagicOnion.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 


### PR DESCRIPTION
This PR removes .NET 6 from the target frameworks. MagicOnion.Server no longer works with .NET 6.

> [!NOTE]
> - .NET 6 will reach End of Support on November 12, 2024.
> - MagicOnion.Client, Abstractions, Shared still remains .NET Standard 2.1 support. It is possible to build client-side applications on .NET 6.