### PR TITLE
Update package dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <PropertyGroup>
     <GrpcVersion>2.57.0</GrpcVersion>
@@ -10,9 +11,6 @@
     <MicrosoftCodeAnalysisVersion>4.3.1</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisVersionUnity>3.9.0</MicrosoftCodeAnalysisVersionUnity>
     <MulticasterVersion>0.1.12</MulticasterVersion>
-    <!-- for perf -->
-    <ConsoleAppFrameworkVersion>4.2.2</ConsoleAppFrameworkVersion>
-    <JetBrainsProfilerApiVersion>1.4.3</JetBrainsProfilerApiVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
@@ -35,20 +33,18 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="PolySharp" Version="1.13.2" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.0.601" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
   </ItemGroup>
   <!-- for tests -->
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
-    <!-- from https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2-beta1.24163.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="NSubstitute" Version="5.0.0" />
     <PackageVersion Include="Testcontainers" Version="2.3.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
@@ -56,8 +52,14 @@
   </ItemGroup>
   <!-- for samples/perf -->
   <ItemGroup>
-    <PackageVersion Include="ConsoleAppFramework" Version="$(ConsoleAppFrameworkVersion)" />
-    <PackageVersion Include="JetBrains.Profiler.Api" Version="$(JetBrainsProfilerApiVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageVersion Include="ConsoleAppFramework" Version="4.2.2" />
+    <PackageVersion Include="JetBrains.Profiler.Api" Version="1.4.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
+  </ItemGroup>
+  <!-- for transitive dependencies (legacy) -->
+  <ItemGroup>
+    <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,16 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <packageSources>
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-  </packageSources>
   <packageSourceMapping>
     <clear />
     <packageSource key="nuget.org">
       <package pattern="*" />
-      <package pattern="Microsoft.CodeAnalysis.*" />
-    </packageSource>
-    <packageSource key="dotnet-tools">
-      <package pattern="Microsoft.CodeAnalysis.*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/MagicOnion.Client.SourceGenerator.Tests.csproj
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/MagicOnion.Client.SourceGenerator.Tests.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Verifiers/MagicOnionSourceGeneratorVerifier.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Verifiers/MagicOnionSourceGeneratorVerifier.cs
@@ -11,7 +11,6 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.Text;
 using VerifyCS = MagicOnion.Client.SourceGenerator.Tests.Verifiers.MagicOnionSourceGeneratorVerifier;
 
@@ -78,7 +77,7 @@ internal class MagicOnionSourceGeneratorVerifier
         await test.RunAsync();
     }
 
-    internal class Test : CSharpSourceGeneratorTest<EmptySourceGeneratorProvider, XUnitVerifier>
+    internal class Test : CSharpSourceGeneratorTest<EmptySourceGeneratorProvider, DefaultVerifier>
     {
         readonly string testFile;
         readonly string testMethod;

--- a/tests/MagicOnion.Client.SourceGenerator.Unity.Tests/MagicOnion.Client.SourceGenerator.Unity.Tests.csproj
+++ b/tests/MagicOnion.Client.SourceGenerator.Unity.Tests/MagicOnion.Client.SourceGenerator.Unity.Tests.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MagicOnion.Server.InternalTesting/MagicOnion.Server.InternalTesting.csproj
+++ b/tests/MagicOnion.Server.InternalTesting/MagicOnion.Server.InternalTesting.csproj
@@ -5,6 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\src\MagicOnion\opensource.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/MagicOnion.Server.JsonTranscoding.Tests/UnaryFunctionalTests.cs
+++ b/tests/MagicOnion.Server.JsonTranscoding.Tests/UnaryFunctionalTests.cs
@@ -55,7 +55,7 @@ public class UnaryFunctionalTests(JsonTranscodingEnabledMagicOnionApplicationFac
         // Assert
         var result = default(object); // null
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal(result, JsonSerializer.Deserialize<object>(content, JsonSerializerOptions.Web));
+        Assert.Equal(result, JsonSerializer.Deserialize<object>(content, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
         Assert.Equal("application/json", response.Content.Headers.ContentType?.ToString());
         Assert.True((bool)factory.Items.GetValueOrDefault($"{nameof(Method_NoParameter_NoResult)}.Called", false));
     }
@@ -73,7 +73,7 @@ public class UnaryFunctionalTests(JsonTranscodingEnabledMagicOnionApplicationFac
         // Assert
         var result = nameof(Method_NoParameter_ResultRefType); // string
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal(result, JsonSerializer.Deserialize<string>(content, JsonSerializerOptions.Web));
+        Assert.Equal(result, JsonSerializer.Deserialize<string>(content, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
         Assert.Equal("application/json", response.Content.Headers.ContentType?.ToString());
     }
 
@@ -98,7 +98,7 @@ public class UnaryFunctionalTests(JsonTranscodingEnabledMagicOnionApplicationFac
                 D = 98765432100,
                 E = "Hello!",
             },
-        }, JsonSerializer.Deserialize<TestResponse>(content, JsonSerializerOptions.Web));
+        }, JsonSerializer.Deserialize<TestResponse>(content, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("application/json", response.Content.Headers.ContentType?.ToString());
     }
@@ -118,7 +118,7 @@ public class UnaryFunctionalTests(JsonTranscodingEnabledMagicOnionApplicationFac
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal("Alice", JsonSerializer.Deserialize<string>(content, JsonSerializerOptions.Web));
+        Assert.Equal("Alice", JsonSerializer.Deserialize<string>(content, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
         Assert.Equal("application/json", response.Content.Headers.ContentType?.ToString());
     }
 

--- a/tests/samples/MagicOnionTestServer/MagicOnionTestServer.csproj
+++ b/tests/samples/MagicOnionTestServer/MagicOnionTestServer.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\src\MagicOnion\opensource.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update Directory.Packages.props for central package transitive pinning.
- Downgrade System.Text.Json to 8.0.5
- Upgrade Microsoft.AspNetCore.Mvc.Testing to 8.0.0
- Upgrade Microsoft.NET.Test.Sdk to 17.12.0
- Replace Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit to Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing
- Enable assembly signing in MagicOnion.Server.InternalTesting.csproj and MagicOnionTestServer.csproj.