### PR TITLE
Remove Fluent Assertions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,6 @@
   <!-- for tests -->
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
-    <PackageVersion Include="FluentAssertions" Version="8.0.0-rc.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />

--- a/tests/MagicOnion.Abstractions.Tests/BoxTest.cs
+++ b/tests/MagicOnion.Abstractions.Tests/BoxTest.cs
@@ -12,18 +12,18 @@ public class BoxTest
         var box2 = Box.Create(2);
         var box2a = Box.Create(2);
 
-        box1.Equals(box1).Should().BeTrue();
-        box1.Equals(box1a).Should().BeTrue();
-        box1.Equals(box2).Should().BeFalse();
+        Assert.True(box1.Equals(box1));
+        Assert.True(box1.Equals(box1a));
+        Assert.False(box1.Equals(box2));
 
-        box2.Equals(box2).Should().BeTrue();
-        box2.Equals(box2a).Should().BeTrue();
+        Assert.True(box2.Equals(box2));
+        Assert.True(box2.Equals(box2a));
 
-        box1.Equals(null!).Should().BeFalse();
-        box2.Equals(null!).Should().BeFalse();
+        Assert.False(box1.Equals(null!));
+        Assert.False(box2.Equals(null!));
 
-        (default(Box<int>)! == box1!).Should().BeFalse();
-        (box1! == default(Box<int>)!).Should().BeFalse();
+        Assert.False((default(Box<int>)! == box1!));
+        Assert.False((box1! == default(Box<int>)!));
     }
 
     [Fact]
@@ -37,8 +37,8 @@ public class BoxTest
         var box2 = Box.Create(value);
 
         // Assert
-        box1.Value.Should().Be(box2.Value);
-        box1.Should().BeSameAs(box2);
+        Assert.Equal(box2.Value, box1.Value);
+        Assert.Same(box2, box1);
     }
     
     [Fact]
@@ -49,10 +49,10 @@ public class BoxTest
         var box2 = Box.Create(false);
 
         // Assert
-        box1.Value.Should().BeTrue();
-        box2.Value.Should().BeFalse();
-        box1.Value.Should().NotBe(box2.Value);
-        box1.Should().NotBeSameAs(box2);
+        Assert.True(box1.Value);
+        Assert.False(box2.Value);
+        Assert.NotEqual(box2.Value, box1.Value);
+        Assert.NotSame(box2, box1);
     }
 
     [Fact]
@@ -63,9 +63,9 @@ public class BoxTest
         var box2 = Box.Create(true);
 
         // Assert
-        box1.Value.Should().BeTrue();
-        box1.Value.Should().Be(box2.Value);
-        box1.Should().BeSameAs(box2);
+        Assert.True(box1.Value);
+        Assert.Equal(box2.Value, box1.Value);
+        Assert.Same(box2, box1);
     }
     
     [Fact]
@@ -76,8 +76,8 @@ public class BoxTest
         var box2 = Box.Create(false);
 
         // Assert
-        box1.Value.Should().BeFalse();
-        box1.Value.Should().Be(box2.Value);
-        box1.Should().BeSameAs(box2);
+        Assert.False(box1.Value);
+        Assert.Equal(box2.Value, box1.Value);
+        Assert.Same(box2, box1);
     }
 }

--- a/tests/MagicOnion.Abstractions.Tests/MagicOnion.Abstractions.Tests.csproj
+++ b/tests/MagicOnion.Abstractions.Tests/MagicOnion.Abstractions.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/MagicOnion.Abstractions.Tests/UnaryResultNonGenericTest.cs
+++ b/tests/MagicOnion.Abstractions.Tests/UnaryResultNonGenericTest.cs
@@ -48,7 +48,7 @@ public class UnaryResultNonGenericTest
 #pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS8604
         // Assert
-        result.Should().BeOfType<ArgumentNullException>();
+        Assert.IsType<ArgumentNullException>(result);
     }
 
     [Fact]
@@ -68,14 +68,14 @@ public class UnaryResultNonGenericTest
         var result = Record.Exception(() => new UnaryResult(value));
 #pragma warning restore CS8604
         // Assert
-        result.Should().BeOfType<ArgumentNullException>();
+        Assert.IsType<ArgumentNullException>(result);
     }
 
     [Fact]
     public async Task ResponseHeadersAsync_Ctor_ResponseContext()
     {
         var result = new UnaryResult(Task.FromResult<IResponseContext<Nil>>(new DummyResponseContext<Nil>(Nil.Default)));
-        (await result.ResponseHeadersAsync).Should().Contain(x => x.Key == "x-foo-bar" && x.Value == "baz");
+        Assert.Contains(await result.ResponseHeadersAsync, x => x.Key == "x-foo-bar" && x.Value == "baz");
     }
 
     [Fact]

--- a/tests/MagicOnion.Abstractions.Tests/UnaryResultTest.cs
+++ b/tests/MagicOnion.Abstractions.Tests/UnaryResultTest.cs
@@ -7,9 +7,9 @@ public class UnaryResultTest
     [Fact]
     public async Task FromResult()
     {
-        (await UnaryResult.FromResult(123)).Should().Be(123);
-        (await UnaryResult.FromResult("foo")).Should().Be("foo");
-        (await UnaryResult.FromResult<string?>(default(string))).Should().BeNull();
+        Assert.Equal(123, (await UnaryResult.FromResult(123)));
+        Assert.Equal("foo", (await UnaryResult.FromResult("foo")));
+        Assert.Null((await UnaryResult.FromResult<string?>(default(string))));
 
         Assert.Throws<ArgumentNullException>(() => UnaryResult.FromResult(default(Task<string>)!));
     }
@@ -18,23 +18,23 @@ public class UnaryResultTest
     public async Task Ctor_RawValue()
     {
         var result = new UnaryResult<int>(123);
-        (await result).Should().Be(123);
+        Assert.Equal(123, (await result));
 
         var result2 = new UnaryResult<string>("foo");
-        (await result2).Should().Be("foo");
+        Assert.Equal("foo", (await result2));
 
         var result3 = new UnaryResult<string?>(default(string));
-        (await result3).Should().BeNull();
+        Assert.Null((await result3));
     }
 
     [Fact]
     public async Task Ctor_RawTask()
     {
         var result = new UnaryResult<int>(Task.FromResult(456));
-        (await result).Should().Be(456);
+        Assert.Equal(456, (await result));
 
         var result2 = new UnaryResult<string>(Task.FromResult("foo"));
-        (await result2).Should().Be("foo");
+        Assert.Equal("foo", (await result2));
 
         Assert.Throws<ArgumentNullException>(() => new UnaryResult<string?>(default(Task<string?>)!));
     }
@@ -43,10 +43,10 @@ public class UnaryResultTest
     public async Task Ctor_TaskOfResponseContext()
     {
         var result = new UnaryResult<int>(Task.FromResult(DummyResponseContext.Create(456)));
-        (await result).Should().Be(456);
+        Assert.Equal(456, (await result));
 
         var result2 = new UnaryResult<string>(Task.FromResult(DummyResponseContext.Create("foo")));
-        (await result2).Should().Be("foo");
+        Assert.Equal("foo", (await result2));
 
         Assert.Throws<ArgumentNullException>(() => new UnaryResult<string?>(default(Task<IResponseContext<string?>>)!));
     }
@@ -85,17 +85,17 @@ public class UnaryResultTest
     public async Task Ctor_Default()
     {
         var result = default(UnaryResult<int>);
-        (await result).Should().Be(0);
+        Assert.Equal(0, (await result));
 
         var result2 = default(UnaryResult<string>);
-        (await result2).Should().Be(null);
+        Assert.Equal(null, (await result2));
     }
 
     [Fact]
     public async Task ResponseHeadersAsync_Ctor_ResponseContext()
     {
         var result = new UnaryResult<int>(Task.FromResult<IResponseContext<int>>(new DummyResponseContext<int>(123)));
-        (await result.ResponseHeadersAsync).Should().Contain(x => x.Key == "x-foo-bar" && x.Value == "baz");
+        Assert.Contains((await result.ResponseHeadersAsync), x => x.Key == "x-foo-bar" && x.Value == "baz");
     }
 
     [Fact]
@@ -109,14 +109,14 @@ public class UnaryResultTest
     public async Task ResponseAsync_Ctor_Task()
     {
         var result = new UnaryResult<int>(Task.FromResult(123));
-        (await result.ResponseAsync).Should().Be(123);
+        Assert.Equal(123, (await result.ResponseAsync));
     }
 
     [Fact]
     public async Task ResponseAsync_Ctor_TaskOfNil()
     {
         var result = new UnaryResult<int>(Task.FromResult(123));
-        (await result.ResponseAsync).Should().Be(123);
+        Assert.Equal(123, (await result.ResponseAsync));
     }
 
     [Fact]

--- a/tests/MagicOnion.Abstractions.Tests/UnaryResultTest.cs
+++ b/tests/MagicOnion.Abstractions.Tests/UnaryResultTest.cs
@@ -88,7 +88,7 @@ public class UnaryResultTest
         Assert.Equal(0, (await result));
 
         var result2 = default(UnaryResult<string>);
-        Assert.Equal(null, (await result2));
+        Assert.Null((await result2));
     }
 
     [Fact]

--- a/tests/MagicOnion.Abstractions.Tests/Usings.cs
+++ b/tests/MagicOnion.Abstractions.Tests/Usings.cs
@@ -1,5 +1,4 @@
 global using Xunit;
-global using FluentAssertions;
 
 global using Grpc.Core;
 global using MessagePack;

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MagicOnionTypeInfoTest.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MagicOnionTypeInfoTest.cs
@@ -13,11 +13,11 @@ public class MagicOnionTypeInfoTest
 
         // Assert
         var fullName = typeInfo.FullName;
-        fullName.Should().Be("global::System.String");
-        typeInfo.IsArray.Should().BeFalse();
-        typeInfo.IsEnum.Should().BeFalse();
-        typeInfo.ElementType.Should().BeNull();
-        typeInfo.UnderlyingType.Should().BeNull();
+        Assert.Equal("global::System.String", fullName);
+        Assert.False(typeInfo.IsArray);
+        Assert.False(typeInfo.IsEnum);
+        Assert.Null(typeInfo.ElementType);
+        Assert.Null(typeInfo.UnderlyingType);
     }
 
     [Fact]
@@ -28,9 +28,9 @@ public class MagicOnionTypeInfoTest
 
         // Assert
         var fullName = typeInfo.FullName;
-        fullName.Should().Be("global::System.String[]");
-        typeInfo.IsArray.Should().BeTrue();
-        typeInfo.ElementType.Should().Be(MagicOnionTypeInfo.Create("System", "String"));
+        Assert.Equal("global::System.String[]", fullName);
+        Assert.True(typeInfo.IsArray);
+        Assert.Equal(MagicOnionTypeInfo.Create("System", "String"), typeInfo.ElementType);
     }
     
     [Fact]
@@ -43,8 +43,8 @@ public class MagicOnionTypeInfoTest
 
         // Assert
         var fullName = typeInfo.FullName;
-        fullName.Should().Be("global::System.Tuple<global::System.Int32[], global::System.String>[]");
-        typeInfo.IsArray.Should().BeTrue();
+        Assert.Equal("global::System.Tuple<global::System.Int32[], global::System.String>[]", fullName);
+        Assert.True(typeInfo.IsArray);
     }
     
     [Fact]
@@ -55,9 +55,9 @@ public class MagicOnionTypeInfoTest
 
         // Assert
         var fullName = typeInfo.FullName;
-        fullName.Should().Be("global::System.String[][]");
-        typeInfo.IsArray.Should().BeTrue();
-        typeInfo.ElementType.Should().Be(MagicOnionTypeInfo.Create("System", "String[]")); // NOTE: Currently, MOTypeInfo doesn't handle an element type for jagged array.
+        Assert.Equal("global::System.String[][]", fullName);
+        Assert.True(typeInfo.IsArray);
+        Assert.Equal(MagicOnionTypeInfo.Create("System", "String[]"), typeInfo.ElementType); // NOTE: Currently, MOTypeInfo doesn't handle an element type for jagged array.
     }
        
     [Fact]
@@ -68,9 +68,9 @@ public class MagicOnionTypeInfoTest
 
         // Assert
         var fullName = typeInfo.FullName;
-        fullName.Should().Be("global::System.String[,,]");
-        typeInfo.ArrayRank.Should().Be(3);
-        typeInfo.IsArray.Should().BeTrue();
+        Assert.Equal("global::System.String[,,]", fullName);
+        Assert.Equal(3, typeInfo.ArrayRank);
+        Assert.True(typeInfo.IsArray);
     }
 
     [Fact]
@@ -80,10 +80,10 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromType<string>();
 
         // Assert
-        typeInfo.FullName.Should().Be("global::System.String");
-        typeInfo.IsEnum.Should().BeFalse();
-        typeInfo.IsArray.Should().BeFalse();
-        typeInfo.IsValueType.Should().BeFalse();
+        Assert.Equal("global::System.String", typeInfo.FullName);
+        Assert.False(typeInfo.IsEnum);
+        Assert.False(typeInfo.IsArray);
+        Assert.False(typeInfo.IsValueType);
     }
 
     [Fact]
@@ -93,10 +93,10 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromType<byte>();
 
         // Assert
-        typeInfo.FullName.Should().Be("global::System.Byte");
-        typeInfo.IsEnum.Should().BeFalse();
-        typeInfo.IsArray.Should().BeFalse();
-        typeInfo.IsValueType.Should().BeTrue();
+        Assert.Equal("global::System.Byte", typeInfo.FullName);
+        Assert.False(typeInfo.IsEnum);
+        Assert.False(typeInfo.IsArray);
+        Assert.True(typeInfo.IsValueType);
     }
 
     [Fact]
@@ -106,10 +106,10 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromType<Tuple<int, string>>();
 
         // Assert
-        typeInfo.FullName.Should().Be("global::System.Tuple<global::System.Int32, global::System.String>");
-        typeInfo.GenericArguments.Should().HaveCount(2);
-        typeInfo.IsEnum.Should().BeFalse();
-        typeInfo.IsArray.Should().BeFalse();
+        Assert.Equal("global::System.Tuple<global::System.Int32, global::System.String>", typeInfo.FullName);
+        Assert.Equal(2, typeInfo.GenericArguments.Count());
+        Assert.False(typeInfo.IsEnum);
+        Assert.False(typeInfo.IsArray);
     }
     
     [Fact]
@@ -119,12 +119,12 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromType<int[]>();
 
         // Assert
-        typeInfo.FullName.Should().Be("global::System.Int32[]");
-        typeInfo.GenericArguments.Should().BeEmpty();
-        typeInfo.IsEnum.Should().BeFalse();
-        typeInfo.IsArray.Should().BeTrue();
-        typeInfo.ElementType.Should().Be(MagicOnionTypeInfo.CreateValueType("System", "Int32"));
-        typeInfo.ArrayRank.Should().Be(1);
+        Assert.Equal("global::System.Int32[]", typeInfo.FullName);
+        Assert.Empty(typeInfo.GenericArguments);
+        Assert.False(typeInfo.IsEnum);
+        Assert.True(typeInfo.IsArray);
+        Assert.Equal(MagicOnionTypeInfo.CreateValueType("System", "Int32"), typeInfo.ElementType);
+        Assert.Equal(1, typeInfo.ArrayRank);
     }
 
     [Fact]
@@ -134,12 +134,12 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromType<int[,,]>();
 
         // Assert
-        typeInfo.FullName.Should().Be("global::System.Int32[,,]");
-        typeInfo.GenericArguments.Should().BeEmpty();
-        typeInfo.IsEnum.Should().BeFalse();
-        typeInfo.IsArray.Should().BeTrue();
-        typeInfo.ElementType.Should().Be(MagicOnionTypeInfo.CreateValueType("System", "Int32"));
-        typeInfo.ArrayRank.Should().Be(3);
+        Assert.Equal("global::System.Int32[,,]", typeInfo.FullName);
+        Assert.Empty(typeInfo.GenericArguments);
+        Assert.False(typeInfo.IsEnum);
+        Assert.True(typeInfo.IsArray);
+        Assert.Equal(MagicOnionTypeInfo.CreateValueType("System", "Int32"), typeInfo.ElementType);
+        Assert.Equal(3, typeInfo.ArrayRank);
     }
 
     [Fact]
@@ -149,13 +149,13 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromType<DayOfWeek>();
 
         // Assert
-        typeInfo.FullName.Should().Be("global::System.DayOfWeek");
-        typeInfo.GenericArguments.Should().BeEmpty();
-        typeInfo.IsEnum.Should().BeTrue();
-        typeInfo.IsValueType.Should().BeTrue();
-        typeInfo.UnderlyingType.Should().Be(MagicOnionTypeInfo.CreateValueType("System", "Int32"));
-        typeInfo.IsArray.Should().BeFalse();
-        typeInfo.ElementType.Should().BeNull();
+        Assert.Equal("global::System.DayOfWeek", typeInfo.FullName);
+        Assert.Empty(typeInfo.GenericArguments);
+        Assert.True(typeInfo.IsEnum);
+        Assert.True(typeInfo.IsValueType);
+        Assert.Equal(MagicOnionTypeInfo.CreateValueType("System", "Int32"), typeInfo.UnderlyingType);
+        Assert.False(typeInfo.IsArray);
+        Assert.Null(typeInfo.ElementType);
     }
     
     [Fact]
@@ -165,17 +165,17 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromType<DayOfWeek[]>();
 
         // Assert
-        typeInfo.FullName.Should().Be("global::System.DayOfWeek[]");
-        typeInfo.GenericArguments.Should().BeEmpty();
-        typeInfo.IsEnum.Should().BeFalse();
-        typeInfo.UnderlyingType.Should().BeNull();
-        typeInfo.IsArray.Should().BeTrue();
+        Assert.Equal("global::System.DayOfWeek[]", typeInfo.FullName);
+        Assert.Empty(typeInfo.GenericArguments);
+        Assert.False(typeInfo.IsEnum);
+        Assert.Null(typeInfo.UnderlyingType);
+        Assert.True(typeInfo.IsArray);
         Assert.NotNull(typeInfo.ElementType);
-        typeInfo.ElementType.Should().Be(MagicOnionTypeInfo.CreateEnum("System", "DayOfWeek", MagicOnionTypeInfo.CreateValueType("System", "Int32")));
-        typeInfo.ElementType.IsEnum.Should().BeTrue();
-        typeInfo.ElementType.IsArray.Should().BeFalse();
-        typeInfo.ElementType.IsValueType.Should().BeTrue();
-        typeInfo.ElementType.UnderlyingType.Should().Be(MagicOnionTypeInfo.CreateValueType("System", "Int32"));
+        Assert.Equal(MagicOnionTypeInfo.CreateEnum("System", "DayOfWeek", MagicOnionTypeInfo.CreateValueType("System", "Int32")), typeInfo.ElementType);
+        Assert.True(typeInfo.ElementType.IsEnum);
+        Assert.False(typeInfo.ElementType.IsArray);
+        Assert.True(typeInfo.ElementType.IsValueType);
+        Assert.Equal(MagicOnionTypeInfo.CreateValueType("System", "Int32"), typeInfo.ElementType.UnderlyingType);
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateValueType("MyNamespace", "MyStruct", new [] { MagicOnionTypeInfo.CreateFromType<byte>() });
 
         // Assert
-        typeInfo.IsValueType.Should().BeTrue();
+        Assert.True(typeInfo.IsValueType);
     }
 
     [Fact]
@@ -206,8 +206,8 @@ public class MagicOnionTypeInfoTest
         // Assert
         var fullName = typeInfo.FullName;
         var genericArguments = typeInfo.GenericArguments;
-        fullName.Should().Be("global::System.Collections.Generic.Dictionary<global::System.String, global::System.Int32>");
-        genericArguments.Should().Equal(MagicOnionTypeInfo.Create("System", "String"), MagicOnionTypeInfo.CreateValueType("System", "Int32"));
+        Assert.Equal("global::System.Collections.Generic.Dictionary<global::System.String, global::System.Int32>", fullName);
+        Assert.Equal([MagicOnionTypeInfo.Create("System", "String"), MagicOnionTypeInfo.CreateValueType("System", "Int32")], genericArguments);
     }
 
     [Fact]
@@ -223,8 +223,8 @@ public class MagicOnionTypeInfoTest
         // Assert
         var fullName = typeInfo.FullName;
         var genericArgumentsNested = typeInfo.GenericArguments[1].GenericArguments;
-        fullName.Should().Be("global::System.Collections.Generic.Dictionary<global::System.String, global::System.Tuple<global::System.Double, global::System.Byte>>");
-        genericArgumentsNested.Should().Equal(MagicOnionTypeInfo.CreateValueType("System", "Double"), MagicOnionTypeInfo.CreateValueType("System", "Byte"));
+        Assert.Equal("global::System.Collections.Generic.Dictionary<global::System.String, global::System.Tuple<global::System.Double, global::System.Byte>>", fullName);
+        Assert.Equal([MagicOnionTypeInfo.CreateValueType("System", "Double"), MagicOnionTypeInfo.CreateValueType("System", "Byte")], genericArgumentsNested);
     }
 
     [Fact]
@@ -240,9 +240,9 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0]);
 
         // Assert
-        typeInfo.Namespace.Should().BeEmpty();
-        typeInfo.Name.Should().Be("MyClass");
-        typeInfo.FullName.Should().Be("global::MyClass");
+        Assert.Empty(typeInfo.Namespace);
+        Assert.Equal("MyClass", typeInfo.Name);
+        Assert.Equal("global::MyClass", typeInfo.FullName);
     }
 
     [Fact]
@@ -261,9 +261,9 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0]);
 
         // Assert
-        typeInfo.Namespace.Should().Be("MyNamespace");
-        typeInfo.Name.Should().Be("MyClass");
-        typeInfo.FullName.Should().Be("global::MyNamespace.MyClass");
+        Assert.Equal("MyNamespace", typeInfo.Namespace);
+        Assert.Equal("MyClass", typeInfo.Name);
+        Assert.Equal("global::MyNamespace.MyClass", typeInfo.FullName);
     }
 
     [Fact]
@@ -287,11 +287,11 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Should().Be(MagicOnionTypeInfo.Create("System", "Tuple",
+        Assert.Equal(MagicOnionTypeInfo.Create("System", "Tuple",
             MagicOnionTypeInfo.CreateValueType("System", "Nullable", 
                 MagicOnionTypeInfo.CreateValueType("System", "Boolean")),
             MagicOnionTypeInfo.CreateValueType("System", "Nullable",
-                MagicOnionTypeInfo.CreateValueType("System", "Int64"))));
+                MagicOnionTypeInfo.CreateValueType("System", "Int64"))), typeInfo);
     }
        
     [Fact]
@@ -315,9 +315,9 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Should().Be(MagicOnionTypeInfo.CreateValueType( "System", "Int32", Array.Empty<MagicOnionTypeInfo>()));
-        typeInfo.IsValueType.Should().BeTrue();
-        typeInfo.IsEnum.Should().BeFalse();
+        Assert.Equal(MagicOnionTypeInfo.CreateValueType( "System", "Int32", Array.Empty<MagicOnionTypeInfo>()), typeInfo);
+        Assert.True(typeInfo.IsValueType);
+        Assert.False(typeInfo.IsEnum);
     }
 
     [Fact]
@@ -345,7 +345,7 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Should().Be(MagicOnionTypeInfo.CreateEnum( "MyNamespace", "MyEnum", MagicOnionTypeInfo.CreateValueType("System", "Byte")));
+        Assert.Equal(MagicOnionTypeInfo.CreateEnum( "MyNamespace", "MyEnum", MagicOnionTypeInfo.CreateValueType("System", "Byte")), typeInfo);
     }
         
     [Fact]
@@ -373,7 +373,7 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Should().Be(MagicOnionTypeInfo.CreateArray(MagicOnionTypeInfo.CreateEnum( "MyNamespace", "MyEnum", MagicOnionTypeInfo.CreateValueType("System", "Byte"))));
+        Assert.Equal(MagicOnionTypeInfo.CreateArray(MagicOnionTypeInfo.CreateEnum( "MyNamespace", "MyEnum", MagicOnionTypeInfo.CreateValueType("System", "Byte"))), typeInfo);
     }
            
     [Fact]
@@ -401,9 +401,10 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Should().Be(MagicOnionTypeInfo.Create("System", "Tuple", 
+        Assert.Equal(MagicOnionTypeInfo.Create("System", "Tuple", 
             MagicOnionTypeInfo.CreateValueType("System", "Int32"),
-            MagicOnionTypeInfo.CreateEnum( "MyNamespace", "MyEnum", MagicOnionTypeInfo.CreateValueType("System", "Byte"))));
+            MagicOnionTypeInfo.CreateEnum( "MyNamespace", "MyEnum", MagicOnionTypeInfo.CreateValueType("System", "Byte"))),
+            typeInfo);
     }
     
     [Fact]
@@ -427,7 +428,7 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Should().Be(MagicOnionTypeInfo.CreateArray(MagicOnionTypeInfo.CreateValueType("System", "Int32")));
+        Assert.Equal(MagicOnionTypeInfo.CreateArray(MagicOnionTypeInfo.CreateValueType("System", "Int32")), typeInfo);
     }
         
     [Fact]
@@ -451,7 +452,7 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Should().Be(MagicOnionTypeInfo.CreateArray("System", "Int32[]"));
+        Assert.Equal(MagicOnionTypeInfo.CreateArray("System", "Int32[]"), typeInfo);
     }
 
     [Fact]
@@ -475,9 +476,10 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Should().Be(MagicOnionTypeInfo.CreateArray("System", "Tuple", 
+        Assert.Equal(MagicOnionTypeInfo.CreateArray("System", "Tuple", 
             MagicOnionTypeInfo.CreateValueType("System", "Int32"),
-            MagicOnionTypeInfo.Create("System", "String")));
+            MagicOnionTypeInfo.Create("System", "String")),
+            typeInfo);
     }
     
     [Fact]
@@ -501,7 +503,7 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Should().Be(MagicOnionTypeInfo.CreateArray("System", "String", Array.Empty<MagicOnionTypeInfo>(), 3));
+        Assert.Equal(MagicOnionTypeInfo.CreateArray("System", "String", Array.Empty<MagicOnionTypeInfo>(), 3), typeInfo);
     }
 
     [Fact]
@@ -525,11 +527,11 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Namespace.Should().Be("System.Collections.Generic");
-        typeInfo.Name.Should().Be("List");
-        typeInfo.GenericArguments.Should().HaveCount(1);
-        typeInfo.GenericArguments[0].Should().Be(MagicOnionTypeInfo.Create("System", "String"));
-        typeInfo.FullName.Should().Be("global::System.Collections.Generic.List<global::System.String>");
+        Assert.Equal("System.Collections.Generic", typeInfo.Namespace);
+        Assert.Equal("List", typeInfo.Name);
+        Assert.Equal(1, typeInfo.GenericArguments.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("System", "String"), typeInfo.GenericArguments[0]);
+        Assert.Equal("global::System.Collections.Generic.List<global::System.String>", typeInfo.FullName);
     }
 
     [Fact]
@@ -555,11 +557,11 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Namespace.Should().Be("System.Collections.Generic");
-        typeInfo.Name.Should().Be("List");
-        typeInfo.GenericArguments.Should().HaveCount(1);
-        typeInfo.GenericArguments[0].Should().Be(MagicOnionTypeInfo.Create("System", "Tuple", MagicOnionTypeInfo.CreateValueType("System", "Int32"), MagicOnionTypeInfo.Create("System", "String")));
-        typeInfo.FullName.Should().Be("global::System.Collections.Generic.List<global::System.Tuple<global::System.Int32, global::System.String>>");
+        Assert.Equal("System.Collections.Generic", typeInfo.Namespace);
+        Assert.Equal("List", typeInfo.Name);
+        Assert.Equal(1, typeInfo.GenericArguments.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("System", "Tuple", MagicOnionTypeInfo.CreateValueType("System", "Int32"), MagicOnionTypeInfo.Create("System", "String")), typeInfo.GenericArguments[0]);
+        Assert.Equal("global::System.Collections.Generic.List<global::System.Tuple<global::System.Int32, global::System.String>>", typeInfo.FullName);
     }
 
     [Fact]
@@ -585,12 +587,12 @@ public class MagicOnionTypeInfoTest
         var typeInfo = MagicOnionTypeInfo.CreateFromSymbol(symbols[0].Type);
 
         // Assert
-        typeInfo.Namespace.Should().Be("System");
-        typeInfo.Name.Should().Be("ValueTuple");
-        typeInfo.GenericArguments.Should().HaveCount(2);
-        typeInfo.GenericArguments[0].Should().Be(MagicOnionTypeInfo.Create("System", "String"));
-        typeInfo.GenericArguments[1].Should().Be(MagicOnionTypeInfo.CreateValueType("System", "Int32"));
-        typeInfo.FullName.Should().Be("global::System.ValueTuple<global::System.String, global::System.Int32>");
+        Assert.Equal("System", typeInfo.Namespace);
+        Assert.Equal("ValueTuple", typeInfo.Name);
+        Assert.Equal(2, typeInfo.GenericArguments.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("System", "String"), typeInfo.GenericArguments[0]);
+        Assert.Equal(MagicOnionTypeInfo.CreateValueType("System", "Int32"), typeInfo.GenericArguments[1]);
+        Assert.Equal("global::System.ValueTuple<global::System.String, global::System.Int32>", typeInfo.FullName);
     }
 
     [Fact]
@@ -601,7 +603,7 @@ public class MagicOnionTypeInfoTest
         // Act
         var formatted = typeInfo.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.Short);
         // Assert
-        formatted.Should().Be("Nil");
+        Assert.Equal("Nil", formatted);
     }
     
     [Fact]
@@ -612,7 +614,7 @@ public class MagicOnionTypeInfoTest
         // Act
         var formatted = typeInfo.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.Short);
         // Assert
-        formatted.Should().Be("Tuple<String, Int32>");
+        Assert.Equal("Tuple<String, Int32>", formatted);
     }
 
     [Fact]
@@ -623,7 +625,7 @@ public class MagicOnionTypeInfoTest
         // Act
         var formatted = typeInfo.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.FullyQualified);
         // Assert
-        formatted.Should().Be("global::MessagePack.Nil");
+        Assert.Equal("global::MessagePack.Nil", formatted);
     }
 
     [Fact]
@@ -634,7 +636,7 @@ public class MagicOnionTypeInfoTest
         // Act
         var formatted = typeInfo.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.FullyQualified);
         // Assert
-        formatted.Should().Be("global::System.Tuple<global::System.String, global::System.Int32>");
+        Assert.Equal("global::System.Tuple<global::System.String, global::System.Int32>", formatted);
     }
 
     [Fact]
@@ -645,7 +647,7 @@ public class MagicOnionTypeInfoTest
         // Act
         var formatted = typeInfo.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.Namespace);
         // Assert
-        formatted.Should().Be("MessagePack.Nil");
+        Assert.Equal("MessagePack.Nil", formatted);
     }
 
     [Fact]
@@ -656,7 +658,7 @@ public class MagicOnionTypeInfoTest
         // Act
         var formatted = typeInfo.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.OpenGenerics);
         // Assert
-        formatted.Should().Be("Tuple<,>");
+        Assert.Equal("Tuple<,>", formatted);
     }
     
     [Fact]
@@ -667,7 +669,7 @@ public class MagicOnionTypeInfoTest
         // Act
         var formatted = typeInfo.ToDisplayName(MagicOnionTypeInfo.DisplayNameFormat.WithoutGenericArguments);
         // Assert
-        formatted.Should().Be("Tuple");
+        Assert.Equal("Tuple", formatted);
     }
 
     [Fact]
@@ -678,7 +680,7 @@ public class MagicOnionTypeInfoTest
         // Act
         var types = typeInfo.EnumerateDependentTypes().ToArray();
         // Assert
-        types.Should().Equal(MagicOnionTypeInfo.CreateFromType<int>());
+        Assert.Equal([MagicOnionTypeInfo.CreateFromType<int>()], types);
     }
     
     [Fact]
@@ -689,8 +691,8 @@ public class MagicOnionTypeInfoTest
         // Act
         var types = typeInfo.EnumerateDependentTypes().ToArray();
         // Assert
-        types.Should().Equal(MagicOnionTypeInfo.CreateFromType<DayOfWeek>());
-    }    
+        Assert.Equal([MagicOnionTypeInfo.CreateFromType<DayOfWeek>()], types);
+    }
 
     [Fact]
     public void EnumerateDependentTypes_Enum_Generics()
@@ -700,7 +702,7 @@ public class MagicOnionTypeInfoTest
         // Act
         var types = typeInfo.EnumerateDependentTypes().ToArray();
         // Assert
-        types.Should().Equal(MagicOnionTypeInfo.CreateFromType<DayOfWeek[]>(), MagicOnionTypeInfo.CreateFromType<DayOfWeek>());
+        Assert.Equal([MagicOnionTypeInfo.CreateFromType<DayOfWeek[]>(), MagicOnionTypeInfo.CreateFromType<DayOfWeek>()], types);
     }
 
     [Fact]
@@ -711,7 +713,7 @@ public class MagicOnionTypeInfoTest
         // Act
         var types = typeInfo.EnumerateDependentTypes().ToArray();
         // Assert
-        types.Should().Equal(MagicOnionTypeInfo.CreateFromType<int>(), MagicOnionTypeInfo.CreateFromType<string>());
+        Assert.Equal([MagicOnionTypeInfo.CreateFromType<int>(), MagicOnionTypeInfo.CreateFromType<string>()], types);
     }
     
     [Fact]
@@ -722,13 +724,15 @@ public class MagicOnionTypeInfoTest
         // Act
         var types = typeInfo.EnumerateDependentTypes().ToArray();
         // Assert
-        types.Should().Equal(
-            MagicOnionTypeInfo.CreateFromType<int>(),
-            MagicOnionTypeInfo.CreateFromType<Dictionary<string, Task<byte[]>>>(),
-            MagicOnionTypeInfo.CreateFromType<string>(),
-            MagicOnionTypeInfo.CreateFromType<Task<byte[]>>(),
-            MagicOnionTypeInfo.CreateFromType<byte[]>(),
-            MagicOnionTypeInfo.CreateFromType<byte>());
+        Assert.Equal([
+                MagicOnionTypeInfo.CreateFromType<int>(),
+                MagicOnionTypeInfo.CreateFromType<Dictionary<string, Task<byte[]>>>(),
+                MagicOnionTypeInfo.CreateFromType<string>(),
+                MagicOnionTypeInfo.CreateFromType<Task<byte[]>>(),
+                MagicOnionTypeInfo.CreateFromType<byte[]>(),
+                MagicOnionTypeInfo.CreateFromType<byte>()
+            ],
+            types);
     }
 
     [Fact]
@@ -739,6 +743,6 @@ public class MagicOnionTypeInfoTest
         // Act
         var genericDefinition = typeInfo.GetGenericTypeDefinition();
         // Assert
-        genericDefinition.Should().Be(MagicOnionTypeInfo.Create("System", "ValueTuple", Array.Empty<MagicOnionTypeInfo>(), true));
+        Assert.Equal(MagicOnionTypeInfo.Create("System", "ValueTuple", Array.Empty<MagicOnionTypeInfo>(), true), genericDefinition);
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MagicOnionTypeInfoTest.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MagicOnionTypeInfoTest.cs
@@ -529,7 +529,7 @@ public class MagicOnionTypeInfoTest
         // Assert
         Assert.Equal("System.Collections.Generic", typeInfo.Namespace);
         Assert.Equal("List", typeInfo.Name);
-        Assert.Equal(1, typeInfo.GenericArguments.Count());
+        Assert.Single(typeInfo.GenericArguments);
         Assert.Equal(MagicOnionTypeInfo.Create("System", "String"), typeInfo.GenericArguments[0]);
         Assert.Equal("global::System.Collections.Generic.List<global::System.String>", typeInfo.FullName);
     }
@@ -559,7 +559,7 @@ public class MagicOnionTypeInfoTest
         // Assert
         Assert.Equal("System.Collections.Generic", typeInfo.Namespace);
         Assert.Equal("List", typeInfo.Name);
-        Assert.Equal(1, typeInfo.GenericArguments.Count());
+        Assert.Single(typeInfo.GenericArguments);
         Assert.Equal(MagicOnionTypeInfo.Create("System", "Tuple", MagicOnionTypeInfo.CreateValueType("System", "Int32"), MagicOnionTypeInfo.Create("System", "String")), typeInfo.GenericArguments[0]);
         Assert.Equal("global::System.Collections.Generic.List<global::System.Tuple<global::System.Int32, global::System.String>>", typeInfo.FullName);
     }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MethodCollectorServicesTest.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MethodCollectorServicesTest.cs
@@ -37,14 +37,14 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().HaveCount(1);
-        serviceCollection.Services[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"));
-        serviceCollection.Services[0].Methods.Should().HaveCount(2);
-        serviceCollection.Services[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Services[0].Methods[1].MethodName.Should().Be("MethodC");
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
+        Assert.Equal(2, serviceCollection.Services[0].Methods.Count());
+        Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
+        Assert.Equal("MethodC", serviceCollection.Services[0].Methods[1].MethodName);
     }
 
     [Fact]
@@ -77,10 +77,10 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().BeEmpty();
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Empty(serviceCollection.Services);
     }
 
     [Fact]
@@ -109,10 +109,10 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<Nil>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<Nil>());
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<UnaryResult>());
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Nil>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Nil>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<UnaryResult>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -141,10 +141,10 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<Tuple<bool, long>[]>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<Tuple<int, string>[]>());
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<UnaryResult<Tuple<int, string>[]>>());
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Tuple<bool, long>[]>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Tuple<int, string>[]>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<UnaryResult<Tuple<int, string>[]>>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -173,10 +173,10 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<Tuple<bool?, long?>>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<int?>());
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<UnaryResult<int?>>());
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Tuple<bool?, long?>>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int?>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<UnaryResult<int?>>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -205,19 +205,19 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().HaveCount(1);
-        serviceCollection.Services[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"));
-        serviceCollection.Services[0].Methods.Should().HaveCount(1);
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
+        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
         // UnaryResult<Nil> MethodA();
-        serviceCollection.Services[0].Methods[0].ServiceName.Should().Be("IMyService");
-        serviceCollection.Services[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<Nil>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<Nil>());
-        serviceCollection.Services[0].Methods[0].Parameters.Should().BeEmpty();
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<UnaryResult<Nil>>());
+        Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
+        Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Nil>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Nil>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Empty(serviceCollection.Services[0].Methods[0].Parameters);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<UnaryResult<Nil>>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
 
@@ -247,19 +247,19 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().HaveCount(1);
-        serviceCollection.Services[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"));
-        serviceCollection.Services[0].Methods.Should().HaveCount(1);
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
+        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
         // UnaryResult<string> MethodA();
-        serviceCollection.Services[0].Methods[0].ServiceName.Should().Be("IMyService");
-        serviceCollection.Services[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<Nil>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Services[0].Methods[0].Parameters.Should().BeEmpty();
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<UnaryResult<string>>());
+        Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
+        Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Nil>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Empty(serviceCollection.Services[0].Methods[0].Parameters);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<UnaryResult<string>>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -288,20 +288,20 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().HaveCount(1);
-        serviceCollection.Services[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"));
-        serviceCollection.Services[0].Methods.Should().HaveCount(1);
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
+        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
         // UnaryResult<Nil> MethodA(string arg1);
-        serviceCollection.Services[0].Methods[0].ServiceName.Should().Be("IMyService");
-        serviceCollection.Services[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<Nil>());
-        serviceCollection.Services[0].Methods[0].Parameters[0].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Services[0].Methods[0].Parameters[0].Name.Should().Be("arg1");
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<UnaryResult<Nil>>());
+        Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
+        Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Nil>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Services[0].Methods[0].Parameters[0].Type);
+        Assert.Equal("arg1", serviceCollection.Services[0].Methods[0].Parameters[0].Name);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<UnaryResult<Nil>>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -330,20 +330,20 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().HaveCount(1);
-        serviceCollection.Services[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"));
-        serviceCollection.Services[0].Methods.Should().HaveCount(1);
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
+        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
         // UnaryResult<Nil> MethodA(string arg1, int arg2);
-        serviceCollection.Services[0].Methods[0].ServiceName.Should().Be("IMyService");
-        serviceCollection.Services[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<string, int>>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<Nil>());
-        serviceCollection.Services[0].Methods[0].Parameters[0].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Services[0].Methods[0].Parameters[1].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<UnaryResult<Nil>>());
+        Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
+        Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<string, int>>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Nil>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Services[0].Methods[0].Parameters[0].Type);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Services[0].Methods[0].Parameters[1].Type);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<UnaryResult<Nil>>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
 
@@ -373,19 +373,19 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Services[0].Methods[0].Parameters[0].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Services[0].Methods[0].Parameters[0].HasExplicitDefaultValue.Should().BeTrue();
-        serviceCollection.Services[0].Methods[0].Parameters[0].DefaultValue.Should().Be("\"Hello\"");
-        serviceCollection.Services[0].Methods[0].Parameters[1].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Services[0].Methods[0].Parameters[1].DefaultValue.Should().Be("1234");
-        serviceCollection.Services[0].Methods[0].Parameters[1].HasExplicitDefaultValue.Should().BeTrue();
-        serviceCollection.Services[0].Methods[0].Parameters[2].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<long>());
-        serviceCollection.Services[0].Methods[0].Parameters[2].DefaultValue.Should().Be("0");
-        serviceCollection.Services[0].Methods[0].Parameters[2].HasExplicitDefaultValue.Should().BeTrue();
-        serviceCollection.Services[0].Methods[0].Parameters[3].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Services[0].Methods[0].Parameters[3].DefaultValue.Should().Be("null");
-        serviceCollection.Services[0].Methods[0].Parameters[3].HasExplicitDefaultValue.Should().BeTrue();
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Services[0].Methods[0].Parameters[0].Type);
+        Assert.True(serviceCollection.Services[0].Methods[0].Parameters[0].HasExplicitDefaultValue);
+        Assert.Equal("\"Hello\"", serviceCollection.Services[0].Methods[0].Parameters[0].DefaultValue);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Services[0].Methods[0].Parameters[1].Type);
+        Assert.Equal("1234", serviceCollection.Services[0].Methods[0].Parameters[1].DefaultValue);
+        Assert.True(serviceCollection.Services[0].Methods[0].Parameters[1].HasExplicitDefaultValue);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<long>(), serviceCollection.Services[0].Methods[0].Parameters[2].Type);
+        Assert.Equal("0", serviceCollection.Services[0].Methods[0].Parameters[2].DefaultValue);
+        Assert.True(serviceCollection.Services[0].Methods[0].Parameters[2].HasExplicitDefaultValue);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Services[0].Methods[0].Parameters[3].Type);
+        Assert.Equal("null", serviceCollection.Services[0].Methods[0].Parameters[3].DefaultValue);
+        Assert.True(serviceCollection.Services[0].Methods[0].Parameters[3].HasExplicitDefaultValue);
     }
 
     [Fact]
@@ -417,12 +417,12 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().HaveCount(1);
-        serviceCollection.Services[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"));
-        serviceCollection.Services[0].Methods.Should().HaveCount(4);
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
+        Assert.Equal(4, serviceCollection.Services[0].Methods.Count());
     }
 
     [Fact]
@@ -451,8 +451,8 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        diagnostics.Should().HaveCount(1);
-        diagnostics[0].Id.Should().Be(MagicOnionDiagnosticDescriptors.UnaryUnsupportedMethodReturnType.Id);
+        Assert.Equal(1, diagnostics.Count());
+        Assert.Equal(MagicOnionDiagnosticDescriptors.UnaryUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
     [Fact]
@@ -481,8 +481,8 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        diagnostics.Should().HaveCount(1);
-        diagnostics[0].Id.Should().Be(MagicOnionDiagnosticDescriptors.UnaryUnsupportedMethodReturnType.Id);
+        Assert.Equal(1, diagnostics.Count());
+        Assert.Equal(MagicOnionDiagnosticDescriptors.UnaryUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
     [Fact]
@@ -511,8 +511,8 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        diagnostics.Should().HaveCount(1);
-        diagnostics[0].Id.Should().Be(MagicOnionDiagnosticDescriptors.UnaryUnsupportedMethodReturnType.Id);
+        Assert.Equal(1, diagnostics.Count());
+        Assert.Equal(MagicOnionDiagnosticDescriptors.UnaryUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
     [Fact]
@@ -541,8 +541,8 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        diagnostics.Should().HaveCount(1);
-        diagnostics[0].Id.Should().Be(MagicOnionDiagnosticDescriptors.ServiceUnsupportedMethodReturnType.Id);
+        Assert.Equal(1, diagnostics.Count());
+        Assert.Equal(MagicOnionDiagnosticDescriptors.ServiceUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
     [Fact]
@@ -570,19 +570,19 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().HaveCount(1);
-        serviceCollection.Services[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"));
-        serviceCollection.Services[0].Methods.Should().HaveCount(1);
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
+        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
         // Task<ServerStreamingResult<int>> ServerStreamingNoArg();
-        serviceCollection.Services[0].Methods[0].ServiceName.Should().Be("IMyService");
-        serviceCollection.Services[0].Methods[0].MethodName.Should().Be("ServerStreaming");
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<Nil>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Services[0].Methods[0].Parameters.Should().BeEmpty();
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<Task<ServerStreamingResult<int>>>());
+        Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
+        Assert.Equal("ServerStreaming", serviceCollection.Services[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Nil>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Empty(serviceCollection.Services[0].Methods[0].Parameters);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Task<ServerStreamingResult<int>>>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -610,20 +610,20 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().HaveCount(1);
-        serviceCollection.Services[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"));
-        serviceCollection.Services[0].Methods.Should().HaveCount(1);
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
+        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
         // Task<ServerStreamingResult<int>> ServerStreamingNoArg();
-        serviceCollection.Services[0].Methods[0].ServiceName.Should().Be("IMyService");
-        serviceCollection.Services[0].Methods[0].MethodName.Should().Be("ServerStreaming");
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Services[0].Methods[0].Parameters[0].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Services[0].Methods[0].Parameters[0].Name.Should().Be("arg1");
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<Task<ServerStreamingResult<int>>>());
+        Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
+        Assert.Equal("ServerStreaming", serviceCollection.Services[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Services[0].Methods[0].Parameters[0].Type);
+        Assert.Equal("arg1", serviceCollection.Services[0].Methods[0].Parameters[0].Name);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Task<ServerStreamingResult<int>>>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -651,22 +651,22 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().HaveCount(1);
-        serviceCollection.Services[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"));
-        serviceCollection.Services[0].Methods.Should().HaveCount(1);
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
+        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
         // Task<ServerStreamingResult<int>> ServerStreamingNoArg();
-        serviceCollection.Services[0].Methods[0].ServiceName.Should().Be("IMyService");
-        serviceCollection.Services[0].Methods[0].MethodName.Should().Be("ServerStreaming");
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<string, int>>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Services[0].Methods[0].Parameters[0].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Services[0].Methods[0].Parameters[0].Name.Should().Be("arg1");
-        serviceCollection.Services[0].Methods[0].Parameters[1].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Services[0].Methods[0].Parameters[1].Name.Should().Be("arg2");
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<Task<ServerStreamingResult<int>>>());
+        Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
+        Assert.Equal("ServerStreaming", serviceCollection.Services[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<string, int>>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Services[0].Methods[0].Parameters[0].Type);
+        Assert.Equal("arg1", serviceCollection.Services[0].Methods[0].Parameters[0].Name);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Services[0].Methods[0].Parameters[1].Type);
+        Assert.Equal("arg2", serviceCollection.Services[0].Methods[0].Parameters[1].Name);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Task<ServerStreamingResult<int>>>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -694,8 +694,8 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        diagnostics.Should().HaveCount(1);
-        diagnostics[0].Id.Should().Be(MagicOnionDiagnosticDescriptors.ServiceUnsupportedMethodReturnType.Id);
+        Assert.Equal(1, diagnostics.Count());
+        Assert.Equal(MagicOnionDiagnosticDescriptors.ServiceUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
 
@@ -724,19 +724,19 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().HaveCount(1);
-        serviceCollection.Services[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"));
-        serviceCollection.Services[0].Methods.Should().HaveCount(1);
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
+        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
         // Task<DuplexStreamingResult<int, string>> MethodA();
-        serviceCollection.Services[0].Methods[0].ServiceName.Should().Be("IMyService");
-        serviceCollection.Services[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Services[0].Methods[0].Parameters.Should().BeEmpty();
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<Task<DuplexStreamingResult<int, string>>>());
+        Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
+        Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Empty(serviceCollection.Services[0].Methods[0].Parameters);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Task<DuplexStreamingResult<int, string>>>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -764,8 +764,8 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        diagnostics.Should().HaveCount(1);
-        diagnostics[0].Id.Should().Be(MagicOnionDiagnosticDescriptors.StreamingMethodMustHaveNoParameters.Id);
+        Assert.Equal(1, diagnostics.Count());
+        Assert.Equal(MagicOnionDiagnosticDescriptors.StreamingMethodMustHaveNoParameters.Id, diagnostics[0].Id);
     }
 
     [Fact]
@@ -793,19 +793,19 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        compilation.GetDiagnostics(TestContext.Current.CancellationToken).Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().HaveCount(1);
-        serviceCollection.Services[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"));
-        serviceCollection.Services[0].Methods.Should().HaveCount(1);
+        Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
+        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
         // Task<DuplexStreamingResult<int, string>> MethodA();
-        serviceCollection.Services[0].Methods[0].ServiceName.Should().Be("IMyService");
-        serviceCollection.Services[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Services[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Services[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Services[0].Methods[0].Parameters.Should().BeEmpty();
-        serviceCollection.Services[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<Task<ClientStreamingResult<int, string>>>());
+        Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
+        Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Services[0].Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Services[0].Methods[0].ResponseType);
+        Assert.Empty(serviceCollection.Services[0].Methods[0].Parameters);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Task<ClientStreamingResult<int, string>>>(), serviceCollection.Services[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -833,7 +833,7 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        diagnostics.Should().HaveCount(1);
-        diagnostics[0].Id.Should().Be(MagicOnionDiagnosticDescriptors.StreamingMethodMustHaveNoParameters.Id);
+        Assert.Equal(1, diagnostics.Count());
+        Assert.Equal(MagicOnionDiagnosticDescriptors.StreamingMethodMustHaveNoParameters.Id, diagnostics[0].Id);
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MethodCollectorServicesTest.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MethodCollectorServicesTest.cs
@@ -40,7 +40,7 @@ public interface IMyService : IService<IMyService>
         Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
         Assert.NotNull(serviceCollection);
         Assert.Empty(serviceCollection.Hubs);
-        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Single(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
         Assert.Equal(2, serviceCollection.Services[0].Methods.Count());
         Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
@@ -208,9 +208,9 @@ namespace MyNamespace
         Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
         Assert.NotNull(serviceCollection);
         Assert.Empty(serviceCollection.Hubs);
-        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Single(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
-        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
+        Assert.Single(serviceCollection.Services[0].Methods);
         // UnaryResult<Nil> MethodA();
         Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
         Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
@@ -250,9 +250,9 @@ namespace MyNamespace
         Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
         Assert.NotNull(serviceCollection);
         Assert.Empty(serviceCollection.Hubs);
-        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Single(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
-        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
+        Assert.Single(serviceCollection.Services[0].Methods);
         // UnaryResult<string> MethodA();
         Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
         Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
@@ -291,9 +291,9 @@ namespace MyNamespace
         Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
         Assert.NotNull(serviceCollection);
         Assert.Empty(serviceCollection.Hubs);
-        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Single(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
-        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
+        Assert.Single(serviceCollection.Services[0].Methods);
         // UnaryResult<Nil> MethodA(string arg1);
         Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
         Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
@@ -333,9 +333,9 @@ namespace MyNamespace
         Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
         Assert.NotNull(serviceCollection);
         Assert.Empty(serviceCollection.Hubs);
-        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Single(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
-        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
+        Assert.Single(serviceCollection.Services[0].Methods);
         // UnaryResult<Nil> MethodA(string arg1, int arg2);
         Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
         Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
@@ -420,7 +420,7 @@ namespace MyNamespace
         Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
         Assert.NotNull(serviceCollection);
         Assert.Empty(serviceCollection.Hubs);
-        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Single(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
         Assert.Equal(4, serviceCollection.Services[0].Methods.Count());
     }
@@ -451,7 +451,7 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, diagnostics.Count());
+        Assert.Single(diagnostics);
         Assert.Equal(MagicOnionDiagnosticDescriptors.UnaryUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
@@ -481,7 +481,7 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, diagnostics.Count());
+        Assert.Single(diagnostics);
         Assert.Equal(MagicOnionDiagnosticDescriptors.UnaryUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
@@ -511,7 +511,7 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, diagnostics.Count());
+        Assert.Single(diagnostics);
         Assert.Equal(MagicOnionDiagnosticDescriptors.UnaryUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
@@ -541,7 +541,7 @@ namespace MyNamespace
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, diagnostics.Count());
+        Assert.Single(diagnostics);
         Assert.Equal(MagicOnionDiagnosticDescriptors.ServiceUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
@@ -573,9 +573,9 @@ public interface IMyService : IService<IMyService>
         Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
         Assert.NotNull(serviceCollection);
         Assert.Empty(serviceCollection.Hubs);
-        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Single(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
-        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
+        Assert.Single(serviceCollection.Services[0].Methods);
         // Task<ServerStreamingResult<int>> ServerStreamingNoArg();
         Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
         Assert.Equal("ServerStreaming", serviceCollection.Services[0].Methods[0].MethodName);
@@ -613,9 +613,9 @@ public interface IMyService : IService<IMyService>
         Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
         Assert.NotNull(serviceCollection);
         Assert.Empty(serviceCollection.Hubs);
-        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Single(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
-        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
+        Assert.Single(serviceCollection.Services[0].Methods);
         // Task<ServerStreamingResult<int>> ServerStreamingNoArg();
         Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
         Assert.Equal("ServerStreaming", serviceCollection.Services[0].Methods[0].MethodName);
@@ -654,9 +654,9 @@ public interface IMyService : IService<IMyService>
         Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
         Assert.NotNull(serviceCollection);
         Assert.Empty(serviceCollection.Hubs);
-        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Single(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
-        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
+        Assert.Single(serviceCollection.Services[0].Methods);
         // Task<ServerStreamingResult<int>> ServerStreamingNoArg();
         Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
         Assert.Equal("ServerStreaming", serviceCollection.Services[0].Methods[0].MethodName);
@@ -694,7 +694,7 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, diagnostics.Count());
+        Assert.Single(diagnostics);
         Assert.Equal(MagicOnionDiagnosticDescriptors.ServiceUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
@@ -727,9 +727,9 @@ public interface IMyService : IService<IMyService>
         Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
         Assert.NotNull(serviceCollection);
         Assert.Empty(serviceCollection.Hubs);
-        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Single(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
-        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
+        Assert.Single(serviceCollection.Services[0].Methods);
         // Task<DuplexStreamingResult<int, string>> MethodA();
         Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
         Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
@@ -764,7 +764,7 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, diagnostics.Count());
+        Assert.Single(diagnostics);
         Assert.Equal(MagicOnionDiagnosticDescriptors.StreamingMethodMustHaveNoParameters.Id, diagnostics[0].Id);
     }
 
@@ -796,9 +796,9 @@ public interface IMyService : IService<IMyService>
         Assert.DoesNotContain(compilation.GetDiagnostics(TestContext.Current.CancellationToken), x => x.Severity == DiagnosticSeverity.Error);
         Assert.NotNull(serviceCollection);
         Assert.Empty(serviceCollection.Hubs);
-        Assert.Equal(1, serviceCollection.Services.Count());
+        Assert.Single(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyService"), serviceCollection.Services[0].ServiceType);
-        Assert.Equal(1, serviceCollection.Services[0].Methods.Count());
+        Assert.Single(serviceCollection.Services[0].Methods);
         // Task<DuplexStreamingResult<int, string>> MethodA();
         Assert.Equal("IMyService", serviceCollection.Services[0].Methods[0].ServiceName);
         Assert.Equal("MethodA", serviceCollection.Services[0].Methods[0].MethodName);
@@ -833,7 +833,7 @@ public interface IMyService : IService<IMyService>
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, diagnostics.Count());
+        Assert.Single(diagnostics);
         Assert.Equal(MagicOnionDiagnosticDescriptors.StreamingMethodMustHaveNoParameters.Id, diagnostics[0].Id);
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MethodCollectorStreamingHubsTest.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MethodCollectorStreamingHubsTest.cs
@@ -41,13 +41,13 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().HaveCount(1);
-        serviceCollection.Services.Should().BeEmpty();
-        serviceCollection.Hubs[0].ServiceType.Should().Be(MagicOnionTypeInfo.Create("MyNamespace", "IMyHub"));
-        serviceCollection.Hubs[0].Methods.Should().HaveCount(2);
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[1].MethodName.Should().Be("MethodC");
+        Assert.NotNull(serviceCollection);
+        Assert.Equal(1, serviceCollection.Hubs.Count());
+        Assert.Empty(serviceCollection.Services);
+        Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyHub"), serviceCollection.Hubs[0].ServiceType);
+        Assert.Equal(2, serviceCollection.Hubs[0].Methods.Count());
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal("MethodC", serviceCollection.Hubs[0].Methods[1].MethodName);
     }
 
     [Fact]
@@ -81,10 +81,10 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().BeEmpty();
-        serviceCollection.Services.Should().BeEmpty();
-        serviceCollection.Hubs.Should().BeEmpty();
+        Assert.NotNull(serviceCollection);
+        Assert.Empty(serviceCollection.Hubs);
+        Assert.Empty(serviceCollection.Services);
+        Assert.Empty(serviceCollection.Hubs);
     }
 
     [Fact]
@@ -118,9 +118,9 @@ public interface IMyHubReceiver
 
         // Assert
         // Task MethodA();
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<Nil>());
-        serviceCollection.Hubs[0].Methods[0].Parameters.Should().BeEmpty();
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Nil>(), serviceCollection.Hubs[0].Methods[0].RequestType);
+        Assert.Empty(serviceCollection.Hubs[0].Methods[0].Parameters);
     }
 
     [Fact]
@@ -154,13 +154,13 @@ public interface IMyHubReceiver
 
         // Assert
         // Task MethodA();
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Hubs[0].Methods[0].Parameters.Should().HaveCount(1);
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].Name.Should().Be("arg1");
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].HasExplicitDefaultValue.Should().BeFalse();
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].DefaultValue.Should().Be("default(int)");
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Hubs[0].Methods[0].RequestType);
+        Assert.Equal(1, serviceCollection.Hubs[0].Methods[0].Parameters.Count());
+        Assert.Equal("arg1", serviceCollection.Hubs[0].Methods[0].Parameters[0].Name);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Hubs[0].Methods[0].Parameters[0].Type);
+        Assert.False(serviceCollection.Hubs[0].Methods[0].Parameters[0].HasExplicitDefaultValue);
+        Assert.Equal("default(int)", serviceCollection.Hubs[0].Methods[0].Parameters[0].DefaultValue);
     }
 
     [Fact]
@@ -194,17 +194,17 @@ public interface IMyHubReceiver
 
         // Assert
         // Task MethodA();
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<int, string>>());
-        serviceCollection.Hubs[0].Methods[0].Parameters.Should().HaveCount(2);
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].Name.Should().Be("arg1");
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].HasExplicitDefaultValue.Should().BeFalse();
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].DefaultValue.Should().Be("default(int)");
-        serviceCollection.Hubs[0].Methods[0].Parameters[1].Name.Should().Be("arg2");
-        serviceCollection.Hubs[0].Methods[0].Parameters[1].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Hubs[0].Methods[0].Parameters[1].HasExplicitDefaultValue.Should().BeFalse();
-        serviceCollection.Hubs[0].Methods[0].Parameters[1].DefaultValue.Should().Be("default(string)");
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<int, string>>(), serviceCollection.Hubs[0].Methods[0].RequestType);
+        Assert.Equal(2, serviceCollection.Hubs[0].Methods[0].Parameters.Count());
+        Assert.Equal("arg1", serviceCollection.Hubs[0].Methods[0].Parameters[0].Name);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Hubs[0].Methods[0].Parameters[0].Type);
+        Assert.False(serviceCollection.Hubs[0].Methods[0].Parameters[0].HasExplicitDefaultValue);
+        Assert.Equal("default(int)", serviceCollection.Hubs[0].Methods[0].Parameters[0].DefaultValue);
+        Assert.Equal("arg2", serviceCollection.Hubs[0].Methods[0].Parameters[1].Name);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Hubs[0].Methods[0].Parameters[1].Type);
+        Assert.False(serviceCollection.Hubs[0].Methods[0].Parameters[1].HasExplicitDefaultValue);
+        Assert.Equal("default(string)", serviceCollection.Hubs[0].Methods[0].Parameters[1].DefaultValue);
     }
 
 
@@ -239,17 +239,17 @@ public interface IMyHubReceiver
 
         // Assert
         // Task MethodA();
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<int, string>>());
-        serviceCollection.Hubs[0].Methods[0].Parameters.Should().HaveCount(2);
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].Name.Should().Be("arg1");
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].HasExplicitDefaultValue.Should().BeFalse();
-        serviceCollection.Hubs[0].Methods[0].Parameters[0].DefaultValue.Should().Be("default(int)");
-        serviceCollection.Hubs[0].Methods[0].Parameters[1].Name.Should().Be("arg2");
-        serviceCollection.Hubs[0].Methods[0].Parameters[1].Type.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Hubs[0].Methods[0].Parameters[1].HasExplicitDefaultValue.Should().BeTrue();
-        serviceCollection.Hubs[0].Methods[0].Parameters[1].DefaultValue.Should().Be("\"DEFAULT\"");
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<int, string>>(), serviceCollection.Hubs[0].Methods[0].RequestType);
+        Assert.Equal(2, serviceCollection.Hubs[0].Methods[0].Parameters.Count());
+        Assert.Equal("arg1", serviceCollection.Hubs[0].Methods[0].Parameters[0].Name);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Hubs[0].Methods[0].Parameters[0].Type);
+        Assert.False(serviceCollection.Hubs[0].Methods[0].Parameters[0].HasExplicitDefaultValue);
+        Assert.Equal("default(int)", serviceCollection.Hubs[0].Methods[0].Parameters[0].DefaultValue);
+        Assert.Equal("arg2", serviceCollection.Hubs[0].Methods[0].Parameters[1].Name);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Hubs[0].Methods[0].Parameters[1].Type);
+        Assert.True(serviceCollection.Hubs[0].Methods[0].Parameters[1].HasExplicitDefaultValue);
+        Assert.Equal("\"DEFAULT\"", serviceCollection.Hubs[0].Methods[0].Parameters[1].DefaultValue);
     }
 
     [Fact]
@@ -282,15 +282,15 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().HaveCount(1);
-        serviceCollection.Hubs[0].Methods.Should().HaveCount(1);
+        Assert.NotNull(serviceCollection);
+        Assert.Equal(1, serviceCollection.Hubs.Count());
+        Assert.Equal(1, serviceCollection.Hubs[0].Methods.Count());
         // Task MethodA();
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[0].HubId.Should().Be(1497325507);
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal(1497325507, serviceCollection.Hubs[0].Methods[0].HubId);
         // void EventA();
-        serviceCollection.Hubs[0].Receiver.Methods[0].MethodName.Should().Be("EventA");
-        serviceCollection.Hubs[0].Receiver.Methods[0].HubId.Should().Be(842297178);
+        Assert.Equal("EventA", serviceCollection.Hubs[0].Receiver.Methods[0].MethodName);
+        Assert.Equal(842297178, serviceCollection.Hubs[0].Receiver.Methods[0].HubId);
     }
 
     [Fact]
@@ -327,15 +327,15 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().HaveCount(1);
-        serviceCollection.Hubs[0].Methods.Should().HaveCount(1);
+        Assert.NotNull(serviceCollection);
+        Assert.Equal(1, serviceCollection.Hubs.Count());
+        Assert.Equal(1, serviceCollection.Hubs[0].Methods.Count());
         // Task MethodA();
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[0].HubId.Should().Be(12345);
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal(12345, serviceCollection.Hubs[0].Methods[0].HubId);
         // void EventA();
-        serviceCollection.Hubs[0].Receiver.Methods[0].MethodName.Should().Be("EventA");
-        serviceCollection.Hubs[0].Receiver.Methods[0].HubId.Should().Be(67890);
+        Assert.Equal("EventA", serviceCollection.Hubs[0].Receiver.Methods[0].MethodName);
+        Assert.Equal(67890, serviceCollection.Hubs[0].Receiver.Methods[0].HubId);
     }
 
     [Fact]
@@ -368,8 +368,8 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        diagnostics.Should().HaveCount(1);
-        diagnostics[0].Id.Should().Be(MagicOnionDiagnosticDescriptors.StreamingHubUnsupportedMethodReturnType.Id);
+        Assert.Equal(1, diagnostics.Count());
+        Assert.Equal(MagicOnionDiagnosticDescriptors.StreamingHubUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
     [Fact]
@@ -402,9 +402,9 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
-        serviceCollection.Hubs[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_Threading_Tasks_Task);
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.System_Threading_Tasks_Task, serviceCollection.Hubs[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -437,9 +437,9 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_String);
-        serviceCollection.Hubs[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<Task<string>>());
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.System_String, serviceCollection.Hubs[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Task<string>>(), serviceCollection.Hubs[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -472,9 +472,9 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
-        serviceCollection.Hubs[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_Threading_Tasks_ValueTask);
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.System_Threading_Tasks_ValueTask, serviceCollection.Hubs[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -507,9 +507,9 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_String);
-        serviceCollection.Hubs[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<ValueTask<string>>());
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.System_String, serviceCollection.Hubs[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<ValueTask<string>>(), serviceCollection.Hubs[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -542,9 +542,9 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Hubs[0].Methods[0].MethodName.Should().Be("MethodA");
-        serviceCollection.Hubs[0].Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
-        serviceCollection.Hubs[0].Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_Void);
+        Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.System_Void, serviceCollection.Hubs[0].Methods[0].MethodReturnType);
     }
 
     [Fact]
@@ -579,32 +579,32 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().HaveCount(1);
-        serviceCollection.Hubs[0].Methods.Should().HaveCount(1);
-        serviceCollection.Hubs[0].Receiver.Should().NotBeNull();
-        serviceCollection.Hubs[0].Receiver.Methods.Should().HaveCount(3);
+        Assert.NotNull(serviceCollection);
+        Assert.Equal(1, serviceCollection.Hubs.Count());
+        Assert.Equal(1, serviceCollection.Hubs[0].Methods.Count());
+        Assert.NotNull(serviceCollection.Hubs[0].Receiver);
+        Assert.Equal(3, serviceCollection.Hubs[0].Receiver.Methods.Count());
         // void EventA();
-        serviceCollection.Hubs[0].Receiver.Methods[0].MethodName.Should().Be("EventA");
-        serviceCollection.Hubs[0].Receiver.Methods[0].IsClientResult.Should().BeFalse();
-        serviceCollection.Hubs[0].Receiver.Methods[0].Parameters.Should().BeEmpty();
-        serviceCollection.Hubs[0].Receiver.Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
-        serviceCollection.Hubs[0].Receiver.Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
-        serviceCollection.Hubs[0].Receiver.Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_Void);
+        Assert.Equal("EventA", serviceCollection.Hubs[0].Receiver.Methods[0].MethodName);
+        Assert.False(serviceCollection.Hubs[0].Receiver.Methods[0].IsClientResult);
+        Assert.Empty(serviceCollection.Hubs[0].Receiver.Methods[0].Parameters);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Receiver.Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Receiver.Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.System_Void, serviceCollection.Hubs[0].Receiver.Methods[0].MethodReturnType);
         // void EventB(Nil nil);
-        serviceCollection.Hubs[0].Receiver.Methods[1].MethodName.Should().Be("EventB");
-        serviceCollection.Hubs[0].Receiver.Methods[1].IsClientResult.Should().BeFalse();
-        serviceCollection.Hubs[0].Receiver.Methods[1].Parameters.Should().HaveCount(1);
-        serviceCollection.Hubs[0].Receiver.Methods[1].RequestType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
-        serviceCollection.Hubs[0].Receiver.Methods[1].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
-        serviceCollection.Hubs[0].Receiver.Methods[1].MethodReturnType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_Void);
+        Assert.Equal("EventB", serviceCollection.Hubs[0].Receiver.Methods[1].MethodName);
+        Assert.False(serviceCollection.Hubs[0].Receiver.Methods[1].IsClientResult);
+        Assert.Equal(1, serviceCollection.Hubs[0].Receiver.Methods[1].Parameters.Count());
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Receiver.Methods[1].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Receiver.Methods[1].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.System_Void, serviceCollection.Hubs[0].Receiver.Methods[1].MethodReturnType);
         // void EventB(Nil nil);
-        serviceCollection.Hubs[0].Receiver.Methods[2].MethodName.Should().Be("EventC");
-        serviceCollection.Hubs[0].Receiver.Methods[2].IsClientResult.Should().BeFalse();
-        serviceCollection.Hubs[0].Receiver.Methods[2].Parameters.Should().HaveCount(2);
-        serviceCollection.Hubs[0].Receiver.Methods[2].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<string, int>>());
-        serviceCollection.Hubs[0].Receiver.Methods[2].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
-        serviceCollection.Hubs[0].Receiver.Methods[2].MethodReturnType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_Void);
+        Assert.Equal("EventC", serviceCollection.Hubs[0].Receiver.Methods[2].MethodName);
+        Assert.False(serviceCollection.Hubs[0].Receiver.Methods[2].IsClientResult);
+        Assert.Equal(2, serviceCollection.Hubs[0].Receiver.Methods[2].Parameters.Count());
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<string, int>>(), serviceCollection.Hubs[0].Receiver.Methods[2].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Receiver.Methods[2].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.System_Void, serviceCollection.Hubs[0].Receiver.Methods[2].MethodReturnType);
     }
 
     [Fact]
@@ -641,39 +641,39 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().HaveCount(1);
-        serviceCollection.Hubs[0].Methods.Should().HaveCount(1);
-        serviceCollection.Hubs[0].Receiver.Should().NotBeNull();
-        serviceCollection.Hubs[0].Receiver.Methods.Should().HaveCount(4);
+        Assert.NotNull(serviceCollection);
+        Assert.Equal(1, serviceCollection.Hubs.Count());
+        Assert.Equal(1, serviceCollection.Hubs[0].Methods.Count());
+        Assert.NotNull(serviceCollection.Hubs[0].Receiver);
+        Assert.Equal(4, serviceCollection.Hubs[0].Receiver.Methods.Count());
         // Task ClientResultA();
-        serviceCollection.Hubs[0].Receiver.Methods[0].MethodName.Should().Be("ClientResultA");
-        serviceCollection.Hubs[0].Receiver.Methods[0].IsClientResult.Should().BeTrue();
-        serviceCollection.Hubs[0].Receiver.Methods[0].Parameters.Should().BeEmpty();
-        serviceCollection.Hubs[0].Receiver.Methods[0].RequestType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
-        serviceCollection.Hubs[0].Receiver.Methods[0].ResponseType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
-        serviceCollection.Hubs[0].Receiver.Methods[0].MethodReturnType.Should().Be(MagicOnionTypeInfo.KnownTypes.System_Threading_Tasks_Task);
+        Assert.Equal("ClientResultA", serviceCollection.Hubs[0].Receiver.Methods[0].MethodName);
+        Assert.True(serviceCollection.Hubs[0].Receiver.Methods[0].IsClientResult);
+        Assert.Empty(serviceCollection.Hubs[0].Receiver.Methods[0].Parameters);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Receiver.Methods[0].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Receiver.Methods[0].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.System_Threading_Tasks_Task, serviceCollection.Hubs[0].Receiver.Methods[0].MethodReturnType);
         // Task<int> ClientResultB(Nil nil);
-        serviceCollection.Hubs[0].Receiver.Methods[1].MethodName.Should().Be("ClientResultB");
-        serviceCollection.Hubs[0].Receiver.Methods[1].IsClientResult.Should().BeTrue();
-        serviceCollection.Hubs[0].Receiver.Methods[1].Parameters.Should().HaveCount(1);
-        serviceCollection.Hubs[0].Receiver.Methods[1].RequestType.Should().Be(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil);
-        serviceCollection.Hubs[0].Receiver.Methods[1].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<int>());
-        serviceCollection.Hubs[0].Receiver.Methods[1].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<Task<int>>());
+        Assert.Equal("ClientResultB", serviceCollection.Hubs[0].Receiver.Methods[1].MethodName);
+        Assert.True(serviceCollection.Hubs[0].Receiver.Methods[1].IsClientResult);
+        Assert.Equal(1, serviceCollection.Hubs[0].Receiver.Methods[1].Parameters.Count());
+        Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Receiver.Methods[1].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Hubs[0].Receiver.Methods[1].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Task<int>>(), serviceCollection.Hubs[0].Receiver.Methods[1].MethodReturnType);
         // Task<string> ClientResultC(string arg1, int arg2);
-        serviceCollection.Hubs[0].Receiver.Methods[2].MethodName.Should().Be("ClientResultC");
-        serviceCollection.Hubs[0].Receiver.Methods[2].IsClientResult.Should().BeTrue();
-        serviceCollection.Hubs[0].Receiver.Methods[2].Parameters.Should().HaveCount(2);
-        serviceCollection.Hubs[0].Receiver.Methods[2].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<string, int>>());
-        serviceCollection.Hubs[0].Receiver.Methods[2].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Hubs[0].Receiver.Methods[2].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<Task<string>>());
+        Assert.Equal("ClientResultC", serviceCollection.Hubs[0].Receiver.Methods[2].MethodName);
+        Assert.True(serviceCollection.Hubs[0].Receiver.Methods[2].IsClientResult);
+        Assert.Equal(2, serviceCollection.Hubs[0].Receiver.Methods[2].Parameters.Count());
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<string, int>>(), serviceCollection.Hubs[0].Receiver.Methods[2].RequestType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Hubs[0].Receiver.Methods[2].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Task<string>>(), serviceCollection.Hubs[0].Receiver.Methods[2].MethodReturnType);
         // Task<string> ClientResultD(string arg1, int arg2, CancellationToken cancellationToken);
-        serviceCollection.Hubs[0].Receiver.Methods[3].MethodName.Should().Be("ClientResultD");
-        serviceCollection.Hubs[0].Receiver.Methods[3].IsClientResult.Should().BeTrue();
-        serviceCollection.Hubs[0].Receiver.Methods[3].Parameters.Should().HaveCount(3);
-        serviceCollection.Hubs[0].Receiver.Methods[3].RequestType.Should().Be(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<string, int>>()); // Skip CancellationToken
-        serviceCollection.Hubs[0].Receiver.Methods[3].ResponseType.Should().Be(MagicOnionTypeInfo.CreateFromType<string>());
-        serviceCollection.Hubs[0].Receiver.Methods[3].MethodReturnType.Should().Be(MagicOnionTypeInfo.CreateFromType<Task<string>>());
+        Assert.Equal("ClientResultD", serviceCollection.Hubs[0].Receiver.Methods[3].MethodName);
+        Assert.True(serviceCollection.Hubs[0].Receiver.Methods[3].IsClientResult);
+        Assert.Equal(3, serviceCollection.Hubs[0].Receiver.Methods[3].Parameters.Count());
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<DynamicArgumentTuple<string, int>>(), serviceCollection.Hubs[0].Receiver.Methods[3].RequestType); // Skip CancellationToken
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<string>(), serviceCollection.Hubs[0].Receiver.Methods[3].ResponseType);
+        Assert.Equal(MagicOnionTypeInfo.CreateFromType<Task<string>>(), serviceCollection.Hubs[0].Receiver.Methods[3].MethodReturnType);
     }
 
     [Fact]
@@ -706,8 +706,8 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        diagnostics.Should().HaveCount(1);
-        diagnostics[0].Id.Should().Be(MagicOnionDiagnosticDescriptors.StreamingHubUnsupportedReceiverMethodReturnType.Id);
+        Assert.Equal(1, diagnostics.Count());
+        Assert.Equal(MagicOnionDiagnosticDescriptors.StreamingHubUnsupportedReceiverMethodReturnType.Id, diagnostics[0].Id);
     }
 
     [Fact]
@@ -743,7 +743,7 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        diagnostics.Should().BeEmpty();
+        Assert.Empty(diagnostics);
     }
 
     [Fact]
@@ -780,8 +780,8 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        diagnostics.Should().HaveCount(1);
-        diagnostics[0].Id.Should().Be(MagicOnionDiagnosticDescriptors.StreamingHubInterfaceHasTwoOrMoreIStreamingHub.Id);
+        Assert.Equal(1, diagnostics.Count());
+        Assert.Equal(MagicOnionDiagnosticDescriptors.StreamingHubInterfaceHasTwoOrMoreIStreamingHub.Id, diagnostics[0].Id);
     }
 
     [Fact]
@@ -823,9 +823,9 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().HaveCount(1);
-        serviceCollection.Hubs[0].Methods.Should().HaveCount(3);
+        Assert.NotNull(serviceCollection);
+        Assert.Equal(1, serviceCollection.Hubs.Count());
+        Assert.Equal(3, serviceCollection.Hubs[0].Methods.Count());
     }
     
     [Fact]
@@ -867,8 +867,8 @@ public interface IExtraReceiverMethods2
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        serviceCollection.Should().NotBeNull();
-        serviceCollection.Hubs.Should().HaveCount(1);
-        serviceCollection.Hubs[0].Receiver.Methods.Should().HaveCount(3);
+        Assert.NotNull(serviceCollection);
+        Assert.Equal(1, serviceCollection.Hubs.Count());
+        Assert.Equal(3, serviceCollection.Hubs[0].Receiver.Methods.Count());
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MethodCollectorStreamingHubsTest.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/MethodCollectorStreamingHubsTest.cs
@@ -42,7 +42,7 @@ public interface IMyHubReceiver
 
         // Assert
         Assert.NotNull(serviceCollection);
-        Assert.Equal(1, serviceCollection.Hubs.Count());
+        Assert.Single(serviceCollection.Hubs);
         Assert.Empty(serviceCollection.Services);
         Assert.Equal(MagicOnionTypeInfo.Create("MyNamespace", "IMyHub"), serviceCollection.Hubs[0].ServiceType);
         Assert.Equal(2, serviceCollection.Hubs[0].Methods.Count());
@@ -156,7 +156,7 @@ public interface IMyHubReceiver
         // Task MethodA();
         Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
         Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Hubs[0].Methods[0].RequestType);
-        Assert.Equal(1, serviceCollection.Hubs[0].Methods[0].Parameters.Count());
+        Assert.Single(serviceCollection.Hubs[0].Methods[0].Parameters);
         Assert.Equal("arg1", serviceCollection.Hubs[0].Methods[0].Parameters[0].Name);
         Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Hubs[0].Methods[0].Parameters[0].Type);
         Assert.False(serviceCollection.Hubs[0].Methods[0].Parameters[0].HasExplicitDefaultValue);
@@ -283,8 +283,8 @@ public interface IMyHubReceiver
 
         // Assert
         Assert.NotNull(serviceCollection);
-        Assert.Equal(1, serviceCollection.Hubs.Count());
-        Assert.Equal(1, serviceCollection.Hubs[0].Methods.Count());
+        Assert.Single(serviceCollection.Hubs);
+        Assert.Single(serviceCollection.Hubs[0].Methods);
         // Task MethodA();
         Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
         Assert.Equal(1497325507, serviceCollection.Hubs[0].Methods[0].HubId);
@@ -328,8 +328,8 @@ public interface IMyHubReceiver
 
         // Assert
         Assert.NotNull(serviceCollection);
-        Assert.Equal(1, serviceCollection.Hubs.Count());
-        Assert.Equal(1, serviceCollection.Hubs[0].Methods.Count());
+        Assert.Single(serviceCollection.Hubs);
+        Assert.Single(serviceCollection.Hubs[0].Methods);
         // Task MethodA();
         Assert.Equal("MethodA", serviceCollection.Hubs[0].Methods[0].MethodName);
         Assert.Equal(12345, serviceCollection.Hubs[0].Methods[0].HubId);
@@ -368,7 +368,7 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, diagnostics.Count());
+        Assert.Single(diagnostics);
         Assert.Equal(MagicOnionDiagnosticDescriptors.StreamingHubUnsupportedMethodReturnType.Id, diagnostics[0].Id);
     }
 
@@ -580,8 +580,8 @@ public interface IMyHubReceiver
 
         // Assert
         Assert.NotNull(serviceCollection);
-        Assert.Equal(1, serviceCollection.Hubs.Count());
-        Assert.Equal(1, serviceCollection.Hubs[0].Methods.Count());
+        Assert.Single(serviceCollection.Hubs);
+        Assert.Single(serviceCollection.Hubs[0].Methods);
         Assert.NotNull(serviceCollection.Hubs[0].Receiver);
         Assert.Equal(3, serviceCollection.Hubs[0].Receiver.Methods.Count());
         // void EventA();
@@ -594,7 +594,7 @@ public interface IMyHubReceiver
         // void EventB(Nil nil);
         Assert.Equal("EventB", serviceCollection.Hubs[0].Receiver.Methods[1].MethodName);
         Assert.False(serviceCollection.Hubs[0].Receiver.Methods[1].IsClientResult);
-        Assert.Equal(1, serviceCollection.Hubs[0].Receiver.Methods[1].Parameters.Count());
+        Assert.Single(serviceCollection.Hubs[0].Receiver.Methods[1].Parameters);
         Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Receiver.Methods[1].RequestType);
         Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Receiver.Methods[1].ResponseType);
         Assert.Equal(MagicOnionTypeInfo.KnownTypes.System_Void, serviceCollection.Hubs[0].Receiver.Methods[1].MethodReturnType);
@@ -642,8 +642,8 @@ public interface IMyHubReceiver
 
         // Assert
         Assert.NotNull(serviceCollection);
-        Assert.Equal(1, serviceCollection.Hubs.Count());
-        Assert.Equal(1, serviceCollection.Hubs[0].Methods.Count());
+        Assert.Single(serviceCollection.Hubs);
+        Assert.Single(serviceCollection.Hubs[0].Methods);
         Assert.NotNull(serviceCollection.Hubs[0].Receiver);
         Assert.Equal(4, serviceCollection.Hubs[0].Receiver.Methods.Count());
         // Task ClientResultA();
@@ -656,7 +656,7 @@ public interface IMyHubReceiver
         // Task<int> ClientResultB(Nil nil);
         Assert.Equal("ClientResultB", serviceCollection.Hubs[0].Receiver.Methods[1].MethodName);
         Assert.True(serviceCollection.Hubs[0].Receiver.Methods[1].IsClientResult);
-        Assert.Equal(1, serviceCollection.Hubs[0].Receiver.Methods[1].Parameters.Count());
+        Assert.Single(serviceCollection.Hubs[0].Receiver.Methods[1].Parameters);
         Assert.Equal(MagicOnionTypeInfo.KnownTypes.MessagePack_Nil, serviceCollection.Hubs[0].Receiver.Methods[1].RequestType);
         Assert.Equal(MagicOnionTypeInfo.CreateFromType<int>(), serviceCollection.Hubs[0].Receiver.Methods[1].ResponseType);
         Assert.Equal(MagicOnionTypeInfo.CreateFromType<Task<int>>(), serviceCollection.Hubs[0].Receiver.Methods[1].MethodReturnType);
@@ -706,7 +706,7 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, diagnostics.Count());
+        Assert.Single(diagnostics);
         Assert.Equal(MagicOnionDiagnosticDescriptors.StreamingHubUnsupportedReceiverMethodReturnType.Id, diagnostics[0].Id);
     }
 
@@ -780,7 +780,7 @@ public interface IMyHubReceiver
         var (serviceCollection, diagnostics) = MethodCollector.Collect(interfaceSymbols, referenceSymbols, CancellationToken.None);
 
         // Assert
-        Assert.Equal(1, diagnostics.Count());
+        Assert.Single(diagnostics);
         Assert.Equal(MagicOnionDiagnosticDescriptors.StreamingHubInterfaceHasTwoOrMoreIStreamingHub.Id, diagnostics[0].Id);
     }
 
@@ -824,7 +824,7 @@ public interface IMyHubReceiver
 
         // Assert
         Assert.NotNull(serviceCollection);
-        Assert.Equal(1, serviceCollection.Hubs.Count());
+        Assert.Single(serviceCollection.Hubs);
         Assert.Equal(3, serviceCollection.Hubs[0].Methods.Count());
     }
     
@@ -868,7 +868,7 @@ public interface IExtraReceiverMethods2
 
         // Assert
         Assert.NotNull(serviceCollection);
-        Assert.Equal(1, serviceCollection.Hubs.Count());
+        Assert.Single(serviceCollection.Hubs);
         Assert.Equal(3, serviceCollection.Hubs[0].Receiver.Methods.Count());
     }
 }

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/SerializationInfoCollectorTest.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Collector/SerializationInfoCollectorTest.cs
@@ -27,10 +27,10 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Enums.Should().BeEmpty();
-        serializationInfoCollection.Generics.Should().BeEmpty();
-        serializationInfoCollection.TypeHints.Should().HaveCount(3);
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Empty(serializationInfoCollection.Enums);
+        Assert.Empty(serializationInfoCollection.Generics);
+        Assert.Equal(3, serializationInfoCollection.TypeHints.Count());
     }
 
     [Fact]
@@ -48,12 +48,12 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Enums.Should().BeEmpty();
-        serializationInfoCollection.Generics.Should().HaveCount(2);
-        serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.NullableFormatter<global::MyNamespace.MyGenericObject>()");
-        serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.NullableFormatter<global::MyNamespace.YetAnotherGenericObject>()");
-        serializationInfoCollection.TypeHints.Should().HaveCount(4); // Non-nullable + Nullable
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Empty(serializationInfoCollection.Enums);
+        Assert.Equal(2, serializationInfoCollection.Generics.Count());
+        Assert.Equal("global::MessagePack.Formatters.NullableFormatter<global::MyNamespace.MyGenericObject>()", serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.NullableFormatter<global::MyNamespace.YetAnotherGenericObject>()", serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs());
+        Assert.Equal(4, serializationInfoCollection.TypeHints.Count()); // Non-nullable + Nullable
     }
 
     [Fact]
@@ -71,11 +71,11 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Generics.Should().HaveCount(2);
-        serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.MyNamespace.MyGenericObjectFormatter<global::System.String, global::System.Int64>()");
-        serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.MyNamespace.MyGenericObjectFormatter<global::System.String, global::System.Int32>()");
-        serializationInfoCollection.TypeHints.Should().HaveCount(5); // string, int, long, MyGenericObject<string, long>, MyGenericObject<string, int>
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Equal(2, serializationInfoCollection.Generics.Count());
+        Assert.Equal("global::MessagePack.Formatters.MyNamespace.MyGenericObjectFormatter<global::System.String, global::System.Int64>()", serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.MyNamespace.MyGenericObjectFormatter<global::System.String, global::System.Int32>()", serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs());
+        Assert.Equal(5, serializationInfoCollection.TypeHints.Count()); // string, int, long, MyGenericObject<string, long>, MyGenericObject<string, int>
     }
 
     [Fact]
@@ -96,19 +96,19 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Generics.Should().HaveCount(3);
-        serializationInfoCollection.Enums.Should().HaveCount(3);
-        serializationInfoCollection.Enums[0].Namespace.Should().Be("MyNamespace");
-        serializationInfoCollection.Enums[0].Name.Should().Be("MyEnum");
-        serializationInfoCollection.Enums[0].GetFormatterNameWithConstructorArgs().Should().Be("MyEnumFormatter()");
-        serializationInfoCollection.Enums[1].Namespace.Should().Be("MyNamespace");
-        serializationInfoCollection.Enums[1].Name.Should().Be("MyEnumConditional");
-        serializationInfoCollection.Enums[1].GetFormatterNameWithConstructorArgs().Should().Be("MyEnumConditionalFormatter()");
-        serializationInfoCollection.Enums[2].Namespace.Should().Be("MyNamespace");
-        serializationInfoCollection.Enums[2].Name.Should().Be("YetAnotherEnum");
-        serializationInfoCollection.Enums[2].GetFormatterNameWithConstructorArgs().Should().Be("YetAnotherEnumFormatter()");
-        serializationInfoCollection.TypeHints.Should().HaveCount(6); // MyEnum, MyEnumConditional, YetAnotherEnum, MyGenericObject<MyEnum>, MyGenericObject<MyEnumConditional>, MyGenericObject<YetAnotherEnum>
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Equal(3, serializationInfoCollection.Generics.Count());
+        Assert.Equal(3, serializationInfoCollection.Enums.Count());
+        Assert.Equal("MyNamespace", serializationInfoCollection.Enums[0].Namespace);
+        Assert.Equal("MyEnum", serializationInfoCollection.Enums[0].Name);
+        Assert.Equal("MyEnumFormatter()", serializationInfoCollection.Enums[0].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("MyNamespace", serializationInfoCollection.Enums[1].Namespace);
+        Assert.Equal("MyEnumConditional", serializationInfoCollection.Enums[1].Name);
+        Assert.Equal("MyEnumConditionalFormatter()", serializationInfoCollection.Enums[1].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("MyNamespace", serializationInfoCollection.Enums[2].Namespace);
+        Assert.Equal("YetAnotherEnum", serializationInfoCollection.Enums[2].Name);
+        Assert.Equal("YetAnotherEnumFormatter()", serializationInfoCollection.Enums[2].GetFormatterNameWithConstructorArgs());
+        Assert.Equal(6, serializationInfoCollection.TypeHints.Count()); // MyEnum, MyEnumConditional, YetAnotherEnum, MyGenericObject<MyEnum>, MyGenericObject<MyEnumConditional>, MyGenericObject<YetAnotherEnum>
     }
         
     [Fact]
@@ -126,9 +126,9 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Generics.Should().BeEmpty();
-        serializationInfoCollection.TypeHints.Should().HaveCount(3); // byte, ArraySegment<byte>, Nullable<ArraySegment<byte>>
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Empty(serializationInfoCollection.Generics);
+        Assert.Equal(3, serializationInfoCollection.TypeHints.Count()); // byte, ArraySegment<byte>, Nullable<ArraySegment<byte>>
     }
 
     [Fact]
@@ -167,9 +167,9 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Generics.Should().BeEmpty();
-        serializationInfoCollection.TypeHints.Should().HaveCount(46);
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Empty(serializationInfoCollection.Generics);
+        Assert.Equal(46, serializationInfoCollection.TypeHints.Count());
     }  
     
     [Fact]
@@ -189,13 +189,13 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Generics.Should().HaveCount(4);
-        serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.ArrayFormatter<global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.TwoDimensionalArrayFormatter<global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.ThreeDimensionalArrayFormatter<global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[3].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.FourDimensionalArrayFormatter<global::MyNamespace.MyObject>()");
-        serializationInfoCollection.TypeHints.Should().HaveCount(5); // MyObject, MyObject[], MyObject[,], MyObject[,,], MyObject[,,,]
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Equal(4, serializationInfoCollection.Generics.Count());
+        Assert.Equal("global::MessagePack.Formatters.ArrayFormatter<global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.TwoDimensionalArrayFormatter<global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.ThreeDimensionalArrayFormatter<global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.FourDimensionalArrayFormatter<global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[3].GetFormatterNameWithConstructorArgs());
+        Assert.Equal(5, serializationInfoCollection.TypeHints.Count()); // MyObject, MyObject[], MyObject[,], MyObject[,,], MyObject[,,,]
     }
 
     [Fact]
@@ -223,21 +223,21 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Generics.Should().HaveCount(12);
-        serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.ListFormatter<global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.InterfaceListFormatter2<global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.InterfaceReadOnlyListFormatter<global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[3].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.DictionaryFormatter<global::System.String, global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[4].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.InterfaceDictionaryFormatter<global::System.String, global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[5].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.InterfaceReadOnlyDictionaryFormatter<global::System.String, global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[6].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.InterfaceCollectionFormatter2<global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[7].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.InterfaceReadOnlyCollectionFormatter<global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[8].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.InterfaceEnumerableFormatter<global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[9].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.KeyValuePairFormatter<global::System.String, global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[10].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.InterfaceLookupFormatter<global::System.String, global::MyNamespace.MyObject>()");
-        serializationInfoCollection.Generics[11].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.InterfaceGroupingFormatter<global::System.String, global::MyNamespace.MyObject>()");
-        serializationInfoCollection.TypeHints.Should().HaveCount(14);
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Equal(12, serializationInfoCollection.Generics.Count());
+        Assert.Equal("global::MessagePack.Formatters.ListFormatter<global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.InterfaceListFormatter2<global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.InterfaceReadOnlyListFormatter<global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.DictionaryFormatter<global::System.String, global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[3].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.InterfaceDictionaryFormatter<global::System.String, global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[4].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.InterfaceReadOnlyDictionaryFormatter<global::System.String, global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[5].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.InterfaceCollectionFormatter2<global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[6].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.InterfaceReadOnlyCollectionFormatter<global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[7].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.InterfaceEnumerableFormatter<global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[8].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.KeyValuePairFormatter<global::System.String, global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[9].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.InterfaceLookupFormatter<global::System.String, global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[10].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.InterfaceGroupingFormatter<global::System.String, global::MyNamespace.MyObject>()", serializationInfoCollection.Generics[11].GetFormatterNameWithConstructorArgs());
+        Assert.Equal(14, serializationInfoCollection.TypeHints.Count());
     }
     
     [Fact]
@@ -266,10 +266,10 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Enums.Should().BeEmpty();
-        serializationInfoCollection.Generics.Should().BeEmpty();
-        serializationInfoCollection.TypeHints.Should().HaveCount(26);
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Empty(serializationInfoCollection.Enums);
+        Assert.Empty(serializationInfoCollection.Generics);
+        Assert.Equal(26, serializationInfoCollection.TypeHints.Count());
     }
 
     [Fact]
@@ -293,17 +293,17 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Generics.Should().HaveCount(8);
-        serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32>()");
-        serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String>()");
-        serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64>()");
-        serializationInfoCollection.Generics[3].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single>()");
-        serializationInfoCollection.Generics[4].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean>()");
-        serializationInfoCollection.Generics[5].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte>()");
-        serializationInfoCollection.Generics[6].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte, global::System.Int16>()");
-        serializationInfoCollection.Generics[7].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte, global::System.Int16, global::System.Guid>()");
-        serializationInfoCollection.TypeHints.Should().HaveCount(8 + 8);
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Equal(8, serializationInfoCollection.Generics.Count());
+        Assert.Equal("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32>()", serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String>()", serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64>()", serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single>()", serializationInfoCollection.Generics[3].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean>()", serializationInfoCollection.Generics[4].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte>()", serializationInfoCollection.Generics[5].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte, global::System.Int16>()", serializationInfoCollection.Generics[6].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.ValueTupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte, global::System.Int16, global::System.Guid>()", serializationInfoCollection.Generics[7].GetFormatterNameWithConstructorArgs());
+        Assert.Equal(8 + 8, serializationInfoCollection.TypeHints.Count());
     }
 
     [Fact]
@@ -327,16 +327,16 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Generics.Should().HaveCount(8);
-        serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.TupleFormatter<global::System.Int32>()");
-        serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String>()");
-        serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64>()");
-        serializationInfoCollection.Generics[3].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single>()");
-        serializationInfoCollection.Generics[4].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean>()");
-        serializationInfoCollection.Generics[5].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte>()");
-        serializationInfoCollection.Generics[6].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte, global::System.Int16>()");
-        serializationInfoCollection.Generics[7].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte, global::System.Int16, global::System.Guid>()");
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Equal(8, serializationInfoCollection.Generics.Count());
+        Assert.Equal("global::MessagePack.Formatters.TupleFormatter<global::System.Int32>()", serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String>()", serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64>()", serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single>()", serializationInfoCollection.Generics[3].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean>()", serializationInfoCollection.Generics[4].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte>()", serializationInfoCollection.Generics[5].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte, global::System.Int16>()", serializationInfoCollection.Generics[6].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.TupleFormatter<global::System.Int32, global::System.String, global::System.Int64, global::System.Single, global::System.Boolean, global::System.Byte, global::System.Int16, global::System.Guid>()", serializationInfoCollection.Generics[7].GetFormatterNameWithConstructorArgs());
     }
 
     [Fact]
@@ -354,11 +354,11 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Generics.Should().HaveCount(2);
-        serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs().Should().Be("global::MagicOnion.Serialization.MessagePack.DynamicArgumentTupleFormatter<global::System.String, global::System.Int64>(default(global::System.String), default(global::System.Int64))");
-        serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs().Should().Be("global::MagicOnion.Serialization.MessagePack.DynamicArgumentTupleFormatter<global::System.String, global::System.Int32>(default(global::System.String), default(global::System.Int32))");
-        serializationInfoCollection.TypeHints.Should().HaveCount(5); // string, long, int, DynamicArgumentTuple<string, long>, DynamicArgumentTuple<string, int>
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Equal(2, serializationInfoCollection.Generics.Count());
+        Assert.Equal("global::MagicOnion.Serialization.MessagePack.DynamicArgumentTupleFormatter<global::System.String, global::System.Int64>(default(global::System.String), default(global::System.Int64))", serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MagicOnion.Serialization.MessagePack.DynamicArgumentTupleFormatter<global::System.String, global::System.Int32>(default(global::System.String), default(global::System.Int32))", serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs());
+        Assert.Equal(5, serializationInfoCollection.TypeHints.Count()); // string, long, int, DynamicArgumentTuple<string, long>, DynamicArgumentTuple<string, int>
     }
 
     [Fact]
@@ -378,12 +378,12 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Enums.Should().BeEmpty();
-        serializationInfoCollection.Generics.Should().HaveCount(3);
-        serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.NullableFormatter<global::MyNamespace.MyGenericObject>()");
-        serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs().Should().Be("global::MagicOnion.Serialization.MessagePack.DynamicArgumentTupleFormatter<global::System.String, global::System.Int64>(default(global::System.String), default(global::System.Int64))");
-        serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs().Should().Be("global::MyFormatters.MyNamespace.MyGenericObjectFormatter<global::System.String>()");
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Empty(serializationInfoCollection.Enums);
+        Assert.Equal(3, serializationInfoCollection.Generics.Count());
+        Assert.Equal("global::MessagePack.Formatters.NullableFormatter<global::MyNamespace.MyGenericObject>()", serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MagicOnion.Serialization.MessagePack.DynamicArgumentTupleFormatter<global::System.String, global::System.Int64>(default(global::System.String), default(global::System.Int64))", serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MyFormatters.MyNamespace.MyGenericObjectFormatter<global::System.String>()", serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs());
     }
 
     [Fact]
@@ -402,12 +402,12 @@ public class SerializationInfoCollectorTest
         var serializationInfoCollection = collector.Collect(types);
 
         // Assert
-        serializationInfoCollection.Should().NotBeNull();
-        serializationInfoCollection.Enums.Should().BeEmpty();
-        serializationInfoCollection.Generics.Should().HaveCount(3);
-        serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.NullableFormatter<global::MyNamespace.MyGenericObject>()");
-        serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs().Should().Be("global::MagicOnion.Serialization.MessagePack.DynamicArgumentTupleFormatter<global::System.String, global::System.Int64>(default(global::System.String), default(global::System.Int64))");
-        serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs().Should().Be("global::MessagePack.Formatters.MyNamespace.MyGenericObjectFormatter<global::System.String>()");
+        Assert.NotNull(serializationInfoCollection);
+        Assert.Empty(serializationInfoCollection.Enums);
+        Assert.Equal(3, serializationInfoCollection.Generics.Count());
+        Assert.Equal("global::MessagePack.Formatters.NullableFormatter<global::MyNamespace.MyGenericObject>()", serializationInfoCollection.Generics[0].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MagicOnion.Serialization.MessagePack.DynamicArgumentTupleFormatter<global::System.String, global::System.Int64>(default(global::System.String), default(global::System.Int64))", serializationInfoCollection.Generics[1].GetFormatterNameWithConstructorArgs());
+        Assert.Equal("global::MessagePack.Formatters.MyNamespace.MyGenericObjectFormatter<global::System.String>()", serializationInfoCollection.Generics[2].GetFormatterNameWithConstructorArgs());
     }
 }
 

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/MagicOnion.Client.SourceGenerator.Tests.csproj
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/MagicOnion.Client.SourceGenerator.Tests.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="MemoryPack" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />

--- a/tests/MagicOnion.Client.SourceGenerator.Tests/Usings.cs
+++ b/tests/MagicOnion.Client.SourceGenerator.Tests/Usings.cs
@@ -1,2 +1,1 @@
 global using Xunit;
-global using FluentAssertions;

--- a/tests/MagicOnion.Client.Tests/ClientFilterTest.cs
+++ b/tests/MagicOnion.Client.Tests/ClientFilterTest.cs
@@ -29,7 +29,7 @@ public class ClientFilterTest
         var result = await client.MethodA("Request");
 
         // Assert
-        result.Should().Be("Response");
+        Assert.Equal("Response", result);
         callInvokerMock.DidNotReceive();
         clientFilterMock.Received();
     }
@@ -60,10 +60,11 @@ public class ClientFilterTest
         var result = await client.MethodA("Request");
 
         // Assert
-        result.Should().Be("Response");
-        requestHeaders.Should().HaveCount(2);
-        requestHeaders.Should().Contain(x => x.Key == "x-header-1" && x.Value == "valueA");
-        requestHeaders.Should().Contain(x => x.Key == "x-header-2" && x.Value == "valueB");
+        Assert.Equal("Response", result);
+        Assert.NotNull(requestHeaders);
+        Assert.Equal(2, requestHeaders.Count());
+        Assert.Contains(requestHeaders, x => x.Key == "x-header-1" && x.Value == "valueA");
+        Assert.Contains(requestHeaders, x => x.Key == "x-header-2" && x.Value == "valueB");
     }
 
     class ClientFilterTestRequestHeaders : IClientFilter
@@ -120,11 +121,11 @@ public class ClientFilterTest
         var result = await client.MethodA("Request");
 
         // Assert
-        result.Should().Be("Response");
+        Assert.Equal("Response", result);
         callInvokerMock.Received();
         clientFilterMockFirst.Received();
         clientFilterMockSecond.Received();
-        calledFilters.Should().BeEquivalentTo(new[] { "First", "Second" });
+        Assert.Equal(new[] { "First", "Second" }, calledFilters);
     }
 
 

--- a/tests/MagicOnion.Client.Tests/ClientStreamingTest.cs
+++ b/tests/MagicOnion.Client.Tests/ClientStreamingTest.cs
@@ -14,7 +14,7 @@ public class ClientStreamingTest
         var client = MagicOnionClient.Create<IClientStreamingTestService>(callInvokerMock);
 
         // Assert
-        client.Should().NotBeNull();
+        Assert.NotNull(client);
     }
 
     [Fact]
@@ -42,11 +42,11 @@ public class ClientStreamingTest
         await result.RequestStream.CompleteAsync();
 
         // Assert
-        client.Should().NotBeNull();
-        (await result.ResponseAsync).Should().Be(9876);
+        Assert.NotNull(client);
+        Assert.Equal(9876, (await result.ResponseAsync));
         callInvokerMock.Received();
-        clientStreamWriterMock.Completed.Should().BeTrue();
-        clientStreamWriterMock.Written.Should().BeEquivalentTo(new[] { Box.Create(123), Box.Create(456) });
+        Assert.True(clientStreamWriterMock.Completed);
+        Assert.Equal(new[] { Box.Create(123), Box.Create(456) }, clientStreamWriterMock.Written);
     }
 
     [Fact]
@@ -75,11 +75,11 @@ public class ClientStreamingTest
         await result.RequestStream.CompleteAsync();
 
         // Assert
-        client.Should().NotBeNull();
-        (await result.ResponseAsync).Should().Be(9876);
+        Assert.NotNull(client);
+        Assert.Equal(9876, (await result.ResponseAsync));
         callInvokerMock.Received();
-        clientStreamWriterMock.Completed.Should().BeTrue();
-        clientStreamWriterMock.Written.Should().BeEquivalentTo(new[] { "foo", "bar" });
+        Assert.True(clientStreamWriterMock.Completed);
+        Assert.Equal(new[] { "foo", "bar" }, clientStreamWriterMock.Written);
     }
 
     [Fact]
@@ -107,11 +107,11 @@ public class ClientStreamingTest
         await result.RequestStream.CompleteAsync();
 
         // Assert
-        client.Should().NotBeNull();
-        (await result.ResponseAsync).Should().Be("OK");
+        Assert.NotNull(client);
+        Assert.Equal("OK", (await result.ResponseAsync));
         callInvokerMock.Received();
-        clientStreamWriterMock.Completed.Should().BeTrue();
-        clientStreamWriterMock.Written.Should().BeEquivalentTo(new[] { Box.Create(123), Box.Create(456) });
+        Assert.True(clientStreamWriterMock.Completed);
+        Assert.Equal(new[] { Box.Create(123), Box.Create(456) }, clientStreamWriterMock.Written);
     }
     
     [Fact]
@@ -139,11 +139,11 @@ public class ClientStreamingTest
         await result.RequestStream.CompleteAsync();
 
         // Assert
-        client.Should().NotBeNull();
-        (await result.ResponseAsync).Should().Be("OK");
+        Assert.NotNull(client);
+        Assert.Equal("OK", (await result.ResponseAsync));
         callInvokerMock.Received();
-        clientStreamWriterMock.Completed.Should().BeTrue();
-        clientStreamWriterMock.Written.Should().BeEquivalentTo(new[] { Tuple.Create("Foo", "Bar"), Tuple.Create("Baz", "Hello") });
+        Assert.True(clientStreamWriterMock.Completed);
+        Assert.Equal(new[] { Tuple.Create("Foo", "Bar"), Tuple.Create("Baz", "Hello") }, clientStreamWriterMock.Written);
     }
 
     public interface IClientStreamingTestService : IService<IClientStreamingTestService>

--- a/tests/MagicOnion.Client.Tests/DuplexStreamingTest.cs
+++ b/tests/MagicOnion.Client.Tests/DuplexStreamingTest.cs
@@ -12,7 +12,7 @@ public class DuplexStreamingTest
         var client = MagicOnionClient.Create<IDuplexStreamingTestService>(callInvokerMock);
 
         // Assert
-        client.Should().NotBeNull();
+        Assert.NotNull(client);
     }
 
     public interface IDuplexStreamingTestService : IService<IDuplexStreamingTestService>

--- a/tests/MagicOnion.Client.Tests/DynamicClient/ServiceClientDefinitionTest.cs
+++ b/tests/MagicOnion.Client.Tests/DynamicClient/ServiceClientDefinitionTest.cs
@@ -23,47 +23,47 @@ public class ServiceClientDefinitionTest
     public void Unary()
     {
         var methodInfo = ServiceClientDefinition.MagicOnionServiceMethodInfo.Create(typeof(IDummyService), typeof(IDummyService).GetMethod(nameof(IDummyService.Unary))!);
-        methodInfo.Should().NotBeNull();
-        methodInfo.MethodName.Should().Be(nameof(IDummyService.Unary));
-        methodInfo.MethodReturnType.Should().Be<UnaryResult<int>>();
-        methodInfo.ResponseType.Should().Be<int>();
+        Assert.NotNull(methodInfo);
+        Assert.Equal(nameof(IDummyService.Unary), methodInfo.MethodName);
+        Assert.Equal(typeof(UnaryResult<int>), methodInfo.MethodReturnType);
+        Assert.Equal(typeof(int), methodInfo.ResponseType);
     }
     
     [Fact]
     public void Unary_NonGeneric()
     {
         var methodInfo = ServiceClientDefinition.MagicOnionServiceMethodInfo.Create(typeof(IDummyService), typeof(IDummyService).GetMethod(nameof(IDummyService.UnaryNonGeneric))!);
-        methodInfo.Should().NotBeNull();
-        methodInfo.MethodName.Should().Be(nameof(IDummyService.UnaryNonGeneric));
-        methodInfo.MethodReturnType.Should().Be<UnaryResult>();
-        methodInfo.ResponseType.Should().Be<Nil>();
+        Assert.NotNull(methodInfo);
+        Assert.Equal(nameof(IDummyService.UnaryNonGeneric), methodInfo.MethodName);
+        Assert.Equal(typeof(UnaryResult), methodInfo.MethodReturnType);
+        Assert.Equal(typeof(Nil), methodInfo.ResponseType);
     }
 
     [Fact]
     public void ClientStreaming()
     {
         var methodInfo = ServiceClientDefinition.MagicOnionServiceMethodInfo.Create(typeof(IDummyService), typeof(IDummyService).GetMethod(nameof(IDummyService.ClientStreaming))!);
-        methodInfo.Should().NotBeNull();
-        methodInfo.MethodName.Should().Be(nameof(IDummyService.ClientStreaming));
-        methodInfo.MethodReturnType.Should().Be<Task<ClientStreamingResult<int, int>>>();
+        Assert.NotNull(methodInfo);
+        Assert.Equal(nameof(IDummyService.ClientStreaming), methodInfo.MethodName);
+        Assert.Equal(typeof(Task<ClientStreamingResult<int, int>>), methodInfo.MethodReturnType);
     }
 
     [Fact]
     public void ServerStreaming()
     {
         var methodInfo = ServiceClientDefinition.MagicOnionServiceMethodInfo.Create(typeof(IDummyService), typeof(IDummyService).GetMethod(nameof(IDummyService.ServerStreaming))!);
-        methodInfo.Should().NotBeNull();
-        methodInfo.MethodName.Should().Be(nameof(IDummyService.ServerStreaming));
-        methodInfo.MethodReturnType.Should().Be<Task<ServerStreamingResult<int>>>();
+        Assert.NotNull(methodInfo);
+        Assert.Equal(nameof(IDummyService.ServerStreaming), methodInfo.MethodName);
+        Assert.Equal(typeof(Task<ServerStreamingResult<int>>), methodInfo.MethodReturnType);
     }
 
     [Fact]
     public void DuplexStreaming()
     {
         var methodInfo = ServiceClientDefinition.MagicOnionServiceMethodInfo.Create(typeof(IDummyService), typeof(IDummyService).GetMethod(nameof(IDummyService.DuplexStreaming))!);
-        methodInfo.Should().NotBeNull();
-        methodInfo.MethodName.Should().Be(nameof(IDummyService.DuplexStreaming));
-        methodInfo.MethodReturnType.Should().Be<Task<DuplexStreamingResult<int, int>>>();
+        Assert.NotNull(methodInfo);
+        Assert.Equal(nameof(IDummyService.DuplexStreaming), methodInfo.MethodName);
+        Assert.Equal(typeof(Task<DuplexStreamingResult<int, int>>), methodInfo.MethodReturnType);
     }
     [Fact]
     public void InvalidUnaryTaskOfUnary()
@@ -73,7 +73,7 @@ public class ServiceClientDefinitionTest
             ServiceClientDefinition.MagicOnionServiceMethodInfo.Create(typeof(IDummyService), typeof(IDummyService).GetMethod(nameof(IDummyService.TaskOfUnary))!);
         });
 
-        ex.Message.Should().Contain("The return type of an Unary method must be 'UnaryResult' or 'UnaryResult<T>'");
+        Assert.Contains("The return type of an Unary method must be 'UnaryResult' or 'UnaryResult<T>'", ex.Message);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class ServiceClientDefinitionTest
             ServiceClientDefinition.MagicOnionServiceMethodInfo.Create(typeof(IDummyService), typeof(IDummyService).GetMethod(nameof(IDummyService.NonTaskOfClientStreamingResult))!);
         });
 
-        ex.Message.Should().Contain("The return type of a Streaming method must be 'Task<");
+        Assert.Contains("The return type of a Streaming method must be 'Task<", ex.Message);
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public class ServiceClientDefinitionTest
             ServiceClientDefinition.MagicOnionServiceMethodInfo.Create(typeof(IDummyService), typeof(IDummyService).GetMethod(nameof(IDummyService.NonTaskOfServerStreamingResult))!);
         });
 
-        ex.Message.Should().Contain("The return type of a Streaming method must be 'Task<");
+        Assert.Contains("The return type of a Streaming method must be 'Task<", ex.Message);
     }
 
     [Fact]
@@ -106,7 +106,7 @@ public class ServiceClientDefinitionTest
             ServiceClientDefinition.MagicOnionServiceMethodInfo.Create(typeof(IDummyService), typeof(IDummyService).GetMethod(nameof(IDummyService.NonTaskOfDuplexStreamingResult))!);
         });
 
-        ex.Message.Should().Contain("The return type of a Streaming method must be 'Task<");
+        Assert.Contains("The return type of a Streaming method must be 'Task<", ex.Message);
     }
 
     [Fact]
@@ -117,6 +117,6 @@ public class ServiceClientDefinitionTest
             ServiceClientDefinition.MagicOnionServiceMethodInfo.Create(typeof(IDummyService), typeof(IDummyService).GetMethod(nameof(IDummyService.Unknown))!);
         });
 
-        ex.Message.Should().Contain("The method of a service must return 'UnaryResult<T>', 'Task<ClientStreamingResult<TRequest, TResponse>>'");
+        Assert.Contains("The method of a service must return 'UnaryResult<T>', 'Task<ClientStreamingResult<TRequest, TResponse>>'", ex.Message);
     }
 }

--- a/tests/MagicOnion.Client.Tests/MagicOnion.Client.Tests.csproj
+++ b/tests/MagicOnion.Client.Tests/MagicOnion.Client.Tests.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="NSubstitute" />

--- a/tests/MagicOnion.Client.Tests/ServerStreamingTest.cs
+++ b/tests/MagicOnion.Client.Tests/ServerStreamingTest.cs
@@ -14,7 +14,7 @@ public class ServerStreamingTest
         var client = MagicOnionClient.Create<IServerStreamingTestService>(callInvokerMock);
 
         // Assert
-        client.Should().NotBeNull();
+        Assert.NotNull(client);
     }
 
     [Fact]
@@ -49,14 +49,14 @@ public class ServerStreamingTest
         var moveNext3 = await result.ResponseStream.MoveNext(TestContext.Current.CancellationToken);
 
         // Assert
-        client.Should().NotBeNull();
-        sendRequest.Should().Be(Box.Create(123));
+        Assert.NotNull(client);
+        Assert.Equal(Box.Create(123), sendRequest);
 
-        moveNext1.Should().BeTrue();
-        current1.Should().Be(1);
-        moveNext2.Should().BeTrue();
-        current2.Should().Be(2);
-        moveNext3.Should().BeFalse();
+        Assert.True(moveNext1);
+        Assert.Equal(1, current1);
+        Assert.True(moveNext2);
+        Assert.Equal(2, current2);
+        Assert.False(moveNext3);
     }
     
     [Fact]
@@ -91,14 +91,14 @@ public class ServerStreamingTest
         var moveNext3 = await result.ResponseStream.MoveNext(TestContext.Current.CancellationToken);
 
         // Assert
-        client.Should().NotBeNull();
-        sendRequest.Should().Be("FooBar");
+        Assert.NotNull(client);
+        Assert.Equal("FooBar", sendRequest);
 
-        moveNext1.Should().BeTrue();
-        current1.Should().Be(1);
-        moveNext2.Should().BeTrue();
-        current2.Should().Be(2);
-        moveNext3.Should().BeFalse();
+        Assert.True(moveNext1);
+        Assert.Equal(1, current1);
+        Assert.True(moveNext2);
+        Assert.Equal(2, current2);
+        Assert.False(moveNext3);
     }
     
     [Fact]
@@ -133,14 +133,14 @@ public class ServerStreamingTest
         var moveNext3 = await result.ResponseStream.MoveNext(TestContext.Current.CancellationToken);
 
         // Assert
-        client.Should().NotBeNull();
-        sendRequest.Should().Be(Box.Create(123));
+        Assert.NotNull(client);
+        Assert.Equal(Box.Create(123), sendRequest);
 
-        moveNext1.Should().BeTrue();
-        current1.Should().Be("Foo");
-        moveNext2.Should().BeTrue();
-        current2.Should().Be("Bar");
-        moveNext3.Should().BeFalse();
+        Assert.True(moveNext1);
+        Assert.Equal("Foo", current1);
+        Assert.True(moveNext2);
+        Assert.Equal("Bar", current2);
+        Assert.False(moveNext3);
     }
     
     [Fact]
@@ -175,14 +175,14 @@ public class ServerStreamingTest
         var moveNext3 = await result.ResponseStream.MoveNext(TestContext.Current.CancellationToken);
 
         // Assert
-        client.Should().NotBeNull();
-        sendRequest.Should().Be("FooBar");
+        Assert.NotNull(client);
+        Assert.Equal("FooBar", sendRequest);
 
-        moveNext1.Should().BeTrue();
-        current1.Should().Be("Foo");
-        moveNext2.Should().BeTrue();
-        current2.Should().Be("Bar");
-        moveNext3.Should().BeFalse();
+        Assert.True(moveNext1);
+        Assert.Equal("Foo", current1);
+        Assert.True(moveNext2);
+        Assert.Equal("Bar", current2);
+        Assert.False(moveNext3);
     }
 
     public interface IServerStreamingTestService : IService<IServerStreamingTestService>

--- a/tests/MagicOnion.Client.Tests/UnaryTest.cs
+++ b/tests/MagicOnion.Client.Tests/UnaryTest.cs
@@ -16,7 +16,7 @@ public class UnaryTest
         var client = MagicOnionClient.Create<IUnaryTestService>(callInvokerMock);
 
         // Assert
-        client.Should().NotBeNull();
+        Assert.NotNull(client);
     }
 
     [Fact]
@@ -40,9 +40,10 @@ public class UnaryTest
         await client.ParameterlessNonGenericReturnType();
 
         // Assert
-        client.Should().NotBeNull();
+        Assert.NotNull(client);
         callInvokerMock.Received();
-        actualCallOptions.Headers.Should().Contain(x => x.Key == "foo" && x.Value == "bar");
+        Assert.NotNull(actualCallOptions.Headers);
+        Assert.Contains(actualCallOptions.Headers, x => x.Key == "foo" && x.Value == "bar");
     }
 
     [Fact]
@@ -59,7 +60,7 @@ public class UnaryTest
         await client.ParameterlessNonGenericReturnType();
 
         // Assert
-        client.Should().NotBeNull();
+        Assert.NotNull(client);
         callInvokerMock.Received();
     }
 
@@ -85,9 +86,9 @@ public class UnaryTest
         await client.ParameterlessNonGenericReturnType();
 
         // Assert
-        client.Should().NotBeNull();
+        Assert.NotNull(client);
         callInvokerMock.Received();
-        actualCancellationToken.Should().Be(cts.Token);
+        Assert.Equal(cts.Token, actualCancellationToken);
     }
     
     [Fact]
@@ -111,9 +112,10 @@ public class UnaryTest
         await client.ParameterlessNonGenericReturnType();
 
         // Assert
-        client.Should().NotBeNull();
+        Assert.NotNull(client);
         callInvokerMock.Received();
-        actualHeaders.Should().Contain(x => x.Key == "foo" && x.Value == "bar");
+        Assert.NotNull(actualHeaders);
+        Assert.Contains(actualHeaders, x => x.Key == "foo" && x.Value == "bar");
     }
 
     [Fact]
@@ -139,9 +141,9 @@ public class UnaryTest
         var result = await client.ParameterlessReturnNil();
 
         // Assert
-        result.Should().Be(Nil.Default);
+        Assert.Equal(Nil.Default, result);
         callInvokerMock.Received();
-        serializedResponse.ToArray().Should().BeEquivalentTo(new[] { MessagePackCode.Nil });
+        Assert.Equal(new[] { MessagePackCode.Nil }, serializedResponse.ToArray());
     }
 
     [Fact]
@@ -157,7 +159,7 @@ public class UnaryTest
         var result = await client.ParameterlessReturnNil();
 
         // Assert
-        result.Should().Be(Nil.Default);
+        Assert.Equal(Nil.Default, result);
         callInvokerMock.Received();
     }
 
@@ -174,7 +176,7 @@ public class UnaryTest
         var result = await client.ParameterlessReturnValueType();
 
         // Assert
-        result.Should().Be(123);
+        Assert.Equal(123, result);
         callInvokerMock.Received();
     }
 
@@ -191,7 +193,7 @@ public class UnaryTest
         var result = await client.ParameterlessReturnRefType();
 
         // Assert
-        result.Should().Be("FooBar");
+        Assert.Equal("FooBar", result);
         callInvokerMock.Received();
     }
 
@@ -210,7 +212,7 @@ public class UnaryTest
         var result = await client.OneRefTypeParameterReturnValueType(request);
 
         // Assert
-        result.Should().Be(123);
+        Assert.Equal(123, result);
         callInvokerMock.Received();
     }
 
@@ -229,7 +231,7 @@ public class UnaryTest
         var result = await client.OneValueTypeParameterReturnValueType(request);
 
         // Assert
-        result.Should().Be(456);
+        Assert.Equal(456, result);
         callInvokerMock.Received();
     }
 
@@ -255,9 +257,9 @@ public class UnaryTest
         var result = await client.OneRefTypeParameterReturnRefType(request);
 
         // Assert
-        result.Should().Be("Ok");
+        Assert.Equal("Ok", result);
         callInvokerMock.Received();
-        sentRequest.Should().Be("RequestValue");
+        Assert.Equal("RequestValue", sentRequest);
     }
 
     [Fact]
@@ -282,9 +284,9 @@ public class UnaryTest
         var result = await client.OneValueTypeParameterReturnRefType(request);
 
         // Assert
-        result.Should().Be("OK");
+        Assert.Equal("OK", result);
         callInvokerMock.Received();
-        (sentRequest?.Value).Should().Be(123);
+        Assert.Equal(123, (sentRequest?.Value));
     }
 
     [Fact]
@@ -310,10 +312,10 @@ public class UnaryTest
         var result = await client.TwoParametersReturnRefType(requestArg1, requestArg2);
 
         // Assert
-        result.Should().Be("OK");
+        Assert.Equal("OK", result);
         callInvokerMock.Received();
-        (sentRequest?.Value.Item1).Should().Be(123);
-        (sentRequest?.Value.Item2).Should().Be("Foo");
+        Assert.Equal(123, (sentRequest?.Value.Item1));
+        Assert.Equal("Foo", (sentRequest?.Value.Item2));
     }
 
     [Fact]
@@ -339,10 +341,10 @@ public class UnaryTest
         var result = await client.TwoParametersReturnValueType(requestArg1, requestArg2);
 
         // Assert
-        result.Should().Be(987);
+        Assert.Equal(987, result);
         callInvokerMock.Received();
-        (sentRequest?.Value.Item1).Should().Be(123);
-        (sentRequest?.Value.Item2).Should().Be("Foo");
+        Assert.Equal(123, (sentRequest?.Value.Item1));
+        Assert.Equal("Foo", (sentRequest?.Value.Item2));
     }
 
     [Fact]
@@ -418,8 +420,8 @@ public class UnaryTest
 
         // Assert
         callInvokerMock.Received();
-        (sentRequest?.Value.Item1).Should().Be(123);
-        (sentRequest?.Value.Item2).Should().Be("Foo");
+        Assert.Equal(123, (sentRequest?.Value.Item1));
+        Assert.Equal("Foo", (sentRequest?.Value.Item2));
     }
 
     [Fact]
@@ -440,8 +442,8 @@ public class UnaryTest
         var result = await Assert.ThrowsAsync<RpcException>(async () => await client.ParameterlessReturnValueType().ResponseHeadersAsync);
 
         // Assert
-        result.StatusCode.Should().Be(StatusCode.Unknown);
-        result.Message.Should().Be("FaultedOnResponseHeaders");
+        Assert.Equal(StatusCode.Unknown, result.StatusCode);
+        Assert.Equal("FaultedOnResponseHeaders", result.Message);
         callInvokerMock.Received();
     }
 
@@ -458,8 +460,8 @@ public class UnaryTest
         var result = await Assert.ThrowsAsync<RpcException>(async () => await client.ParameterlessReturnValueType());
 
         // Assert
-        result.StatusCode.Should().Be(StatusCode.Unknown);
-        result.Message.Should().Be("Faulted");
+        Assert.Equal(StatusCode.Unknown, result.StatusCode);
+        Assert.Equal("Faulted", result.Message);
         callInvokerMock.Received();
     }
 
@@ -491,7 +493,7 @@ public class UnaryTest
         var client = MagicOnionClient.Create<IMaxParametersService>(callInvokerMock);
 
         // Assert
-        client.Should().NotBeNull();
+        Assert.NotNull(client);
     }
 
     public interface IMaxParametersService : IService<IMaxParametersService>

--- a/tests/MagicOnion.Client.Tests/Usings.cs
+++ b/tests/MagicOnion.Client.Tests/Usings.cs
@@ -1,5 +1,4 @@
 global using Xunit;
-global using FluentAssertions;
 global using NSubstitute;
 
 global using Grpc.Core;

--- a/tests/MagicOnion.Integration.Tests/ClientFilterTest.cs
+++ b/tests/MagicOnion.Integration.Tests/ClientFilterTest.cs
@@ -36,11 +36,11 @@ public class ClientFilterTest : IClassFixture<MagicOnionApplicationFactory<Clien
             var filters = Enumerable.Range(0, i).Select(_ => new CountFilter(i)).ToArray();
             var client = clientFactory.Create<IClientFilterTestService>(channel, filters);
             var r0 = await client.Unary1(1000, 2000);
-            r0.Should().Be(3000 + 10 * i);
+            Assert.Equal(3000 + 10 * i, r0);
 
             foreach (var item in filters)
             {
-                item.CalledCount.Should().Be(1);
+                Assert.Equal(1, item.CalledCount);
             }
         }
     }
@@ -59,8 +59,8 @@ public class ClientFilterTest : IClassFixture<MagicOnionApplicationFactory<Clien
         await res;
 
         var trailers = res.GetTrailers();
-        trailers.Should().ContainSingle(x => x.Key == "x-foo" && x.Value == "abcdefg");
-        trailers.Should().ContainSingle(x => x.Key == "x-bar" && x.Value == "hijklmn");
+        Assert.Single(trailers, x => x.Key == "x-foo" && x.Value == "abcdefg");
+        Assert.Single(trailers, x => x.Key == "x-bar" && x.Value == "hijklmn");
     }
 
     [Theory]
@@ -78,8 +78,8 @@ public class ClientFilterTest : IClassFixture<MagicOnionApplicationFactory<Clien
             }).AlwaysError();
         });
 
-        ex.RetryCount.Should().Be(3);
-        ex.LastException.Should().NotBeNull();
+        Assert.Equal(3, ex.RetryCount);
+        Assert.NotNull(ex.LastException);
         logger.WriteLine(ex.LastException?.ToString() ?? "(null)");
     }
 }

--- a/tests/MagicOnion.Integration.Tests/DynamicArgumentTupleTest.cs
+++ b/tests/MagicOnion.Integration.Tests/DynamicArgumentTupleTest.cs
@@ -27,7 +27,7 @@ public class DynamicArgumentTupleServiceTest : IClassFixture<MagicOnionApplicati
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
         var client = clientFactory.Create<IDynamicArgumentTupleService>(channel);
         var result  = await client.Unary1(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-        result.Should().Be(120);
+        Assert.Equal(120, result);
     }
 }
 

--- a/tests/MagicOnion.Integration.Tests/HandCraftedStreamingHubClientTest.cs
+++ b/tests/MagicOnion.Integration.Tests/HandCraftedStreamingHubClientTest.cs
@@ -30,7 +30,7 @@ public class HandCraftedStreamingHubClientTest : IClassFixture<MagicOnionApplica
         var retVal = await client.MethodParameterless();
 
         // Assert
-        retVal.Should().Be(123);
+        Assert.Equal(123, retVal);
     }
 
     [Fact]
@@ -47,8 +47,8 @@ public class HandCraftedStreamingHubClientTest : IClassFixture<MagicOnionApplica
         await Task.Delay(500, TestContext.Current.CancellationToken); // Wait for the broadcast queue to be consumed.
 
         // Assert
-        retVal.Should().Be(123);
-        receiver.Results.Should().Contain("1234,FooBarBaz");
+        Assert.Equal(123, retVal);
+        Assert.Contains("1234,FooBarBaz", receiver.Results);
     }
 
     class Receiver : IHandCraftedStreamingHubClientTestHubReceiver

--- a/tests/MagicOnion.Integration.Tests/MagicOnion.Integration.Tests.csproj
+++ b/tests/MagicOnion.Integration.Tests/MagicOnion.Integration.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/tests/MagicOnion.Integration.Tests/SerializerStreamingHubTest.cs
+++ b/tests/MagicOnion.Integration.Tests/SerializerStreamingHubTest.cs
@@ -37,7 +37,7 @@ public class SerializerStreamingHubTest : IClassFixture<MagicOnionApplicationFac
         var result  = await client.MethodParameterless();
 
         // Assert
-        result.Should().Be(123);
+        Assert.Equal(123, result);
     }
 
     [Theory]
@@ -53,7 +53,7 @@ public class SerializerStreamingHubTest : IClassFixture<MagicOnionApplicationFac
         var result  = await client.MethodParameter_One(12345);
 
         // Assert
-        result.Should().Be(123 + 12345);
+        Assert.Equal(123 + 12345, result);
     }
 
     [Theory]
@@ -69,7 +69,7 @@ public class SerializerStreamingHubTest : IClassFixture<MagicOnionApplicationFac
         var result  = await client.MethodParameter_Many(12345, "6789");
 
         // Assert
-        result.Should().Be(123 + 12345 + 6789);
+        Assert.Equal(123 + 12345 + 6789, result);
     }
 
     [Theory]
@@ -88,11 +88,11 @@ public class SerializerStreamingHubTest : IClassFixture<MagicOnionApplicationFac
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
         // Assert
-        result.Should().Be(123);
-        result2.Should().Be(123);
-        receiver.Received.Should().HaveCount(2);
-        receiver.Received.Should().Contain((12345, "6789"));
-        receiver.Received.Should().Contain((98765, "43210"));
+        Assert.Equal(123, result);
+        Assert.Equal(123, result2);
+        Assert.Equal(2, receiver.Received.Count());
+        Assert.Contains((12345, "6789"), receiver.Received);
+        Assert.Contains((98765, "43210"), receiver.Received);
     }
 
     class Receiver : ISerializerTestHubReceiver

--- a/tests/MagicOnion.Integration.Tests/SerializerUnaryTest.cs
+++ b/tests/MagicOnion.Integration.Tests/SerializerUnaryTest.cs
@@ -37,7 +37,7 @@ public class SerializerUnaryTest : IClassFixture<MagicOnionApplicationFactory<Se
         var client = clientFactory.Create<ISerializerTestService>(channel, MessagePackMagicOnionSerializerProvider.Default); // Use MagicOnionMessagePackMessageSerializer by client. but the server still use XorMagicOnionMessagePackSerializer.
 
         // Act
-        var result  = Record.ExceptionAsync(async () => await client.UnaryReturnNil());
+        var result  = await Record.ExceptionAsync(async () => await client.UnaryReturnNil());
 
         // Assert
         Assert.NotNull(result);

--- a/tests/MagicOnion.Integration.Tests/SerializerUnaryTest.cs
+++ b/tests/MagicOnion.Integration.Tests/SerializerUnaryTest.cs
@@ -40,7 +40,7 @@ public class SerializerUnaryTest : IClassFixture<MagicOnionApplicationFactory<Se
         var result  = Record.ExceptionAsync(async () => await client.UnaryReturnNil());
 
         // Assert
-        result.Should().NotBeNull();
+        Assert.NotNull(result);
     }
 
     [Theory]
@@ -55,7 +55,7 @@ public class SerializerUnaryTest : IClassFixture<MagicOnionApplicationFactory<Se
         var result  = await client.UnaryReturnNil();
 
         // Assert
-        result.Should().Be(Nil.Default);
+        Assert.Equal(Nil.Default, result);
     }
 
     [Theory]
@@ -70,7 +70,7 @@ public class SerializerUnaryTest : IClassFixture<MagicOnionApplicationFactory<Se
         var result  = await client.UnaryParameterless();
 
         // Assert
-        result.Should().Be(123);
+        Assert.Equal(123, result);
     }
 
     [Theory]
@@ -85,7 +85,7 @@ public class SerializerUnaryTest : IClassFixture<MagicOnionApplicationFactory<Se
         var result  = await client.Unary1(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
 
         // Assert
-        result.Should().Be(120);
+        Assert.Equal(120, result);
     }
 }
 

--- a/tests/MagicOnion.Integration.Tests/StreamingHubTest.UnknownMethodId.cs
+++ b/tests/MagicOnion.Integration.Tests/StreamingHubTest.UnknownMethodId.cs
@@ -20,10 +20,10 @@ namespace MagicOnion.Integration.Tests
             var ex = await Record.ExceptionAsync(() => client.CustomMethodId().WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken));
 
             // Assert
-            ex.Should().NotBeNull();
-            var rpcException = ex.Should().BeOfType<RpcException>().Subject;
-            rpcException.Status.StatusCode.Should().Be(StatusCode.Unimplemented);
-            factory.Logs.Should().Contain(x => x.Contains("HubMethodNotFound\tStreamingHub method '-1'"));
+            Assert.NotNull(ex);
+            var rpcException = Assert.IsType<RpcException>(ex);
+            Assert.Equal(StatusCode.Unimplemented, rpcException.Status.StatusCode);
+            Assert.Contains(factory.Logs, x => x.Contains("HubMethodNotFound\tStreamingHub method '-1'"));
         }
     }
 

--- a/tests/MagicOnion.Integration.Tests/StreamingHubTest.cs
+++ b/tests/MagicOnion.Integration.Tests/StreamingHubTest.cs
@@ -82,7 +82,7 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var result = await client.Parameter_Zero();
 
         // Assert
-        result.Should().Be(67890);
+        Assert.Equal(67890, result);
     }
 
     [Theory]
@@ -100,7 +100,7 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var result = await client.Parameter_One(12345);
 
         // Assert
-        result.Should().Be(67890);
+        Assert.Equal(67890, result);
     }
 
     [Theory]
@@ -118,7 +118,7 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var result = await client.Parameter_Many(12345, "Hello✨", true);
 
         // Assert
-        result.Should().Be(67890);
+        Assert.Equal(67890, result);
     }
 
     [Theory]
@@ -182,7 +182,7 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var result = await client.ValueTask_Parameter_Zero();
 
         // Assert
-        result.Should().Be(67890);
+        Assert.Equal(67890, result);
     }
 
     [Theory]
@@ -200,7 +200,7 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var result = await client.ValueTask_Parameter_One(12345);
 
         // Assert
-        result.Should().Be(67890);
+        Assert.Equal(67890, result);
     }
 
     [Theory]
@@ -218,7 +218,7 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var result = await client.ValueTask_Parameter_Many(12345, "Hello✨", true);
 
         // Assert
-        result.Should().Be(67890);
+        Assert.Equal(67890, result);
     }
 
     [Theory]
@@ -310,7 +310,7 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var result = await client.Never_With_Return();
 
         // Assert
-        result.Should().Be(default(int));
+        Assert.Equal(default(int), result);
     }
 
     [Theory]
@@ -345,7 +345,7 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var result = await client.ValueTask_Never_With_Return();
 
         // Assert
-        result.Should().Be(default(int));
+        Assert.Equal(default(int), result);
     }
 
     [Theory]
@@ -364,8 +364,8 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var result = await client.RefType(request);
 
         // Assert
-        result.Should().NotBeNull();
-        result.Value.Should().Be(123 + 456);
+        Assert.NotNull(result);
+        Assert.Equal(123 + 456, result.Value);
     }
 
     [Theory]
@@ -383,7 +383,7 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var result = await client.RefType_Null(null);
 
         // Assert
-        result.Should().BeNull();
+        Assert.Null(result);
     }
 
     [Theory]
@@ -461,9 +461,9 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var ex = (RpcException?)await Record.ExceptionAsync(() => client.ThrowReturnStatusException());
 
         // Assert
-        ex.Should().NotBeNull();
-        ex!.StatusCode.Should().Be(StatusCode.Unknown);
-        ex.Status.Detail.Should().Be("Detail-String");
+        Assert.NotNull(ex);
+        Assert.Equal(StatusCode.Unknown, ex!.StatusCode);
+        Assert.Equal("Detail-String", ex.Status.Detail);
     }
 
     [Fact]
@@ -478,9 +478,9 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var ex = (RpcException?)await Record.ExceptionAsync(() => client.Throw());
 
         // Assert
-        ex.Should().NotBeNull();
-        ex!.StatusCode.Should().Be(StatusCode.Internal);
-        ex.Status.Detail.Should().StartWith("An error occurred while processing handler");
+        Assert.NotNull(ex);
+        Assert.Equal(StatusCode.Internal, ex!.StatusCode);
+        Assert.StartsWith("An error occurred while processing handler", ex.Status.Detail);
     }
 
     [Theory]
@@ -676,8 +676,8 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var reason = await client.WaitForDisconnectAsync();
 
         // Assert
-        reason.Type.Should().Be(DisconnectionType.CompletedNormally);
-        reason.Exception.Should().BeNull();
+        Assert.Equal(DisconnectionType.CompletedNormally, reason.Type);
+        Assert.Null(reason.Exception);
     }
 
     [Theory]
@@ -700,8 +700,8 @@ public partial class StreamingHubTest : IClassFixture<MagicOnionApplicationFacto
         var reason = await client.WaitForDisconnectAsync();
 
         // Assert
-        reason.Type.Should().Be(DisconnectionType.Faulted);
-        reason.Exception.Should().NotBeNull();
+        Assert.Equal(DisconnectionType.Faulted, reason.Type);
+        Assert.NotNull(reason.Exception);
     }
 }
 

--- a/tests/MagicOnion.Integration.Tests/StreamingServiceTest.cs
+++ b/tests/MagicOnion.Integration.Tests/StreamingServiceTest.cs
@@ -42,7 +42,7 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
         var response = await result.ResponseAsync;
 
         // Assert
-        response.Should().Be(123 + 456 + 789 + 123);
+        Assert.Equal(123 + 456 + 789 + 123, response);
     }
 
     [Theory]
@@ -62,7 +62,7 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
         }
 
         // Assert
-        sum.Should().Be(Enumerable.Range(0, 10).Sum(x => (123 + 456) * x));
+        Assert.Equal(Enumerable.Range(0, 10).Sum(x => (123 + 456) * x), sum);
     }
 
     [Theory]
@@ -90,7 +90,7 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
         await readResponseTask;
 
         // Assert
-        sum.Should().Be(123 + 456 + 789 + 123 + 111 + 222);
+        Assert.Equal(123 + 456 + 789 + 123 + 111 + 222, sum);
     }
 
     [Theory]
@@ -109,7 +109,7 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
         var response = await result.ResponseAsync;
 
         // Assert
-        response.Value.Should().Be(123 + 456 + 789 + 123);
+        Assert.Equal(123 + 456 + 789 + 123, response.Value);
     }
 
     [Theory]
@@ -129,7 +129,7 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
         }
 
         // Assert
-        sum.Should().Be(Enumerable.Range(0, 10).Sum(x => (123 + 456) * x));
+        Assert.Equal(Enumerable.Range(0, 10).Sum(x => (123 + 456) * x), sum);
     }
 
     [Theory]
@@ -157,7 +157,7 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
         await readResponseTask;
 
         // Assert
-        sum.Should().Be(123 + 456 + 789 + 123 + 111 + 222);
+        Assert.Equal(123 + 456 + 789 + 123 + 111 + 222, sum);
     }
 
     [Theory]
@@ -176,7 +176,7 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
         var response = await result.ResponseAsync;
 
         // Assert
-        response.Should().BeNull();
+        Assert.Null(response);
     }
 
     [Theory]
@@ -196,7 +196,7 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
         }
 
         // Assert
-        nullResponseCount.Should().Be(10);
+        Assert.Equal(10, nullResponseCount);
     }
 
     [Theory]
@@ -224,7 +224,7 @@ public class StreamingServiceTest : IClassFixture<MagicOnionApplicationFactory<S
         await readResponseTask;
 
         // Assert
-        nullResponseCount.Should().Be(3);
+        Assert.Equal(3, nullResponseCount);
     }
 }
 

--- a/tests/MagicOnion.Integration.Tests/UnaryServiceTest.cs
+++ b/tests/MagicOnion.Integration.Tests/UnaryServiceTest.cs
@@ -30,7 +30,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var result = client.NonGeneric(123);
         await result;
 
-        result.GetTrailers().Should().Contain(x => x.Key == "x-request-arg0" && x.Value == "123");
+        Assert.Contains(result.GetTrailers(), x => x.Key == "x-request-arg0" && x.Value == "123");
     }
 
     [Theory]
@@ -41,7 +41,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var client = clientFactory.Create<IUnaryService>(channel);
         var result  = client.ManyParametersReturnsValueType(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         var result2 = await result;
-        result2.Should().Be(120);
+        Assert.Equal(120, result2);
     }
 
     [Theory]
@@ -51,7 +51,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
         var client = clientFactory.Create<IUnaryService>(channel);
         var result  = await client.RefType(new MyUnaryRequest(123, 456));
-        result.Value.Should().Be(123 + 456);
+        Assert.Equal(123 + 456, result.Value);
     }
 
     [Theory]
@@ -61,7 +61,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = factory.CreateDefaultClient() });
         var client = clientFactory.Create<IUnaryService>(channel);
         var result  = await client.RefTypeNull(default);
-        result.Should().BeNull();
+        Assert.Null(result);
     }
 }
 

--- a/tests/MagicOnion.Integration.Tests/Usings.cs
+++ b/tests/MagicOnion.Integration.Tests/Usings.cs
@@ -1,5 +1,4 @@
 global using Xunit;
-global using FluentAssertions;
 global using NSubstitute;
 
 global using Grpc.Core;

--- a/tests/MagicOnion.Serialization.MemoryPack.Tests/MagicOnion.Serialization.MemoryPack.Tests.csproj
+++ b/tests/MagicOnion.Serialization.MemoryPack.Tests/MagicOnion.Serialization.MemoryPack.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />

--- a/tests/MagicOnion.Serialization.MemoryPack.Tests/MemoryPackSerializerStreamingHubTest.cs
+++ b/tests/MagicOnion.Serialization.MemoryPack.Tests/MemoryPackSerializerStreamingHubTest.cs
@@ -32,8 +32,8 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
         var result = await client.MethodReturnCustomObject();
 
         // Assert
-        result.Item1.Should().Be(12345);
-        result.Item2.Should().Be("6789");
+        Assert.Equal(12345, result.Item1);
+        Assert.Equal("6789", result.Item2);
     }
 
 
@@ -49,7 +49,7 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
         var result = await client.MethodParameterless();
 
         // Assert
-        result.Should().Be(123);
+        Assert.Equal(123, result);
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
         var result = await client.MethodParameter_One(12345);
 
         // Assert
-        result.Should().Be(123 + 12345);
+        Assert.Equal(123 + 12345, result);
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
         var result = await client.MethodParameter_Many(12345, "6789");
 
         // Assert
-        result.Should().Be(123 + 12345 + 6789);
+        Assert.Equal(123 + 12345 + 6789, result);
     }
 
     [Fact]
@@ -94,7 +94,7 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
         var result = await client.MethodParameter_CustomObject(new MyRequestResponse() { Item1 = 12345, Item2 = "6789" });
 
         // Assert
-        result.Should().Be(123 + 12345 + 6789);
+        Assert.Equal(123 + 12345 + 6789, result);
     }
 
     [Fact]
@@ -112,11 +112,11 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
         // Assert
-        result.Should().Be(123);
-        result2.Should().Be(123);
-        receiver.Received.Should().HaveCount(2);
-        receiver.Received.Should().Contain((12345, "6789"));
-        receiver.Received.Should().Contain((98765, "43210"));
+        Assert.Equal(123, result);
+        Assert.Equal(123, result2);
+        Assert.Equal(2, receiver.Received.Count());
+        Assert.Contains((12345, "6789"), receiver.Received);
+        Assert.Contains((98765, "43210"), receiver.Received);
     }
 
     [Fact]
@@ -134,11 +134,11 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
         // Assert
-        result.Should().Be(123);
-        result2.Should().Be(123);
-        receiver.Received.Should().HaveCount(2);
-        receiver.Received.Should().Contain((12345, "6789"));
-        receiver.Received.Should().Contain((98765, "43210"));
+        Assert.Equal(123, result);
+        Assert.Equal(123, result2);
+        Assert.Equal(2, receiver.Received.Count());
+        Assert.Contains((12345, "6789"), receiver.Received);
+        Assert.Contains((98765, "43210"), receiver.Received);
     }
 
     [Fact]
@@ -153,9 +153,9 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
         var ex = (RpcException?)await Record.ExceptionAsync(() => client.ThrowReturnStatusException());
 
         // Assert
-        ex.Should().NotBeNull();
-        ex!.StatusCode.Should().Be(StatusCode.Unknown);
-        ex.Status.Detail.Should().Be("Detail-String");
+        Assert.NotNull(ex);
+        Assert.Equal(StatusCode.Unknown, ex!.StatusCode);
+        Assert.Equal("Detail-String", ex.Status.Detail);
     }
 
     [Fact]
@@ -170,9 +170,9 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
         var ex = (RpcException?)await Record.ExceptionAsync(() => client.Throw());
 
         // Assert
-        ex.Should().NotBeNull();
-        ex!.StatusCode.Should().Be(StatusCode.Internal);
-        ex.Status.Detail.Should().StartWith("An error occurred while processing handler");
+        Assert.NotNull(ex);
+        Assert.Equal(StatusCode.Internal, ex!.StatusCode);
+        Assert.StartsWith("An error occurred while processing handler", ex.Status.Detail);
     }
 
     [Fact]
@@ -188,10 +188,10 @@ public class MemoryPackSerializerStreamingHubTest : IClassFixture<MagicOnionAppl
         var ex = (RpcException?)await Record.ExceptionAsync(() => client.Throw());
 
         // Assert
-        ex.Should().NotBeNull();
-        ex!.StatusCode.Should().Be(StatusCode.Internal);
-        ex.Message.Should().Contain("Something went wrong.");
-        ex.Status.Detail.Should().StartWith("An error occurred while processing handler");
+        Assert.NotNull(ex);
+        Assert.Equal(StatusCode.Internal, ex!.StatusCode);
+        Assert.Contains("Something went wrong.", ex.Message);
+        Assert.StartsWith("An error occurred while processing handler", ex.Status.Detail);
     }
 
     class Receiver : IMemoryPackSerializerTestHubReceiver

--- a/tests/MagicOnion.Serialization.MemoryPack.Tests/MemoryPackSerializerUnaryTest.cs
+++ b/tests/MagicOnion.Serialization.MemoryPack.Tests/MemoryPackSerializerUnaryTest.cs
@@ -30,7 +30,7 @@ public class MemoryPackSerializerUnaryTest : IClassFixture<MagicOnionApplication
         var client = MagicOnionClient.Create<IMemoryPackSerializerTestService>(channel, MessagePackMagicOnionSerializerProvider.Default); // Use MagicOnionMessagePackMessageSerializer by client. but the server still use XorMagicOnionMessagePackSerializer.
 
         // Act
-        var result = Record.ExceptionAsync(async () => await client.UnaryReturnNil());
+        var result = await Record.ExceptionAsync(async () => await client.UnaryReturnNil());
 
         // Assert
         Assert.NotNull(result);

--- a/tests/MagicOnion.Serialization.MemoryPack.Tests/MemoryPackSerializerUnaryTest.cs
+++ b/tests/MagicOnion.Serialization.MemoryPack.Tests/MemoryPackSerializerUnaryTest.cs
@@ -33,7 +33,7 @@ public class MemoryPackSerializerUnaryTest : IClassFixture<MagicOnionApplication
         var result = Record.ExceptionAsync(async () => await client.UnaryReturnNil());
 
         // Assert
-        result.Should().NotBeNull();
+        Assert.NotNull(result);
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class MemoryPackSerializerUnaryTest : IClassFixture<MagicOnionApplication
         var result = await client.UnaryReturnNil();
 
         // Assert
-        result.Should().Be(Nil.Default);
+        Assert.Equal(Nil.Default, result);
     }
 
     [Fact]
@@ -61,8 +61,8 @@ public class MemoryPackSerializerUnaryTest : IClassFixture<MagicOnionApplication
         var result = await client.UnaryReturnCustomObject();
 
         // Assert
-        result.Name.Should().Be("Alice");
-        result.Age.Should().Be(18);
+        Assert.Equal("Alice", result.Name);
+        Assert.Equal(18, result.Age);
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class MemoryPackSerializerUnaryTest : IClassFixture<MagicOnionApplication
         var result = await client.UnaryParameterless();
 
         // Assert
-        result.Should().Be(123);
+        Assert.Equal(123, result);
     }
 
     [Fact]
@@ -90,7 +90,7 @@ public class MemoryPackSerializerUnaryTest : IClassFixture<MagicOnionApplication
         var result = await client.Unary1(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, "15");
 
         // Assert
-        result.Should().Be(120);
+        Assert.Equal(120, result);
     }
 
     [Fact]
@@ -104,8 +104,8 @@ public class MemoryPackSerializerUnaryTest : IClassFixture<MagicOnionApplication
         var result = await client.UnaryCustomObject(new MyObject() { Name = "Alice", Age = 18 });
 
         // Assert
-        result.Name.Should().Be("Alice");
-        result.Age.Should().Be(18);
+        Assert.Equal("Alice", result.Name);
+        Assert.Equal(18, result.Age);
     }
 }
 

--- a/tests/MagicOnion.Serialization.MemoryPack.Tests/Usings.cs
+++ b/tests/MagicOnion.Serialization.MemoryPack.Tests/Usings.cs
@@ -1,5 +1,4 @@
 global using Xunit;
-global using FluentAssertions;
 
 global using Grpc.Core;
 global using MessagePack;

--- a/tests/MagicOnion.Serialization.MessagePack.Tests/MagicOnion.Serialization.MessagePack.Tests.csproj
+++ b/tests/MagicOnion.Serialization.MessagePack.Tests/MagicOnion.Serialization.MessagePack.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />

--- a/tests/MagicOnion.Serialization.MessagePack.Tests/UnsafeDirectBlitResolverTest.cs
+++ b/tests/MagicOnion.Serialization.MessagePack.Tests/UnsafeDirectBlitResolverTest.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using MessagePack;
 using MessagePack.Resolvers;
 
@@ -19,9 +18,9 @@ public class UnsafeDirectBlitResolverTest
 
         var z = MessagePackSerializer.Deserialize<MyStruct>(bin, options, cancellationToken: TestContext.Current.CancellationToken);
 
-        z.X.Should().Be(10);
-        z.Y.Should().Be(99);
-        z.Z.Should().Be(999);
+        Assert.Equal(10, z.X);
+        Assert.Equal(99, z.Y);
+        Assert.Equal(999, z.Z);
     }
 }
 

--- a/tests/MagicOnion.Server.Redis.Tests/MagicOnion.Server.Redis.Tests.csproj
+++ b/tests/MagicOnion.Server.Redis.Tests/MagicOnion.Server.Redis.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/tests/MagicOnion.Server.Redis.Tests/Usings.cs
+++ b/tests/MagicOnion.Server.Redis.Tests/Usings.cs
@@ -1,5 +1,4 @@
 global using Xunit;
-global using FluentAssertions;
 global using NSubstitute;
 
 global using Grpc.Core;

--- a/tests/MagicOnion.Server.Tests/ArgumentPatternTest.cs
+++ b/tests/MagicOnion.Server.Tests/ArgumentPatternTest.cs
@@ -173,16 +173,16 @@ public class ArgumentPatternTest : IClassFixture<ServerFixture<ArgumentPattern>>
 
             var result = await client.Unary1(10, 20, "hogehoge");
 
-            result.Id.Should().Be(30);
-            result.Data.Should().Be("hogehoge");
+            Assert.Equal(30, result.Id);
+            Assert.Equal("hogehoge", result.Data);
         }
         {
             var client = new ArgumentPatternManualClient(channel);
 
             var result = await client.Unary1(10, 20, "__omit_last_argument__");
 
-            result.Id.Should().Be(30);
-            result.Data.Should().Be("unknown");
+            Assert.Equal(30, result.Id);
+            Assert.Equal("unknown", result.Data);
         }
     }
 
@@ -193,8 +193,8 @@ public class ArgumentPatternTest : IClassFixture<ServerFixture<ArgumentPattern>>
 
         var result = await client.Unary2(new MyRequest { Id = 30, Data = "huga" });
 
-        result.Id.Should().Be(30);
-        result.Data.Should().Be("huga");
+        Assert.Equal(30, result.Id);
+        Assert.Equal("huga", result.Data);
     }
 
     [Fact]
@@ -204,8 +204,8 @@ public class ArgumentPatternTest : IClassFixture<ServerFixture<ArgumentPattern>>
 
         var result = await client.Unary3();
 
-        result.Id.Should().Be(-1);
-        result.Data.Should().Be("NoArg");
+        Assert.Equal(-1, result.Id);
+        Assert.Equal("NoArg", result.Data);
     }
 
     [Fact]
@@ -214,7 +214,7 @@ public class ArgumentPatternTest : IClassFixture<ServerFixture<ArgumentPattern>>
         var client = MagicOnionClient.Create<IArgumentPattern>(channel);
 
         var result = await client.Unary4();
-        result.Should().Be(Nil.Default);
+        Assert.Equal(Nil.Default, result);
     }
 
     [Fact]
@@ -223,8 +223,8 @@ public class ArgumentPatternTest : IClassFixture<ServerFixture<ArgumentPattern>>
         var client = MagicOnionClient.Create<IArgumentPattern>(channel);
 
         var result = await client.Unary5(new MyStructRequest(999, 9999));
-        result.X.Should().Be(999);
-        result.Y.Should().Be(9999);
+        Assert.Equal(999, result.X);
+        Assert.Equal(9999, result.Y);
     }
 
     async Task<T> First<T>(IAsyncStreamReader<T> reader)
@@ -241,35 +241,35 @@ public class ArgumentPatternTest : IClassFixture<ServerFixture<ArgumentPattern>>
         {
             var callResult = await client.ServerStreamingResult1(10, 100, "aaa");
             var result = await First(callResult.ResponseStream);
-            result.Id.Should().Be(110);
-            result.Data.Should().Be("aaa");
+            Assert.Equal(110, result.Id);
+            Assert.Equal("aaa", result.Data);
         }
 
         {
             var callResult = await client.ServerStreamingResult2(new MyRequest { Id = 999, Data = "zzz" });
             var result = await First(callResult.ResponseStream);
-            result.Id.Should().Be(999);
-            result.Data.Should().Be("zzz");
+            Assert.Equal(999, result.Id);
+            Assert.Equal("zzz", result.Data);
         }
 
         {
             var callResult = await client.ServerStreamingResult3();
             var result = await First(callResult.ResponseStream);
-            result.Id.Should().Be(-1);
-            result.Data.Should().Be("empty");
+            Assert.Equal(-1, result.Id);
+            Assert.Equal("empty", result.Data);
         }
 
         {
             var callResult = await client.ServerStreamingResult4();
             var result = await First(callResult.ResponseStream);
-            result.Should().Be(Nil.Default);
+            Assert.Equal(Nil.Default, result);
         }
 
         {
             var callResult = await client.ServerStreamingResult5(new MyStructRequest { X = 9, Y = 100 });
             var result = await First(callResult.ResponseStream);
-            result.X.Should().Be(9);
-            result.Y.Should().Be(100);
+            Assert.Equal(9, result.X);
+            Assert.Equal(100, result.Y);
         }
     }
 

--- a/tests/MagicOnion.Server.Tests/AuthorizeServiceTest.cs
+++ b/tests/MagicOnion.Server.Tests/AuthorizeServiceTest.cs
@@ -23,7 +23,7 @@ public class AuthorizeServiceTest : IClassFixture<WebApplicationFactory<Startup>
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "Alice");
         var client = MagicOnionClient.Create<IAuthorizeClassService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
         var userName = await client.GetUserNameAsync();
-        userName.Should().Be("Alice");
+        Assert.Equal("Alice", userName);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class AuthorizeServiceTest : IClassFixture<WebApplicationFactory<Startup>
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IAuthorizeClassService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.GetUserNameAsync());
-        ex.StatusCode.Should().Be(StatusCode.Unauthenticated);
+        Assert.Equal(StatusCode.Unauthenticated, ex.StatusCode);
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class AuthorizeServiceTest : IClassFixture<WebApplicationFactory<Startup>
     {
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IAuthorizeClassService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
-        (await client.AddAsync(123, 456)).Should().Be(579);
+        Assert.Equal(579, (await client.AddAsync(123, 456)));
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class AuthorizeServiceTest : IClassFixture<WebApplicationFactory<Startup>
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "Alice");
         var client = MagicOnionClient.Create<IAuthorizeMethodService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
         var userName = await client.GetUserNameAsync();
-        userName.Should().Be("Alice");
+        Assert.Equal("Alice", userName);
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class AuthorizeServiceTest : IClassFixture<WebApplicationFactory<Startup>
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IAuthorizeMethodService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.GetUserNameAsync());
-        ex.StatusCode.Should().Be(StatusCode.Unauthenticated);
+        Assert.Equal(StatusCode.Unauthenticated, ex.StatusCode);
     }
 
     [Fact]
@@ -67,6 +67,6 @@ public class AuthorizeServiceTest : IClassFixture<WebApplicationFactory<Startup>
     {
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IAuthorizeMethodService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
-        (await client.AddAsync(123, 456)).Should().Be(579);
+        Assert.Equal(579, (await client.AddAsync(123, 456)));
     }
 }

--- a/tests/MagicOnion.Server.Tests/AuthorizeStreamingHubTest.cs
+++ b/tests/MagicOnion.Server.Tests/AuthorizeStreamingHubTest.cs
@@ -23,7 +23,7 @@ public class AuthorizeStreamingHubTest : IClassFixture<WebApplicationFactory<Sta
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "Alice");
         var client = await StreamingHubClient.ConnectAsync<IAuthorizeHub, IAuthorizeHubReceiver>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }), this, cancellationToken: TestContext.Current.CancellationToken);
         var userName = await client.GetUserNameAsync();
-        userName.Should().Be("Alice");
+        Assert.Equal("Alice", userName);
     }
 
     [Fact]
@@ -36,6 +36,6 @@ public class AuthorizeStreamingHubTest : IClassFixture<WebApplicationFactory<Sta
             var client = await StreamingHubClient.ConnectAsync<IAuthorizeHub, IAuthorizeHubReceiver>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }), this, cancellationToken: TestContext.Current.CancellationToken);
         });
 
-        ex.StatusCode.Should().Be(StatusCode.Unauthenticated);
+        Assert.Equal(StatusCode.Unauthenticated, ex.StatusCode);
     }
 }

--- a/tests/MagicOnion.Server.Tests/Filter/FilterHelperTest.cs
+++ b/tests/MagicOnion.Server.Tests/Filter/FilterHelperTest.cs
@@ -21,11 +21,11 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(globalFilters, methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(4);
-        filters[0].Filter.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("Global.Instance");
-        filters[1].Filter.Should().BeOfType<MagicOnionFilterDescriptor<IMagicOnionServiceFilter>.MagicOnionFilterFromTypeFactory>().Which.Type.Should().Be(typeof(TestFilterAttribute));
-        filters[2].Filter.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("Attribute.Class");
-        filters[3].Filter.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("Attribute.Method");
+        Assert.Equal(4, filters.Count());
+        Assert.Equal("Global.Instance", Assert.IsType<TestFilterAttribute>(filters[0].Filter).Name);
+        Assert.Equal(typeof(TestFilterAttribute), Assert.IsType<MagicOnionFilterDescriptor<IMagicOnionServiceFilter>.MagicOnionFilterFromTypeFactory>(filters[1].Filter).Type);
+        Assert.Equal("Attribute.Class", Assert.IsType<TestFilterAttribute>(filters[2].Filter).Name);
+        Assert.Equal("Attribute.Method", Assert.IsType<TestFilterAttribute>(filters[3].Filter).Name);
     }
 
     [Fact]
@@ -38,8 +38,8 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<MagicOnionServiceFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(1);
-        filters[0].Filter.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("Attribute.Class");
+        Assert.Equal(1, filters.Count());
+        Assert.Equal("Attribute.Class", Assert.IsType<TestFilterAttribute>(filters[0].Filter).Name);
     }
 
     [Fact]
@@ -52,9 +52,9 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<MagicOnionServiceFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(2);
-        filters[0].Filter.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("Attribute.Class");
-        filters[1].Filter.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("Attribute.Method");
+        Assert.Equal(2, filters.Count());
+        Assert.Equal("Attribute.Class", Assert.IsType<TestFilterAttribute>(filters[0].Filter).Name);
+        Assert.Equal("Attribute.Method", Assert.IsType<TestFilterAttribute>(filters[1].Filter).Name);
     }
 
     [Fact]
@@ -67,8 +67,8 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<MagicOnionServiceFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(1);
-        filters[0].Filter.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("Attribute.Class");
+        Assert.Equal(1, filters.Count());
+        Assert.Equal("Attribute.Class", Assert.IsType<TestFilterAttribute>(filters[0].Filter).Name);
     }
 
     [Fact]
@@ -88,12 +88,11 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(globalFilters, methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(5 + 4 + 4);
-        filters.Select(x => x.Filter).OfType<TestFilterAttribute>().Select(x => x.Name).Should().Equal(new[]
-        {
+        Assert.Equal(5 + 4 + 4, filters.Count());
+        Assert.Equal([
             "-256", "-123", "-64", "1", "64", "123", "256",
             "Unordered.1", "Unordered.2", "Unordered.3", "Unordered.4", "Unordered.5", "Unordered.6"
-        });
+        ], filters.Select(x => x.Filter).OfType<TestFilterAttribute>().Select(x => x.Name));
     }
 
     [Fact]
@@ -108,9 +107,9 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(globalFilters, methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(2);
-        filters[0].Filter.Should().BeOfType<LegacyFilterFactory>();
-        filters[1].Filter.Should().BeOfType<TestFilterAttribute>();
+        Assert.Equal(2, filters.Count());
+        Assert.IsType<LegacyFilterFactory>(filters[0].Filter);
+        Assert.IsType<TestFilterAttribute>(filters[1].Filter);
     }
 
     [Fact]
@@ -123,9 +122,9 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<MagicOnionServiceFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(2);
-        filters[0].Filter.Should().BeOfType<LegacyFilterFactoryAttribute>();
-        filters[1].Filter.Should().BeOfType<TestFilterAttribute>();
+        Assert.Equal(2, filters.Count());
+        Assert.IsType<LegacyFilterFactoryAttribute>(filters[0].Filter);
+        Assert.IsType<TestFilterAttribute>(filters[1].Filter);
     }
 
     [TestFilter("Attribute.Class")]
@@ -225,11 +224,11 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(globalFilters, methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(4);
-        filters[0].Filter.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("Global.Instance");
-        filters[1].Filter.Should().BeOfType<MagicOnionFilterDescriptor<IStreamingHubFilter>.MagicOnionFilterFromTypeFactory>().Which.Type.Should().Be(typeof(TestHubFilterAttribute));
-        filters[2].Filter.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("Attribute.Class");
-        filters[3].Filter.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("Attribute.Method");
+        Assert.Equal(4, filters.Count());
+        Assert.Equal("Global.Instance", Assert.IsType<TestHubFilterAttribute>(filters[0].Filter).Name);
+        Assert.Equal(typeof(TestHubFilterAttribute), Assert.IsType<MagicOnionFilterDescriptor<IStreamingHubFilter>.MagicOnionFilterFromTypeFactory>(filters[1].Filter).Type);
+        Assert.Equal("Attribute.Class", Assert.IsType<TestHubFilterAttribute>(filters[2].Filter).Name);
+        Assert.Equal("Attribute.Method", Assert.IsType<TestHubFilterAttribute>(filters[3].Filter).Name);
     }
 
     [Fact]
@@ -242,8 +241,8 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<StreamingHubFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(1);
-        filters[0].Filter.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("Attribute.Class");
+        Assert.Equal(1, filters.Count());
+        Assert.Equal("Attribute.Class", Assert.IsType<TestHubFilterAttribute>(filters[0].Filter).Name);
     }
 
     [Fact]
@@ -256,9 +255,9 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<StreamingHubFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(2);
-        filters[0].Filter.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("Attribute.Class");
-        filters[1].Filter.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("Attribute.Method");
+        Assert.Equal(2, filters.Count());
+        Assert.Equal("Attribute.Class", Assert.IsType<TestHubFilterAttribute>(filters[0].Filter).Name);
+        Assert.Equal("Attribute.Method", Assert.IsType<TestHubFilterAttribute>(filters[1].Filter).Name);
     }
 
     [Fact]
@@ -271,8 +270,8 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<StreamingHubFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(1);
-        filters[0].Filter.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("Attribute.Class");
+        Assert.Equal(1, filters.Count());
+        Assert.Equal("Attribute.Class", Assert.IsType<TestHubFilterAttribute>(filters[0].Filter).Name);
     }
 
     [Fact]
@@ -286,10 +285,10 @@ public class FilterHelperTest
         var streamingHubFilters = FilterHelper.GetFilters(Array.Empty<StreamingHubFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        serviceFilters.Should().HaveCount(1);
-        serviceFilters[0].Filter.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("Attribute.Class");
-        streamingHubFilters.Should().HaveCount(1);
-        streamingHubFilters[0].Filter.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("Attribute.Class");
+        Assert.Equal(1, serviceFilters.Count());
+        Assert.Equal("Attribute.Class", Assert.IsType<TestFilterAttribute>(serviceFilters[0].Filter).Name);
+        Assert.Equal(1, streamingHubFilters.Count());
+        Assert.Equal("Attribute.Class", Assert.IsType<TestHubFilterAttribute>(streamingHubFilters[0].Filter).Name);
     }
 
     [Fact]
@@ -309,12 +308,10 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(globalFilters, methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(5 + 4 + 4);
-        filters.Select(x => x.Filter).OfType<TestHubFilterAttribute>().Select(x => x.Name).Should().Equal(new[]
-        {
-            "-256", "-123", "-64", "1", "64", "123", "256",
-            "Unordered.1", "Unordered.2", "Unordered.3", "Unordered.4", "Unordered.5", "Unordered.6"
-        });
+        Assert.Equal(5 + 4 + 4, filters.Count());
+        Assert.Equal(["-256", "-123", "-64", "1", "64", "123", "256",
+                "Unordered.1", "Unordered.2", "Unordered.3", "Unordered.4", "Unordered.5", "Unordered.6"],
+            filters.Select(x => x.Filter).OfType<TestHubFilterAttribute>().Select(x => x.Name));
     }
 
     [Fact]
@@ -329,9 +326,9 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(globalFilters, methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(2);
-        filters[0].Filter.Should().BeOfType<LegacyHubFilterFactory>();
-        filters[1].Filter.Should().BeOfType<TestHubFilterAttribute>();
+        Assert.Equal(2, filters.Count());
+        Assert.IsType<LegacyHubFilterFactory>(filters[0].Filter);
+        Assert.IsType<TestHubFilterAttribute>(filters[1].Filter);
     }
     
     [Fact]
@@ -344,9 +341,9 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<StreamingHubFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        filters.Should().HaveCount(2);
-        filters[0].Filter.Should().BeOfType<LegacyHubFilterFactoryAttribute>();
-        filters[1].Filter.Should().BeOfType<TestHubFilterAttribute>();
+        Assert.Equal(2, filters.Count());
+        Assert.IsType<LegacyHubFilterFactoryAttribute>(filters[0].Filter);
+        Assert.IsType<TestHubFilterAttribute>(filters[1].Filter);
     }
 
     [TestHubFilter("Attribute.Class")]
@@ -453,8 +450,8 @@ public class FilterHelperTest
         var instance = FilterHelper.CreateOrGetInstance(serviceProvider, filterDesc);
 
         // Assert
-        instance.Should().NotBeNull();
-        instance.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("Unnamed");
+        Assert.NotNull(instance);
+        Assert.Equal("Unnamed", Assert.IsType<TestFilterAttribute>(instance).Name);
     }
 
     [Fact]
@@ -468,9 +465,9 @@ public class FilterHelperTest
         var instance = FilterHelper.CreateOrGetInstance(serviceProvider, filterDesc);
 
         // Assert
-        instance.Should().NotBeNull();
-        instance.Should().Be(filterDesc.Filter);
-        instance.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("Instantiated");
+        Assert.NotNull(instance);
+        Assert.Equal(filterDesc.Filter, instance);
+        Assert.Equal("Instantiated", Assert.IsType<TestFilterAttribute>(instance).Name);
     }
 
     [Fact]
@@ -486,8 +483,8 @@ public class FilterHelperTest
         var instance = FilterHelper.CreateOrGetInstance(serviceProvider, filterDesc);
 
         // Assert
-        instance.Should().NotBeNull();
-        instance.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("ValueFromServiceProvider");
+        Assert.NotNull(instance);
+        Assert.Equal("ValueFromServiceProvider", Assert.IsType<TestFilterAttribute>(instance).Name);
     }
 
     [Fact]
@@ -503,8 +500,8 @@ public class FilterHelperTest
         var instance = FilterHelper.CreateOrGetInstance(serviceProvider, filterDesc);
 
         // Assert
-        instance.Should().NotBeNull();
-        instance.Should().BeOfType<TestFilterAttribute>().Which.Name.Should().Be("ValueFromServiceProvider");
+        Assert.NotNull(instance);
+        Assert.Equal("ValueFromServiceProvider", Assert.IsType<TestFilterAttribute>(instance).Name);
     }
 
     class TestServiceFilterFactory : IMagicOnionFilterFactory<IMagicOnionServiceFilter>
@@ -538,8 +535,8 @@ public class FilterHelperTest
         var instance = FilterHelper.CreateOrGetInstance(serviceProvider, filterDesc);
 
         // Assert
-        instance.Should().NotBeNull();
-        instance.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("Unnamed");
+        Assert.NotNull(instance);
+        Assert.Equal("Unnamed", Assert.IsType<TestHubFilterAttribute>(instance).Name);
     }
 
     [Fact]
@@ -553,9 +550,9 @@ public class FilterHelperTest
         var instance = FilterHelper.CreateOrGetInstance(serviceProvider, filterDesc);
 
         // Assert
-        instance.Should().NotBeNull();
-        instance.Should().Be(filterDesc.Filter);
-        instance.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("Instantiated");
+        Assert.NotNull(instance);
+        Assert.Equal(filterDesc.Filter, instance);
+        Assert.Equal("Instantiated", Assert.IsType<TestHubFilterAttribute>(instance).Name);
     }
 
     [Fact]
@@ -571,8 +568,8 @@ public class FilterHelperTest
         var instance = FilterHelper.CreateOrGetInstance(serviceProvider, filterDesc);
 
         // Assert
-        instance.Should().NotBeNull();
-        instance.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("ValueFromServiceProvider");
+        Assert.NotNull(instance);
+        Assert.Equal("ValueFromServiceProvider", Assert.IsType<TestHubFilterAttribute>(instance).Name);
     }
 
     [Fact]
@@ -588,8 +585,8 @@ public class FilterHelperTest
         var instance = FilterHelper.CreateOrGetInstance(serviceProvider, filterDesc);
 
         // Assert
-        instance.Should().NotBeNull();
-        instance.Should().BeOfType<TestHubFilterAttribute>().Which.Name.Should().Be("ValueFromServiceProvider");
+        Assert.NotNull(instance);
+        Assert.Equal("ValueFromServiceProvider", Assert.IsType<TestHubFilterAttribute>(instance).Name);
     }
 
     class TestStreamingHubFilterFactory : IMagicOnionFilterFactory<IStreamingHubFilter>
@@ -635,7 +632,7 @@ public class FilterHelperTest
         await body(default);
 
         // Assert
-        results.Should().Equal(1, 2, 0, 200, 100);
+        Assert.Equal([1, 2, 0, 200, 100], results);
     }
 
     class ListIntInjectedServiceFilter : IMagicOnionFilterFactory<IMagicOnionServiceFilter>
@@ -684,7 +681,7 @@ public class FilterHelperTest
         await body(default);
 
         // Assert
-        results.Should().Equal(1, 2, 0, 200, 100);
+        Assert.Equal([1, 2, 0, 200, 100], results);
     }
 
     class ListIntInjectedStreamingHubFilter : IMagicOnionFilterFactory<IStreamingHubFilter>
@@ -742,7 +739,7 @@ public class FilterHelperTest
         await body(default);
 
         // Assert
-        results.Should().Equal(1, 2, 0, 200, 100);
+        Assert.Equal([1, 2, 0, 200, 100], results);
     }
 
     [Fact]
@@ -773,9 +770,9 @@ public class FilterHelperTest
         var ex = await Record.ExceptionAsync(() => body(default));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.StackTrace.Should().NotContain("MagicOnion.Server.Filters.Internal.FilterHelper.<>c__DisplayClass");
-        callStack.Should().NotContain("MagicOnion.Server.Filters.Internal.FilterHelper.<>c__DisplayClass");
+        Assert.NotNull(ex);
+        Assert.DoesNotContain("MagicOnion.Server.Filters.Internal.FilterHelper.<>c__DisplayClass", ex.StackTrace);
+        Assert.DoesNotContain("MagicOnion.Server.Filters.Internal.FilterHelper.<>c__DisplayClass", callStack);
     }
 
     class DelegateServiceFilter : IMagicOnionServiceFilter
@@ -823,7 +820,7 @@ public class FilterHelperTest
         await body(default);
 
         // Assert
-        results.Should().Equal(1, 2, 0, 200, 100);
+        Assert.Equal([1, 2, 0, 200, 100], results);
     }
 
     [Fact]
@@ -854,9 +851,9 @@ public class FilterHelperTest
         var ex = await Record.ExceptionAsync(() => body(default));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.StackTrace.Should().NotContain("MagicOnion.Server.Filters.Internal.FilterHelper.<>c__DisplayClass");
-        callStack.Should().NotContain("MagicOnion.Server.Filters.Internal.FilterHelper.<>c__DisplayClass");
+        Assert.NotNull(ex);
+        Assert.DoesNotContain("MagicOnion.Server.Filters.Internal.FilterHelper.<>c__DisplayClass", ex.StackTrace);
+        Assert.DoesNotContain("MagicOnion.Server.Filters.Internal.FilterHelper.<>c__DisplayClass", callStack);
     }
 
     class DelegateHubFilter : IStreamingHubFilter

--- a/tests/MagicOnion.Server.Tests/Filter/FilterHelperTest.cs
+++ b/tests/MagicOnion.Server.Tests/Filter/FilterHelperTest.cs
@@ -38,7 +38,7 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<MagicOnionServiceFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        Assert.Equal(1, filters.Count());
+        Assert.Single(filters);
         Assert.Equal("Attribute.Class", Assert.IsType<TestFilterAttribute>(filters[0].Filter).Name);
     }
 
@@ -67,7 +67,7 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<MagicOnionServiceFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        Assert.Equal(1, filters.Count());
+        Assert.Single(filters);
         Assert.Equal("Attribute.Class", Assert.IsType<TestFilterAttribute>(filters[0].Filter).Name);
     }
 
@@ -241,7 +241,7 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<StreamingHubFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        Assert.Equal(1, filters.Count());
+        Assert.Single(filters);
         Assert.Equal("Attribute.Class", Assert.IsType<TestHubFilterAttribute>(filters[0].Filter).Name);
     }
 
@@ -270,7 +270,7 @@ public class FilterHelperTest
         var filters = FilterHelper.GetFilters(Array.Empty<StreamingHubFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        Assert.Equal(1, filters.Count());
+        Assert.Single(filters);
         Assert.Equal("Attribute.Class", Assert.IsType<TestHubFilterAttribute>(filters[0].Filter).Name);
     }
 
@@ -285,9 +285,9 @@ public class FilterHelperTest
         var streamingHubFilters = FilterHelper.GetFilters(Array.Empty<StreamingHubFilterDescriptor>(), methodInfo.Target!.GetType(), methodInfo.Method);
 
         // Assert
-        Assert.Equal(1, serviceFilters.Count());
+        Assert.Single(serviceFilters);
         Assert.Equal("Attribute.Class", Assert.IsType<TestFilterAttribute>(serviceFilters[0].Filter).Name);
-        Assert.Equal(1, streamingHubFilters.Count());
+        Assert.Single(streamingHubFilters);
         Assert.Equal("Attribute.Class", Assert.IsType<TestHubFilterAttribute>(streamingHubFilters[0].Filter).Name);
     }
 

--- a/tests/MagicOnion.Server.Tests/Filter/MagicOnionFilterDescriptorExtensionsTest.cs
+++ b/tests/MagicOnion.Server.Tests/Filter/MagicOnionFilterDescriptorExtensionsTest.cs
@@ -15,8 +15,8 @@ public class MagicOnionFilterDescriptorExtensionsTest
         filters.Add(new ServiceFilter() { Order = 123 });
 
         // Assert
-        filters[0].Filter.Should().BeOfType<ServiceFilter>();
-        filters[0].Order.Should().Be(123);
+        Assert.IsType<ServiceFilter>(filters[0].Filter);
+        Assert.Equal(123, filters[0].Order);
     }
 
     [Fact]
@@ -29,8 +29,8 @@ public class MagicOnionFilterDescriptorExtensionsTest
         filters.Add(new StreamingHubFilter() { Order = 123 });
 
         // Assert
-        filters[0].Filter.Should().BeOfType<StreamingHubFilter>();
-        filters[0].Order.Should().Be(123);
+        Assert.IsType<StreamingHubFilter>(filters[0].Filter);
+        Assert.Equal(123, filters[0].Order);
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class MagicOnionFilterDescriptorExtensionsTest
         filters.Add(new ServiceFilterFactory());
 
         // Assert
-        filters[0].Filter.Should().BeOfType<ServiceFilterFactory>();
+        Assert.IsType<ServiceFilterFactory>(filters[0].Filter);
     }
 
     [Fact]
@@ -56,8 +56,8 @@ public class MagicOnionFilterDescriptorExtensionsTest
         filters.Add<ServiceFilterFactory>();
 
         // Assert
-        filters[0].Filter.Should().BeOfType<MagicOnionFilterDescriptor<IMagicOnionServiceFilter>.MagicOnionFilterFromTypeFactoryFactory>() // `MagicOnionFilterFromTypeFactoryFactory` is internal type
-            .Which.Type.Should().Be(typeof(ServiceFilterFactory));
+        var filter = Assert.IsType<MagicOnionFilterDescriptor<IMagicOnionServiceFilter>.MagicOnionFilterFromTypeFactoryFactory>(filters[0].Filter);
+        Assert.Equal(typeof(ServiceFilterFactory), filter.Type);
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public class MagicOnionFilterDescriptorExtensionsTest
         filters.Add(new StreamingHubFilterFactory());
 
         // Assert
-        filters[0].Filter.Should().BeOfType<StreamingHubFilterFactory>();
+        Assert.IsType<StreamingHubFilterFactory>(filters[0].Filter);
     }
 
     [Fact]
@@ -83,8 +83,8 @@ public class MagicOnionFilterDescriptorExtensionsTest
         filters.Add<StreamingHubFilterFactory>();
 
         // Assert
-        filters[0].Filter.Should().BeOfType<MagicOnionFilterDescriptor<IStreamingHubFilter>.MagicOnionFilterFromTypeFactoryFactory>() // `MagicOnionFilterFromTypeFactoryFactory` is internal type
-            .Which.Type.Should().Be(typeof(StreamingHubFilterFactory));
+        var filter = Assert.IsType<MagicOnionFilterDescriptor<IStreamingHubFilter>.MagicOnionFilterFromTypeFactoryFactory>(filters[0].Filter); // `MagicOnionFilterFromTypeFactoryFactory` is internal type
+        Assert.Equal(typeof(StreamingHubFilterFactory), filter.Type);
     }
 
     class ServiceFilter : IMagicOnionServiceFilter, IMagicOnionOrderedFilter

--- a/tests/MagicOnion.Server.Tests/Filter/MagicOnionFilterDescriptorTest.cs
+++ b/tests/MagicOnion.Server.Tests/Filter/MagicOnionFilterDescriptorTest.cs
@@ -16,7 +16,7 @@ public class MagicOnionFilterDescriptorTest
         var order = desc.Order;
 
         // Assert
-        order.Should().Be(int.MaxValue);
+        Assert.Equal(int.MaxValue, order);
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public class MagicOnionFilterDescriptorTest
         var order = desc.Order;
 
         // Assert
-        order.Should().Be(int.MaxValue);
+        Assert.Equal(int.MaxValue, order);
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class MagicOnionFilterDescriptorTest
         var order = desc.Order;
 
         // Assert
-        order.Should().Be(256);
+        Assert.Equal(256, order);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class MagicOnionFilterDescriptorTest
         var order = desc.Order;
 
         // Assert
-        order.Should().Be(256);
+        Assert.Equal(256, order);
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class MagicOnionFilterDescriptorTest
         var order = desc.Order;
 
         // Assert
-        order.Should().Be(123);
+        Assert.Equal(123, order);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class MagicOnionFilterDescriptorTest
         var order = desc.Order;
 
         // Assert
-        order.Should().Be(123);
+        Assert.Equal(123, order);
     }
 
     [Fact]
@@ -95,9 +95,9 @@ public class MagicOnionFilterDescriptorTest
         var instancedFilter = ((IMagicOnionFilterFactory<IMagicOnionServiceFilter>)desc.Filter).CreateInstance(serviceProvider);
 
         // Assert
-        instancedFilter.Should().BeOfType<ServiceFilter>();
-        desc.Filter.Should().BeOfType<MagicOnionFilterDescriptor<IMagicOnionServiceFilter>.MagicOnionFilterFromTypeFactory>()
-            .Which.Type.Should().Be(typeof(ServiceFilter));
+        Assert.IsType<ServiceFilter>(instancedFilter);
+        var filter = Assert.IsType<MagicOnionFilterDescriptor<IMagicOnionServiceFilter>.MagicOnionFilterFromTypeFactory>(desc.Filter);
+        Assert.Equal(typeof(ServiceFilter), filter.Type);
     }
 
     [Fact]
@@ -111,9 +111,9 @@ public class MagicOnionFilterDescriptorTest
         var instancedFilter = ((IMagicOnionFilterFactory<IMagicOnionServiceFilter>)desc.Filter).CreateInstance(serviceProvider);
 
         // Assert
-        instancedFilter.Should().BeOfType<ServiceFilter>();
-        desc.Filter.Should().BeOfType<MagicOnionFilterDescriptor<IMagicOnionServiceFilter>.MagicOnionFilterFromTypeFactoryFactory>()
-            .Which.Type.Should().Be(typeof(ServiceFilterFactory));
+        Assert.IsType<ServiceFilter>(instancedFilter);
+        var filter = Assert.IsType<MagicOnionFilterDescriptor<IMagicOnionServiceFilter>.MagicOnionFilterFromTypeFactoryFactory>(desc.Filter);
+        Assert.Equal(typeof(ServiceFilterFactory), filter.Type);
     }
 
     [Fact]
@@ -127,9 +127,9 @@ public class MagicOnionFilterDescriptorTest
         var instancedFilter = ((IMagicOnionFilterFactory<IStreamingHubFilter>)desc.Filter).CreateInstance(serviceProvider);
 
         // Assert
-        instancedFilter.Should().BeOfType<StreamingHubFilter>();
-        desc.Filter.Should().BeOfType<MagicOnionFilterDescriptor<IStreamingHubFilter>.MagicOnionFilterFromTypeFactory>()
-            .Which.Type.Should().Be(typeof(StreamingHubFilter));
+        Assert.IsType<StreamingHubFilter>(instancedFilter);
+        var filter = Assert.IsType<MagicOnionFilterDescriptor<IStreamingHubFilter>.MagicOnionFilterFromTypeFactory>(desc.Filter);
+        Assert.Equal(typeof(StreamingHubFilter), filter.Type);
     }
 
     [Fact]
@@ -143,9 +143,9 @@ public class MagicOnionFilterDescriptorTest
         var instancedFilter = ((IMagicOnionFilterFactory<IStreamingHubFilter>)desc.Filter).CreateInstance(serviceProvider);
 
         // Assert
-        instancedFilter.Should().BeOfType<StreamingHubFilter>();
-        desc.Filter.Should().BeOfType<MagicOnionFilterDescriptor<IStreamingHubFilter>.MagicOnionFilterFromTypeFactoryFactory>()
-            .Which.Type.Should().Be(typeof(StreamingHubFilterFactory));
+        Assert.IsType<StreamingHubFilter>(instancedFilter);
+        var filter = Assert.IsType<MagicOnionFilterDescriptor<IStreamingHubFilter>.MagicOnionFilterFromTypeFactoryFactory>(desc.Filter);
+        Assert.Equal(typeof(StreamingHubFilterFactory), filter.Type);
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public class MagicOnionFilterDescriptorTest
         var exception = Record.Exception(() => new MagicOnionServiceFilterDescriptor(targetType)); // MagicOnionServiceFilterDescriptor can't accept non-IMagicOnionServiceFilter types.
 
         // Assert
-        exception.Should().NotBeNull();
+        Assert.NotNull(exception);
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class MagicOnionFilterDescriptorTest
         var exception = Record.Exception(() => new StreamingHubFilterDescriptor(targetType)); // StreamingHubFilterDescriptor can't accept non-IStreamingHubFilter types.
 
         // Assert
-        exception.Should().NotBeNull();
+        Assert.NotNull(exception);
     }
 
     class ServiceFilter : IMagicOnionServiceFilter, IMagicOnionOrderedFilter

--- a/tests/MagicOnion.Server.Tests/FilterConstructorInjectionTest.cs
+++ b/tests/MagicOnion.Server.Tests/FilterConstructorInjectionTest.cs
@@ -34,36 +34,36 @@ public class FilterConstructorInjectionTest
     [Fact]
     public void TypeFilterForClassTest()
     {
-        Assert.Throws<RpcException>(() => client.A().GetAwaiter().GetResult()).Status.Detail
-            .Should().Be("ConstructorInjectedFilterAttribute");
+        var ex = Assert.Throws<RpcException>(() => client.A().GetAwaiter().GetResult());
+        Assert.Equal("ConstructorInjectedFilterAttribute", ex.Status.Detail);
     }
 
     [Fact]
     public void TypeFilterForMethodTest()
     {
-        Assert.Throws<RpcException>(() => client.A().GetAwaiter().GetResult()).Status.Detail
-            .Should().Be("ConstructorInjectedFilterAttribute");
+        var ex = Assert.Throws<RpcException>(() => client.A().GetAwaiter().GetResult());
+        Assert.Equal("ConstructorInjectedFilterAttribute", ex.Status.Detail);
     }
 
     [Fact]
     public void TypeFilterWithArgumentsForMethodTest()
     {
-        Assert.Throws<RpcException>(() => client.C().GetAwaiter().GetResult()).Status.Detail
-            .Should().Be("ConstructorInjectedFilterAttributeConstructorInjectedFilter3Attributefoo987654");
+        var ex = Assert.Throws<RpcException>(() => client.C().GetAwaiter().GetResult());
+        Assert.Equal("ConstructorInjectedFilterAttributeConstructorInjectedFilter3Attributefoo987654", ex.Status.Detail);
     }
 
     [Fact]
     public void ServiceFilterForMethodTest()
     {
-        Assert.Throws<RpcException>(() => client.D().GetAwaiter().GetResult()).Status.Detail
-            .Should().Be("ConstructorInjectedFilterAttributeServiceFilterForMethodTestFilterAttribute");
+        var ex = Assert.Throws<RpcException>(() => client.D().GetAwaiter().GetResult());
+        Assert.Equal("ConstructorInjectedFilterAttributeServiceFilterForMethodTestFilterAttribute", ex.Status.Detail);
     }
 
     [Fact]
     public void FilterFactoryTest()
     {
-        Assert.Throws<RpcException>(() => client.E().GetAwaiter().GetResult()).Status.Detail
-            .Should().Be("ConstructorInjectedFilterAttributeFilterFactoryTestFilterAttributeHogemoge");
+        var ex = Assert.Throws<RpcException>(() => client.E().GetAwaiter().GetResult());
+        Assert.Equal("ConstructorInjectedFilterAttributeFilterFactoryTestFilterAttributeHogemoge", ex.Status.Detail);
     }
 }
 

--- a/tests/MagicOnion.Server.Tests/FilterTest.cs
+++ b/tests/MagicOnion.Server.Tests/FilterTest.cs
@@ -161,13 +161,11 @@ public class FilterTest : IClassFixture<ServerFixture<FilterTester>>
     [Fact]
     public void Filter()
     {
-        Assert.Throws<RpcException>(() => client.A().GetAwaiter().GetResult()).Status.Detail
-            .Should().Be("DumpFilter, SimpleFilter1, MoreThanFilter3 : MoreThanFilter3, Begin, Finally, MoreThanFilter3msg, put-class, SimpleFilter1, Begin, Finally");
-
-        Assert.Throws<RpcException>(() => client.B().GetAwaiter().GetResult()).Status.Detail
-            .Should().Be("DumpFilter, MultiFilter2, MoreThanFilter3, SimpleFilter1 : MoreThanFilter3, Begin, Finally, MoreThanFilter3msg, put-class, MultiFilter2, Begin, Finally, MultiFilter2xyz, (99, 30, 4595), SimpleFilter1, Begin, Finally");
-
-        Assert.Throws<RpcException>(() => client.C().GetAwaiter().GetResult()).Status.Detail
-            .Should().Be("DumpFilter, SimpleFilter1, MoreThanFilter3 : MoreThanFilter3, Begin, Catch, Finally, MoreThanFilter3msg, put-class, SimpleFilter1, Begin, Catch, Finally");
+        var ex1 = Assert.Throws<RpcException>(() => client.A().GetAwaiter().GetResult());
+        Assert.Equal("DumpFilter, SimpleFilter1, MoreThanFilter3 : MoreThanFilter3, Begin, Finally, MoreThanFilter3msg, put-class, SimpleFilter1, Begin, Finally", ex1.Status.Detail);
+        var ex2 = Assert.Throws<RpcException>(() => client.B().GetAwaiter().GetResult());
+        Assert.Equal("DumpFilter, MultiFilter2, MoreThanFilter3, SimpleFilter1 : MoreThanFilter3, Begin, Finally, MoreThanFilter3msg, put-class, MultiFilter2, Begin, Finally, MultiFilter2xyz, (99, 30, 4595), SimpleFilter1, Begin, Finally", ex2.Status.Detail);
+        var ex3 = Assert.Throws<RpcException>(() => client.C().GetAwaiter().GetResult());
+        Assert.Equal("DumpFilter, SimpleFilter1, MoreThanFilter3 : MoreThanFilter3, Begin, Catch, Finally, MoreThanFilter3msg, put-class, SimpleFilter1, Begin, Catch, Finally", ex3.Status.Detail);
     }
 }

--- a/tests/MagicOnion.Server.Tests/InterfaceInheritanceTest.cs
+++ b/tests/MagicOnion.Server.Tests/InterfaceInheritanceTest.cs
@@ -44,12 +44,12 @@ public class InterfaceInheritanceTest : IClassFixture<ServerFixture<InterfaceInh
         var client = MagicOnionClient.Create<IInterfaceInheritanceService>(channel);
 
         var r = await client.Unary1(3, 4);
-        r.Should().Be(3 + 4);
+        Assert.Equal(3 + 4, r);
 
         var m = await client.UnaryBase(3, 4);
-        m.Should().Be(3 * 4);
+        Assert.Equal(3 * 4, m);
 
         var s = await client.UnaryBaseBase(3, 4);
-        s.Should().Be(3 - 4);
+        Assert.Equal(3 - 4, s);
     }
 }

--- a/tests/MagicOnion.Server.Tests/MagicOnion.Server.Tests.csproj
+++ b/tests/MagicOnion.Server.Tests/MagicOnion.Server.Tests.csproj
@@ -14,7 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit.v3" />

--- a/tests/MagicOnion.Server.Tests/MagicOnionEngineTest.cs
+++ b/tests/MagicOnion.Server.Tests/MagicOnionEngineTest.cs
@@ -26,8 +26,8 @@ public class MagicOnionEngineTest
         var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, types, options);
 
         // Assert
-        def.MethodHandlers.Should().BeEmpty();
-        def.StreamingHubHandlers.Should().BeEmpty();
+        Assert.Empty(def.MethodHandlers);
+        Assert.Empty(def.StreamingHubHandlers);
     }
 
     [Fact]
@@ -45,8 +45,8 @@ public class MagicOnionEngineTest
         var ex = Record.Exception(() => MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, types, options));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
@@ -64,8 +64,8 @@ public class MagicOnionEngineTest
         var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, types, options);
 
         // Assert
-        def.MethodHandlers.Should().HaveCount(2);
-        def.StreamingHubHandlers.Should().BeEmpty();
+        Assert.Equal(2, def.MethodHandlers.Count());
+        Assert.Empty(def.StreamingHubHandlers);
     }
 
     [Fact]
@@ -83,8 +83,8 @@ public class MagicOnionEngineTest
         var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, types, options);
 
         // Assert
-        def.MethodHandlers.Should().HaveCount(1); // Connect
-        def.StreamingHubHandlers.Should().HaveCount(2);
+        Assert.Equal(1, def.MethodHandlers.Count()); // Connect
+        Assert.Equal(2, def.StreamingHubHandlers.Count());
     }
 
     [Fact]
@@ -102,8 +102,8 @@ public class MagicOnionEngineTest
         var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, assemblies, options);
 
         // Assert
-        def.MethodHandlers.Should().HaveCount(6); // IMyHub.Connect, IMyService.MethodA, IMyService.MethodB, IMyGenericsHub.Connect, IMyGenericsService.MethodA, IMyGenericsService.MethodB
-        def.StreamingHubHandlers.Should().HaveCount(4); // IMyHub.MethodA, IMyHub.MethodB, IMyGenericsHub.MethodA, IMyGenericsHub.MethodB
+        Assert.Equal(6, def.MethodHandlers.Count()); // IMyHub.Connect, IMyService.MethodA, IMyService.MethodB, IMyGenericsHub.Connect, IMyGenericsService.MethodA, IMyGenericsService.MethodB
+        Assert.Equal(4, def.StreamingHubHandlers.Count()); // IMyHub.MethodA, IMyHub.MethodB, IMyGenericsHub.MethodA, IMyGenericsHub.MethodB
     }
     
     [Fact]
@@ -121,8 +121,8 @@ public class MagicOnionEngineTest
         var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, assemblies, options);
 
         // Assert
-        def.MethodHandlers.Should().NotContain(x => x.ServiceName.Contains("Ignored"));
-        def.StreamingHubHandlers.Should().NotContain(x => x.HubName.Contains("Ignored"));
+        Assert.DoesNotContain(def.MethodHandlers, x => x.ServiceName.Contains("Ignored"));
+        Assert.DoesNotContain(def.StreamingHubHandlers, x => x.HubName.Contains("Ignored"));
     }
   
     [Fact]
@@ -140,8 +140,8 @@ public class MagicOnionEngineTest
         var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, assemblies, options);
 
         // Assert
-        def.MethodHandlers.Should().NotContain(x => x.ServiceName.Contains("NonPublic"));
-        def.StreamingHubHandlers.Should().NotContain(x => x.HubName.Contains("NonPublic"));
+        Assert.DoesNotContain(def.MethodHandlers, x => x.ServiceName.Contains("NonPublic"));
+        Assert.DoesNotContain(def.StreamingHubHandlers, x => x.HubName.Contains("NonPublic"));
     }
  
     [Fact]
@@ -159,8 +159,8 @@ public class MagicOnionEngineTest
         var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, assemblies, options);
 
         // Assert
-        def.MethodHandlers.Should().NotContain(x => x.ServiceName.Contains("Abstract"));
-        def.StreamingHubHandlers.Should().NotContain(x => x.HubName.Contains("Abstract"));
+        Assert.DoesNotContain(def.MethodHandlers, x => x.ServiceName.Contains("Abstract"));
+        Assert.DoesNotContain(def.StreamingHubHandlers, x => x.HubName.Contains("Abstract"));
     }
 
     [Fact]
@@ -178,8 +178,8 @@ public class MagicOnionEngineTest
         var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, assemblies, options);
 
         // Assert
-        def.MethodHandlers.Should().Contain(x => x.ServiceType == typeof(MyConstructedGenericsService));
-        def.StreamingHubHandlers.Should().Contain(x => x.HubType == typeof(MyConstructedGenericsHub));
+        Assert.Contains(def.MethodHandlers, x => x.ServiceType == typeof(MyConstructedGenericsService));
+        Assert.Contains(def.StreamingHubHandlers, x => x.HubType == typeof(MyConstructedGenericsHub));
     }
     
     [Fact]
@@ -197,10 +197,10 @@ public class MagicOnionEngineTest
         var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, assemblies, options);
 
         // Assert
-        def.MethodHandlers.Should().NotContain(x => x.ServiceType.Name.Contains("GenericsDefinition"));
-        def.StreamingHubHandlers.Should().NotContain(x => x.HubType.Name.Contains("GenericsDefinition"));
-        def.MethodHandlers.Should().NotContain(x => x.ServiceType.IsGenericTypeDefinition);
-        def.StreamingHubHandlers.Should().NotContain(x => x.HubType.IsGenericTypeDefinition);
+        Assert.DoesNotContain(def.MethodHandlers, x => x.ServiceType.Name.Contains("GenericsDefinition"));
+        Assert.DoesNotContain(def.StreamingHubHandlers, x => x.HubType.Name.Contains("GenericsDefinition"));
+        Assert.DoesNotContain(def.MethodHandlers, x => x.ServiceType.IsGenericTypeDefinition);
+        Assert.DoesNotContain(def.StreamingHubHandlers, x => x.HubType.IsGenericTypeDefinition);
     }
     
     [Fact]
@@ -218,8 +218,8 @@ public class MagicOnionEngineTest
         var ex = Record.Exception(() => MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, types, options));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
@@ -237,8 +237,8 @@ public class MagicOnionEngineTest
         var ex = Record.Exception(() => MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, types, options));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
     
     [Fact]
@@ -251,7 +251,7 @@ public class MagicOnionEngineTest
         var ex = Record.Exception(() => MagicOnionEngine.VerifyServiceType(type));
 
         // Assert
-        ex.Should().BeNull();
+        Assert.Null(ex);
     }
 
     [Fact]
@@ -264,7 +264,7 @@ public class MagicOnionEngineTest
         var ex = Record.Exception(() => MagicOnionEngine.VerifyServiceType(type));
 
         // Assert
-        ex.Should().BeNull();
+        Assert.Null(ex);
     }
 
     [Fact]
@@ -277,8 +277,8 @@ public class MagicOnionEngineTest
         var ex = Record.Exception(() => MagicOnionEngine.VerifyServiceType(type));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
@@ -291,8 +291,8 @@ public class MagicOnionEngineTest
         var ex = Record.Exception(() => MagicOnionEngine.VerifyServiceType(type));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
@@ -305,8 +305,8 @@ public class MagicOnionEngineTest
         var ex = Record.Exception(() => MagicOnionEngine.VerifyServiceType(type));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
@@ -319,8 +319,8 @@ public class MagicOnionEngineTest
         var ex = Record.Exception(() => MagicOnionEngine.VerifyServiceType(type));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     class NonService : IServiceMarker {}
@@ -334,20 +334,20 @@ public class MagicOnionEngineTest
     [Fact]
     public void ShouldIgnoreAssembly()
     {
-        MagicOnionEngine.ShouldIgnoreAssembly("mscorlib").Should().BeTrue();
-        MagicOnionEngine.ShouldIgnoreAssembly("System.Private.CoreLib").Should().BeTrue();
-        MagicOnionEngine.ShouldIgnoreAssembly("Grpc.Net.Client").Should().BeTrue();
-        MagicOnionEngine.ShouldIgnoreAssembly("MagicOnion.Client").Should().BeTrue();
-        MagicOnionEngine.ShouldIgnoreAssembly("MagicOnion.Client._DynamicClient_").Should().BeTrue();
-        MagicOnionEngine.ShouldIgnoreAssembly("MagicOnion.Server").Should().BeTrue();
+        Assert.True(MagicOnionEngine.ShouldIgnoreAssembly("mscorlib"));
+        Assert.True(MagicOnionEngine.ShouldIgnoreAssembly("System.Private.CoreLib"));
+        Assert.True(MagicOnionEngine.ShouldIgnoreAssembly("Grpc.Net.Client"));
+        Assert.True(MagicOnionEngine.ShouldIgnoreAssembly("MagicOnion.Client"));
+        Assert.True(MagicOnionEngine.ShouldIgnoreAssembly("MagicOnion.Client._DynamicClient_"));
+        Assert.True(MagicOnionEngine.ShouldIgnoreAssembly("MagicOnion.Server"));
 
-        MagicOnionEngine.ShouldIgnoreAssembly("").Should().BeFalse();
-        MagicOnionEngine.ShouldIgnoreAssembly("A").Should().BeFalse();
-        MagicOnionEngine.ShouldIgnoreAssembly("AspNetCoreSample").Should().BeFalse();
-        MagicOnionEngine.ShouldIgnoreAssembly("GrpcSample").Should().BeFalse();
-        MagicOnionEngine.ShouldIgnoreAssembly("MyGrpc.Net").Should().BeFalse();
-        MagicOnionEngine.ShouldIgnoreAssembly("MyApp.System.Net").Should().BeFalse();
-        MagicOnionEngine.ShouldIgnoreAssembly("MagicOnionSample").Should().BeFalse();
+        Assert.False(MagicOnionEngine.ShouldIgnoreAssembly(""));
+        Assert.False(MagicOnionEngine.ShouldIgnoreAssembly("A"));
+        Assert.False(MagicOnionEngine.ShouldIgnoreAssembly("AspNetCoreSample"));
+        Assert.False(MagicOnionEngine.ShouldIgnoreAssembly("GrpcSample"));
+        Assert.False(MagicOnionEngine.ShouldIgnoreAssembly("MyGrpc.Net"));
+        Assert.False(MagicOnionEngine.ShouldIgnoreAssembly("MyApp.System.Net"));
+        Assert.False(MagicOnionEngine.ShouldIgnoreAssembly("MagicOnionSample"));
     }
 }
 #endif

--- a/tests/MagicOnion.Server.Tests/MagicOnionEngineTest.cs
+++ b/tests/MagicOnion.Server.Tests/MagicOnionEngineTest.cs
@@ -83,7 +83,7 @@ public class MagicOnionEngineTest
         var def = MagicOnionEngine.BuildServerServiceDefinition(serviceProvider, types, options);
 
         // Assert
-        Assert.Equal(1, def.MethodHandlers.Count()); // Connect
+        Assert.Single(def.MethodHandlers); // Connect
         Assert.Equal(2, def.StreamingHubHandlers.Count());
     }
 

--- a/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
+++ b/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
@@ -47,7 +47,7 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
 
         Assert.Empty(values);
 
-        Assert.Equal(1, values2.Count());
+        Assert.Single(values2);
         Assert.Equal(1, values2[0].Value);
         Assert.Equal("magiconion", values2[0].Tags["rpc.system"]);
         Assert.Equal(nameof(IMagicOnionMetricsTestHub), values2[0].Tags["rpc.service"]);
@@ -72,7 +72,7 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
 
         var values = collector.GetMeasurementSnapshot();
 
-        Assert.Equal(1, values.Count());
+        Assert.Single(values);
         Assert.True(values[0].Value >= 90);
         Assert.Equal("magiconion", values[0].Tags["rpc.system"]);
         Assert.Equal(nameof(IMagicOnionMetricsTestHub), values[0].Tags["rpc.service"]);
@@ -92,7 +92,7 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
 
         var values = collector.GetMeasurementSnapshot();
 
-        Assert.Equal(1, values.Count());
+        Assert.Single(values);
         Assert.Equal(1, values[0].Value);
         Assert.Equal("magiconion", values[0].Tags["rpc.system"]);
         Assert.Equal(nameof(IMagicOnionMetricsTestHub), values[0].Tags["rpc.service"]);
@@ -118,7 +118,7 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
 
         var values = collector.GetMeasurementSnapshot();
 
-        Assert.Equal(1, values.Count());
+        Assert.Single(values);
         Assert.Equal(1, values[0].Value);
         Assert.Equal(nameof(IMagicOnionMetricsTestHub), values[0].Tags["rpc.service"]);
         Assert.Equal(nameof(IMagicOnionMetricsTestHub.ThrowAsync), values[0].Tags["rpc.method"]);
@@ -143,7 +143,7 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
 
         var values = collector.GetMeasurementSnapshot();
 
-        Assert.Equal(1, values.Count());
+        Assert.Single(values);
         Assert.Equal(1, values[0].Value);
         Assert.Equal("magiconion", values[0].Tags["rpc.system"]);
         Assert.Equal(nameof(IMagicOnionMetricsTestHub), values[0].Tags["rpc.service"]);

--- a/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
+++ b/tests/MagicOnion.Server.Tests/MagicOnionMetricsTest.cs
@@ -45,18 +45,18 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
 
         values3 = collector.GetMeasurementSnapshot();
 
-        values.Should().BeEmpty();
+        Assert.Empty(values);
 
-        values2.Should().HaveCount(1);
-        values2[0].Value.Should().Be(1);
-        values2[0].Tags["rpc.system"].Should().Be("magiconion");
-        values2[0].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
+        Assert.Equal(1, values2.Count());
+        Assert.Equal(1, values2[0].Value);
+        Assert.Equal("magiconion", values2[0].Tags["rpc.system"]);
+        Assert.Equal(nameof(IMagicOnionMetricsTestHub), values2[0].Tags["rpc.service"]);
 
-        values3.Should().HaveCount(2);
-        values3[0].Value.Should().Be(1);
-        values3[1].Value.Should().Be(-1);
-        values3[1].Tags["rpc.system"].Should().Be("magiconion");
-        values3[1].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
+        Assert.Equal(2, values3.Count());
+        Assert.Equal(1, values3[0].Value);
+        Assert.Equal(-1, values3[1].Value);
+        Assert.Equal("magiconion", values3[1].Tags["rpc.system"]);
+        Assert.Equal(nameof(IMagicOnionMetricsTestHub), values3[1].Tags["rpc.service"]);
     }
 
     [Fact]
@@ -72,11 +72,11 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
 
         var values = collector.GetMeasurementSnapshot();
 
-        values.Should().HaveCount(1);
-        values[0].Value.Should().BeGreaterThanOrEqualTo(90);
-        values[0].Tags["rpc.system"].Should().Be("magiconion");
-        values[0].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
-        values[0].Tags["rpc.method"].Should().Be(nameof(IMagicOnionMetricsTestHub.SleepAsync));
+        Assert.Equal(1, values.Count());
+        Assert.True(values[0].Value >= 90);
+        Assert.Equal("magiconion", values[0].Tags["rpc.system"]);
+        Assert.Equal(nameof(IMagicOnionMetricsTestHub), values[0].Tags["rpc.service"]);
+        Assert.Equal(nameof(IMagicOnionMetricsTestHub.SleepAsync), values[0].Tags["rpc.method"]);
     }
 
     [Fact]
@@ -92,12 +92,12 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
 
         var values = collector.GetMeasurementSnapshot();
 
-        values.Should().HaveCount(1);
-        values[0].Value.Should().Be(1);
-        values[0].Tags["rpc.system"].Should().Be("magiconion");
-        values[0].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
-        values[0].Tags["rpc.method"].Should().Be(nameof(IMagicOnionMetricsTestHub.MethodAsync));
-        values[0].Tags["magiconion.streaminghub.is_error"].Should().Be(false);
+        Assert.Equal(1, values.Count());
+        Assert.Equal(1, values[0].Value);
+        Assert.Equal("magiconion", values[0].Tags["rpc.system"]);
+        Assert.Equal(nameof(IMagicOnionMetricsTestHub), values[0].Tags["rpc.service"]);
+        Assert.Equal(nameof(IMagicOnionMetricsTestHub.MethodAsync), values[0].Tags["rpc.method"]);
+        Assert.Equal(false, values[0].Tags["magiconion.streaminghub.is_error"]);
     }
 
     [Fact]
@@ -118,11 +118,11 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
 
         var values = collector.GetMeasurementSnapshot();
 
-        values.Should().HaveCount(1);
-        values[0].Value.Should().Be(1);
-        values[0].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
-        values[0].Tags["rpc.method"].Should().Be(nameof(IMagicOnionMetricsTestHub.ThrowAsync));
-        values[0].Tags["magiconion.streaminghub.is_error"].Should().Be(true);
+        Assert.Equal(1, values.Count());
+        Assert.Equal(1, values[0].Value);
+        Assert.Equal(nameof(IMagicOnionMetricsTestHub), values[0].Tags["rpc.service"]);
+        Assert.Equal(nameof(IMagicOnionMetricsTestHub.ThrowAsync), values[0].Tags["rpc.method"]);
+        Assert.Equal(true, values[0].Tags["magiconion.streaminghub.is_error"]);
     }
 
     [Fact]
@@ -143,12 +143,12 @@ public class MagicOnionMetricsTest : IClassFixture<MagicOnionApplicationFactory<
 
         var values = collector.GetMeasurementSnapshot();
 
-        values.Should().HaveCount(1);
-        values[0].Value.Should().Be(1);
-        values[0].Tags["rpc.system"].Should().Be("magiconion");
-        values[0].Tags["rpc.service"].Should().Be(nameof(IMagicOnionMetricsTestHub));
-        values[0].Tags["rpc.method"].Should().Be(nameof(IMagicOnionMetricsTestHub.ThrowAsync));
-        values[0].Tags["error.type"].Should().Be("System.InvalidOperationException");
+        Assert.Equal(1, values.Count());
+        Assert.Equal(1, values[0].Value);
+        Assert.Equal("magiconion", values[0].Tags["rpc.system"]);
+        Assert.Equal(nameof(IMagicOnionMetricsTestHub), values[0].Tags["rpc.service"]);
+        Assert.Equal(nameof(IMagicOnionMetricsTestHub.ThrowAsync), values[0].Tags["rpc.method"]);
+        Assert.Equal("System.InvalidOperationException", values[0].Tags["error.type"]);
     }
 
     class Receiver : IMagicOnionMetricsTestHubReceiver

--- a/tests/MagicOnion.Server.Tests/MethodHandlerMetadataFactoryTest.cs
+++ b/tests/MagicOnion.Server.Tests/MethodHandlerMetadataFactoryTest.cs
@@ -45,9 +45,9 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        Assert.Equal(1, metadata.AttributeLookup.Count());
+        Assert.Single(metadata.AttributeLookup);
         Assert.Equal([typeof(MyFirstAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
     }
 
     [Fact]
@@ -63,8 +63,8 @@ public class MethodHandlerMetadataFactoryTest
         // Assert
         Assert.Equal(2, metadata.AttributeLookup.Count());
         Assert.Equal([typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
+        Assert.Single(metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public class MethodHandlerMetadataFactoryTest
         // Assert
         Assert.Equal(2, metadata.AttributeLookup.Count());
         Assert.Equal([typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
         Assert.Equal(3, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
         Assert.Equal([new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2)], metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }
@@ -96,9 +96,9 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        Assert.Equal(1, metadata.AttributeLookup.Count());
+        Assert.Single(metadata.AttributeLookup);
         Assert.Equal([typeof(MyThirdAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyThirdAttribute)]);
     }
 
     [Fact]
@@ -114,8 +114,8 @@ public class MethodHandlerMetadataFactoryTest
         // Assert
         Assert.Equal(2, metadata.AttributeLookup.Count());
         Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyThirdAttribute)]);
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
     }
 
     [Fact]
@@ -131,9 +131,9 @@ public class MethodHandlerMetadataFactoryTest
         // Assert
         Assert.Equal(3, metadata.AttributeLookup.Count());
         Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyThirdAttribute)]);
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
+        Assert.Single(metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }
 
     [Fact]
@@ -149,8 +149,8 @@ public class MethodHandlerMetadataFactoryTest
         // Assert
         Assert.Equal(3, metadata.AttributeLookup.Count());
         Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyThirdAttribute)]);
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
         Assert.Equal(3, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
         Assert.Equal([new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2)], metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }

--- a/tests/MagicOnion.Server.Tests/MethodHandlerMetadataFactoryTest.cs
+++ b/tests/MagicOnion.Server.Tests/MethodHandlerMetadataFactoryTest.cs
@@ -16,8 +16,8 @@ public class MethodHandlerMetadataFactoryTest
         var ex = Record.Exception(() => MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().BeEmpty();
+        Assert.Empty(metadata.AttributeLookup);
     }
 
     [Fact]
@@ -45,9 +45,9 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(1);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyFirstAttribute));
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
+        Assert.Equal(1, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyFirstAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
     }
 
     [Fact]
@@ -61,10 +61,10 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(2);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyFirstAttribute), typeof(MySecondAttribute));
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().HaveCount(1);
+        Assert.Equal(2, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
     }
 
     [Fact]
@@ -78,11 +78,11 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(2);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyFirstAttribute), typeof(MySecondAttribute));
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().HaveCount(3);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().Equal(new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2));
+        Assert.Equal(2, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Equal(3, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
+        Assert.Equal([new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2)], metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }
 
     [Fact]
@@ -96,9 +96,9 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(1);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyThirdAttribute));
-        metadata.AttributeLookup[typeof(MyThirdAttribute)].Should().HaveCount(1);
+        Assert.Equal(1, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyThirdAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
     }
 
     [Fact]
@@ -112,10 +112,10 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(2);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyThirdAttribute), typeof(MyFirstAttribute));
-        metadata.AttributeLookup[typeof(MyThirdAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
+        Assert.Equal(2, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
     }
 
     [Fact]
@@ -129,11 +129,11 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(3);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute));
-        metadata.AttributeLookup[typeof(MyThirdAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().HaveCount(1);
+        Assert.Equal(3, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
     }
 
     [Fact]
@@ -147,12 +147,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(3);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute));
-        metadata.AttributeLookup[typeof(MyThirdAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().HaveCount(3);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().Equal(new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2));
+        Assert.Equal(3, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Equal(3, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
+        Assert.Equal([new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2)], metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }
 
     [Fact]
@@ -166,12 +166,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.Unary);
-        metadata.RequestType.Should().Be<MessagePack.Nil>();
-        metadata.ResponseType.Should().Be<int>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.Unary, metadata.MethodType);
+        Assert.Equal(typeof(MessagePack.Nil), metadata.RequestType);
+        Assert.Equal(typeof(int), metadata.ResponseType);
     }
 
     [Fact]
@@ -185,12 +185,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.Unary);
-        metadata.RequestType.Should().Be<int>();
-        metadata.ResponseType.Should().Be<int>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.Unary, metadata.MethodType);
+        Assert.Equal(typeof(int), metadata.RequestType);
+        Assert.Equal(typeof(int), metadata.ResponseType);
     }
 
     [Fact]
@@ -204,12 +204,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.Unary);
-        metadata.RequestType.Should().Be<DynamicArgumentTuple<int, string>>();
-        metadata.ResponseType.Should().Be<int>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.Unary, metadata.MethodType);
+        Assert.Equal(typeof(DynamicArgumentTuple<int, string>), metadata.RequestType);
+        Assert.Equal(typeof(int), metadata.ResponseType);
     }
 
     [Fact]
@@ -223,12 +223,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.ServerStreaming);
-        metadata.RequestType.Should().Be<MessagePack.Nil>();
-        metadata.ResponseType.Should().Be<int>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.ServerStreaming, metadata.MethodType);
+        Assert.Equal(typeof(MessagePack.Nil), metadata.RequestType);
+        Assert.Equal(typeof(int), metadata.ResponseType);
     }
 
     [Fact]
@@ -242,12 +242,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.ServerStreaming);
-        metadata.RequestType.Should().Be<int>();
-        metadata.ResponseType.Should().Be<int>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.ServerStreaming, metadata.MethodType);
+        Assert.Equal(typeof(int), metadata.RequestType);
+        Assert.Equal(typeof(int), metadata.ResponseType);
     }
 
     [Fact]
@@ -261,12 +261,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.ServerStreaming);
-        metadata.RequestType.Should().Be<DynamicArgumentTuple<int, string>>();
-        metadata.ResponseType.Should().Be<int>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.ServerStreaming, metadata.MethodType);
+        Assert.Equal(typeof(DynamicArgumentTuple<int, string>), metadata.RequestType);
+        Assert.Equal(typeof(int), metadata.ResponseType);
     }
 
 
@@ -281,12 +281,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.ServerStreaming);
-        metadata.RequestType.Should().Be<MessagePack.Nil>();
-        metadata.ResponseType.Should().Be<int>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.ServerStreaming, metadata.MethodType);
+        Assert.Equal(typeof(MessagePack.Nil), metadata.RequestType);
+        Assert.Equal(typeof(int), metadata.ResponseType);
     }
 
     [Fact]
@@ -300,12 +300,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.ServerStreaming);
-        metadata.RequestType.Should().Be<int>();
-        metadata.ResponseType.Should().Be<int>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.ServerStreaming, metadata.MethodType);
+        Assert.Equal(typeof(int), metadata.RequestType);
+        Assert.Equal(typeof(int), metadata.ResponseType);
     }
 
     [Fact]
@@ -319,12 +319,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.ServerStreaming);
-        metadata.RequestType.Should().Be<DynamicArgumentTuple<int, string>>();
-        metadata.ResponseType.Should().Be<int>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.ServerStreaming, metadata.MethodType);
+        Assert.Equal(typeof(DynamicArgumentTuple<int, string>), metadata.RequestType);
+        Assert.Equal(typeof(int), metadata.ResponseType);
     }
 
     [Fact]
@@ -338,12 +338,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.ClientStreaming);
-        metadata.RequestType.Should().Be<int>();
-        metadata.ResponseType.Should().Be<string>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.ClientStreaming, metadata.MethodType);
+        Assert.Equal(typeof(int), metadata.RequestType);
+        Assert.Equal(typeof(string), metadata.ResponseType);
     }
 
     [Fact]
@@ -357,8 +357,8 @@ public class MethodHandlerMetadataFactoryTest
         var ex = Record.Exception(() => MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
@@ -372,12 +372,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.ClientStreaming);
-        metadata.RequestType.Should().Be<int>();
-        metadata.ResponseType.Should().Be<string>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.ClientStreaming, metadata.MethodType);
+        Assert.Equal(typeof(int), metadata.RequestType);
+        Assert.Equal(typeof(string), metadata.ResponseType);
     }
 
     [Fact]
@@ -391,8 +391,8 @@ public class MethodHandlerMetadataFactoryTest
         var ex = Record.Exception(() => MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
@@ -406,12 +406,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.DuplexStreaming);
-        metadata.RequestType.Should().Be<int>();
-        metadata.ResponseType.Should().Be<string>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.DuplexStreaming, metadata.MethodType);
+        Assert.Equal(typeof(int), metadata.RequestType);
+        Assert.Equal(typeof(string), metadata.ResponseType);
     }
 
     [Fact]
@@ -425,8 +425,8 @@ public class MethodHandlerMetadataFactoryTest
         var ex = Record.Exception(() => MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
@@ -440,12 +440,12 @@ public class MethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.ServiceImplementationType.Should().Be<MyService>();
-        metadata.ServiceImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.ServiceInterface.Should().Be<IMyService>();
-        metadata.MethodType.Should().Be(MethodType.DuplexStreaming);
-        metadata.RequestType.Should().Be<int>();
-        metadata.ResponseType.Should().Be<string>();
+        Assert.Equal(typeof(MyService), metadata.ServiceImplementationType);
+        Assert.Same(methodInfo, metadata.ServiceImplementationMethod);
+        Assert.Equal(typeof(IMyService), metadata.ServiceInterface);
+        Assert.Equal(MethodType.DuplexStreaming, metadata.MethodType);
+        Assert.Equal(typeof(int), metadata.RequestType);
+        Assert.Equal(typeof(string), metadata.ResponseType);
     }
 
     [Fact]
@@ -459,8 +459,8 @@ public class MethodHandlerMetadataFactoryTest
         var ex = Record.Exception(() => MethodHandlerMetadataFactory.CreateServiceMethodHandlerMetadata(serviceType, methodInfo));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     interface IMyService : IService<IMyService>

--- a/tests/MagicOnion.Server.Tests/ReturnStatusTest.cs
+++ b/tests/MagicOnion.Server.Tests/ReturnStatusTest.cs
@@ -113,6 +113,6 @@ public class ReturnStatusTest : IClassFixture<ServerFixture<ReturnStatus>>
             client.CustomThrow(123).GetAwaiter().GetResult();
         });
 
-        ex.Status.StatusCode.Should().Be((StatusCode)123);
+        Assert.Equal((StatusCode)123, ex.Status.StatusCode);
     }
 }

--- a/tests/MagicOnion.Server.Tests/StreamingHubHandlerTest.cs
+++ b/tests/MagicOnion.Server.Tests/StreamingHubHandlerTest.cs
@@ -35,7 +35,7 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameterless_Returns_Task) + " called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameterless_Returns_Task) + " called.", hubInstance.Results);
         byte[] BuildMessage()
         {
             // [MessageId, MethodId, Nil]
@@ -49,7 +49,7 @@ public class StreamingHubHandlerTest
 
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage());
+        Assert.Equal(BuildMessage(), fakeStreamingHubContext.Responses[0].Memory.ToArray());
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameterless_Returns_TaskOfInt32) + " called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameterless_Returns_TaskOfInt32) + " called.", hubInstance.Results);
         byte[] BuildMessage()
         {
             // [MessageId, MethodId, {Int32:12345}]
@@ -87,7 +87,7 @@ public class StreamingHubHandlerTest
 
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage());
+        Assert.Equal(BuildMessage(), fakeStreamingHubContext.Responses[0].Memory.ToArray());
     }
     [Fact]
     public async Task Parameterless_Returns_ValueTask()
@@ -110,7 +110,7 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameterless_Returns_ValueTask) + " called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameterless_Returns_ValueTask) + " called.", hubInstance.Results);
         byte[] BuildMessage()
         {
             // [MessageId, MethodId, Nil]
@@ -124,7 +124,7 @@ public class StreamingHubHandlerTest
 
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage());
+        Assert.Equal(BuildMessage(), fakeStreamingHubContext.Responses[0].Memory.ToArray());
     }
 
     [Fact]
@@ -148,7 +148,7 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameterless_Returns_ValueTaskOfInt32) + " called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameterless_Returns_ValueTaskOfInt32) + " called.", hubInstance.Results);
         byte[] BuildMessage()
         {
             // [MessageId, MethodId, {Int32:12345}]
@@ -162,7 +162,7 @@ public class StreamingHubHandlerTest
 
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage());
+        Assert.Equal(BuildMessage(), fakeStreamingHubContext.Responses[0].Memory.ToArray());
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameter_Single_Returns_Task) + "(12345) called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameter_Single_Returns_Task) + "(12345) called.", hubInstance.Results);
         byte[] BuildMessage()
         {
             // [MessageId, MethodId, Nil]
@@ -200,7 +200,7 @@ public class StreamingHubHandlerTest
 
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage());
+        Assert.Equal(BuildMessage(), fakeStreamingHubContext.Responses[0].Memory.ToArray());
     }
 
     [Fact]
@@ -224,7 +224,7 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_Task) + "(12345,テスト,True) called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_Task) + "(12345,テスト,True) called.", hubInstance.Results);
         byte[] BuildMessage()
         {
             // [MessageId, MethodId, Nil]
@@ -237,7 +237,7 @@ public class StreamingHubHandlerTest
             writer.Flush();
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage());
+        Assert.Equal(BuildMessage(), fakeStreamingHubContext.Responses[0].Memory.ToArray());
     }
 
     [Fact]
@@ -261,7 +261,7 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_TaskOfInt32) + "(12345,テスト,True) called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_TaskOfInt32) + "(12345,テスト,True) called.", hubInstance.Results);
         byte[] BuildMessage()
         {
             // [MessageId, MethodId, {Int32:12345}]
@@ -274,7 +274,7 @@ public class StreamingHubHandlerTest
             writer.Flush();
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage());
+        Assert.Equal(BuildMessage(), fakeStreamingHubContext.Responses[0].Memory.ToArray());
     }
 
     [Fact]
@@ -301,9 +301,9 @@ public class StreamingHubHandlerTest
         }
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_TaskOfInt32) + "(0,テスト0,True) called.");
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_TaskOfInt32) + "(1,テスト1,False) called.");
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_TaskOfInt32) + "(2,テスト2,True) called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_TaskOfInt32) + "(0,テスト0,True) called.", hubInstance.Results);
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_TaskOfInt32) + "(1,テスト1,False) called.", hubInstance.Results);
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_TaskOfInt32) + "(2,テスト2,True) called.", hubInstance.Results);
 
         byte[] BuildMessage(int messageId, int retVal)
         {
@@ -317,9 +317,9 @@ public class StreamingHubHandlerTest
             writer.Flush();
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage(0, 0));
-        fakeStreamingHubContext.Responses[1].Memory.ToArray().Should().Equal(BuildMessage(1000, 1));
-        fakeStreamingHubContext.Responses[2].Memory.ToArray().Should().Equal(BuildMessage(2000, 2));
+        Assert.Equal(BuildMessage(0, 0), fakeStreamingHubContext.Responses[0].Memory.ToArray());
+        Assert.Equal(BuildMessage(1000, 1), fakeStreamingHubContext.Responses[1].Memory.ToArray());
+        Assert.Equal(BuildMessage(2000, 2), fakeStreamingHubContext.Responses[2].Memory.ToArray());
     }
 
     [Fact]
@@ -343,7 +343,7 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameterless_Void) + " called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameterless_Void) + " called.", hubInstance.Results);
         byte[] BuildMessage()
         {
             // [MessageId, MethodId, Nil]
@@ -357,7 +357,7 @@ public class StreamingHubHandlerTest
 
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage());
+        Assert.Equal(BuildMessage(), fakeStreamingHubContext.Responses[0].Memory.ToArray());
     }
 
     [Fact]
@@ -381,7 +381,7 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameter_Single_Void) + "(12345) called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameter_Single_Void) + "(12345) called.", hubInstance.Results);
         byte[] BuildMessage()
         {
             // [MessageId, MethodId, Nil]
@@ -395,7 +395,7 @@ public class StreamingHubHandlerTest
 
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage());
+        Assert.Equal(BuildMessage(), fakeStreamingHubContext.Responses[0].Memory.ToArray());
     }
 
     [Fact]
@@ -419,7 +419,7 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Void) + "(12345,テスト,True) called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Void) + "(12345,テスト,True) called.", hubInstance.Results);
         byte[] BuildMessage()
         {
             // [MessageId, MethodId, Nil]
@@ -433,7 +433,7 @@ public class StreamingHubHandlerTest
 
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage());
+        Assert.Equal(BuildMessage(), fakeStreamingHubContext.Responses[0].Memory.ToArray());
     }
 
     [Fact]
@@ -457,8 +457,8 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Void) + "(12345,テスト,True) called.");
-        fakeStreamingHubContext.Responses.Should().BeEmpty();
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Void) + "(12345,テスト,True) called.", hubInstance.Results);
+        Assert.Empty(fakeStreamingHubContext.Responses);
     }
 
     [Fact]
@@ -488,7 +488,7 @@ public class StreamingHubHandlerTest
         await handler.MethodBody.Invoke(ctx);
 
         // Assert
-        hubInstance.Results.Should().Contain(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_TaskOfInt32) + "(12345,テスト,True) called.");
+        Assert.Contains(nameof(StreamingHubHandlerTestHub.Method_Parameter_Multiple_Returns_TaskOfInt32) + "(12345,テスト,True) called.", hubInstance.Results);
         byte[] BuildMessage()
         {
             // [MessageId, MethodId, {Xor:Int32:12345}]
@@ -501,7 +501,7 @@ public class StreamingHubHandlerTest
             serializer.Serialize(buffer, 12345);
             return buffer.WrittenMemory.ToArray();
         }
-        fakeStreamingHubContext.Responses[0].Memory.ToArray().Should().Equal(BuildMessage());
+        Assert.Equal(BuildMessage(), fakeStreamingHubContext.Responses[0].Memory.ToArray());
     }
 
     [Fact]

--- a/tests/MagicOnion.Server.Tests/StreamingHubMethodHandlerMetadataFactoryTest.cs
+++ b/tests/MagicOnion.Server.Tests/StreamingHubMethodHandlerMetadataFactoryTest.cs
@@ -134,7 +134,7 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         Assert.Equal(typeof(IMyHub), metadata.StreamingHubInterfaceType);
         Assert.Same(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_OneParameter)), metadata.InterfaceMethod);
         Assert.Same(methodInfo, metadata.ImplementationMethod);
-        Assert.Equal(1, metadata.Parameters.Count());
+        Assert.Single(metadata.Parameters);
         Assert.Equal(typeof(int), metadata.RequestType);
         Assert.Null(metadata.ResponseType);
     }
@@ -184,9 +184,9 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        Assert.Equal(1, metadata.AttributeLookup.Count());
+        Assert.Single(metadata.AttributeLookup);
         Assert.Equal([typeof(MyFirstAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
     }
 
     [Fact]
@@ -202,8 +202,8 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         // Assert
         Assert.Equal(2, metadata.AttributeLookup.Count());
         Assert.Equal([typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
+        Assert.Single(metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }
 
     [Fact]
@@ -219,7 +219,7 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         // Assert
         Assert.Equal(2, metadata.AttributeLookup.Count());
         Assert.Equal([typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
         Assert.Equal(3, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
         Assert.Equal([new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2)], metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }
@@ -235,9 +235,9 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        Assert.Equal(1, metadata.AttributeLookup.Count());
+        Assert.Single(metadata.AttributeLookup);
         Assert.Equal([typeof(MyThirdAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyThirdAttribute)]);
     }
 
     [Fact]
@@ -253,8 +253,8 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         // Assert
         Assert.Equal(2, metadata.AttributeLookup.Count());
         Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyThirdAttribute)]);
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
     }
 
     [Fact]
@@ -270,9 +270,9 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         // Assert
         Assert.Equal(3, metadata.AttributeLookup.Count());
         Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyThirdAttribute)]);
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
+        Assert.Single(metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }
 
     [Fact]
@@ -288,8 +288,8 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         // Assert
         Assert.Equal(3, metadata.AttributeLookup.Count());
         Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
-        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Single(metadata.AttributeLookup[typeof(MyThirdAttribute)]);
+        Assert.Single(metadata.AttributeLookup[typeof(MyFirstAttribute)]);
         Assert.Equal(3, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
         Assert.Equal([new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2)], metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }

--- a/tests/MagicOnion.Server.Tests/StreamingHubMethodHandlerMetadataFactoryTest.cs
+++ b/tests/MagicOnion.Server.Tests/StreamingHubMethodHandlerMetadataFactoryTest.cs
@@ -18,7 +18,7 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo);
 
         // Assert
-        metadata.MethodId.Should().Be(FNV1A32.GetHashCode(nameof(IMyHub_MethodId.Method_Default)));
+        Assert.Equal(FNV1A32.GetHashCode(nameof(IMyHub_MethodId.Method_Default)), metadata.MethodId);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo);
 
         // Assert
-        metadata.MethodId.Should().Be(12345);
+        Assert.Equal(12345, metadata.MethodId);
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var ex = Record.Exception(() => MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo));
 
         // Assert
-        ex.Should().NotBeNull();
+        Assert.NotNull(ex);
     }
 
     [Fact]
@@ -60,8 +60,8 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var ex = Record.Exception(() => MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
@@ -75,8 +75,8 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var ex = Record.Exception(() => MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo));
 
         // Assert
-        ex.Should().NotBeNull();
-        ex.Should().BeOfType<InvalidOperationException>();
+        Assert.NotNull(ex);
+        Assert.IsType<InvalidOperationException>(ex);
     }
 
     [Fact]
@@ -90,13 +90,13 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo);
 
         // Assert
-        metadata.StreamingHubImplementationType.Should().Be<MyHub>();
-        metadata.StreamingHubInterfaceType.Should().Be<IMyHub>();
-        metadata.InterfaceMethod.Should().BeSameAs(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_Task)));
-        metadata.ImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.Parameters.Should().BeEmpty();
-        metadata.RequestType.Should().Be<Nil>();
-        metadata.ResponseType.Should().BeNull();
+        Assert.Equal(typeof(MyHub), metadata.StreamingHubImplementationType);
+        Assert.Equal(typeof(IMyHub), metadata.StreamingHubInterfaceType);
+        Assert.Same(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_Task)), metadata.InterfaceMethod);
+        Assert.Same(methodInfo, metadata.ImplementationMethod);
+        Assert.Empty(metadata.Parameters);
+        Assert.Equal(typeof(Nil), metadata.RequestType);
+        Assert.Null(metadata.ResponseType);
     }
 
     [Fact]
@@ -110,13 +110,13 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo);
 
         // Assert
-        metadata.StreamingHubImplementationType.Should().Be<MyHub>();
-        metadata.StreamingHubInterfaceType.Should().Be<IMyHub>();
-        metadata.InterfaceMethod.Should().BeSameAs(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_TaskOfValue)));
-        metadata.ImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.Parameters.Should().BeEmpty();
-        metadata.RequestType.Should().Be<Nil>();
-        metadata.ResponseType.Should().Be<int>();
+        Assert.Equal(typeof(MyHub), metadata.StreamingHubImplementationType);
+        Assert.Equal(typeof(IMyHub), metadata.StreamingHubInterfaceType);
+        Assert.Same(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_TaskOfValue)), metadata.InterfaceMethod);
+        Assert.Same(methodInfo, metadata.ImplementationMethod);
+        Assert.Empty(metadata.Parameters);
+        Assert.Equal(typeof(Nil), metadata.RequestType);
+        Assert.Equal(typeof(int), metadata.ResponseType);
     }
 
     [Fact]
@@ -130,13 +130,13 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo);
 
         // Assert
-        metadata.StreamingHubImplementationType.Should().Be<MyHub>();
-        metadata.StreamingHubInterfaceType.Should().Be<IMyHub>();
-        metadata.InterfaceMethod.Should().BeSameAs(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_OneParameter)));
-        metadata.ImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.Parameters.Should().HaveCount(1);
-        metadata.RequestType.Should().Be<int>();
-        metadata.ResponseType.Should().BeNull();
+        Assert.Equal(typeof(MyHub), metadata.StreamingHubImplementationType);
+        Assert.Equal(typeof(IMyHub), metadata.StreamingHubInterfaceType);
+        Assert.Same(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_OneParameter)), metadata.InterfaceMethod);
+        Assert.Same(methodInfo, metadata.ImplementationMethod);
+        Assert.Equal(1, metadata.Parameters.Count());
+        Assert.Equal(typeof(int), metadata.RequestType);
+        Assert.Null(metadata.ResponseType);
     }
 
     [Fact]
@@ -150,13 +150,13 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo);
 
         // Assert
-        metadata.StreamingHubImplementationType.Should().Be<MyHub>();
-        metadata.StreamingHubInterfaceType.Should().Be<IMyHub>();
-        metadata.InterfaceMethod.Should().BeSameAs(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_TwoParameters)));
-        metadata.ImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.Parameters.Should().HaveCount(2);
-        metadata.RequestType.Should().Be<DynamicArgumentTuple<int, string>>();
-        metadata.ResponseType.Should().BeNull();
+        Assert.Equal(typeof(MyHub), metadata.StreamingHubImplementationType);
+        Assert.Equal(typeof(IMyHub), metadata.StreamingHubInterfaceType);
+        Assert.Same(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_TwoParameters)), metadata.InterfaceMethod);
+        Assert.Same(methodInfo, metadata.ImplementationMethod);
+        Assert.Equal(2, metadata.Parameters.Count());
+        Assert.Equal(typeof(DynamicArgumentTuple<int, string>), metadata.RequestType);
+        Assert.Null(metadata.ResponseType);
     }
 
     [Fact]
@@ -170,7 +170,7 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().BeEmpty();
+        Assert.Empty(metadata.AttributeLookup);
     }
 
     [Fact]
@@ -184,9 +184,9 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(1);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyFirstAttribute));
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
+        Assert.Equal(1, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyFirstAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
     }
 
     [Fact]
@@ -200,10 +200,10 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(2);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyFirstAttribute), typeof(MySecondAttribute));
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().HaveCount(1);
+        Assert.Equal(2, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
     }
 
     [Fact]
@@ -217,11 +217,11 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(2);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyFirstAttribute), typeof(MySecondAttribute));
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().HaveCount(3);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().Equal(new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2));
+        Assert.Equal(2, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Equal(3, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
+        Assert.Equal([new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2)], metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }
 
     [Fact]
@@ -235,9 +235,9 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(1);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyThirdAttribute));
-        metadata.AttributeLookup[typeof(MyThirdAttribute)].Should().HaveCount(1);
+        Assert.Equal(1, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyThirdAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
     }
 
     [Fact]
@@ -251,10 +251,10 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(2);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyThirdAttribute), typeof(MyFirstAttribute));
-        metadata.AttributeLookup[typeof(MyThirdAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
+        Assert.Equal(2, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
     }
 
     [Fact]
@@ -268,11 +268,11 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(3);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute));
-        metadata.AttributeLookup[typeof(MyThirdAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().HaveCount(1);
+        Assert.Equal(3, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
     }
 
     [Fact]
@@ -286,12 +286,12 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.AttributeLookup.Should().HaveCount(3);
-        metadata.AttributeLookup.Select(x => x.Key).Should().Equal(typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute));
-        metadata.AttributeLookup[typeof(MyThirdAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MyFirstAttribute)].Should().HaveCount(1);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().HaveCount(3);
-        metadata.AttributeLookup[typeof(MySecondAttribute)].Should().Equal(new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2));
+        Assert.Equal(3, metadata.AttributeLookup.Count());
+        Assert.Equal([typeof(MyThirdAttribute), typeof(MyFirstAttribute), typeof(MySecondAttribute)], metadata.AttributeLookup.Select(x => x.Key));
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyThirdAttribute)].Count());
+        Assert.Equal(1, metadata.AttributeLookup[typeof(MyFirstAttribute)].Count());
+        Assert.Equal(3, metadata.AttributeLookup[typeof(MySecondAttribute)].Count());
+        Assert.Equal([new MySecondAttribute(0), new MySecondAttribute(1), new MySecondAttribute(2)], metadata.AttributeLookup[typeof(MySecondAttribute)]);
     }
 
     [Fact]
@@ -305,11 +305,11 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(serviceType, methodInfo);
 
         // Assert
-        metadata.Metadata.Should().HaveCount(5);
-        metadata.Metadata.Select(x => x.GetType().Name).Should().Equal([ /* Class */ nameof(MyThirdAttribute),  /* Method */ nameof(MyFirstAttribute), nameof(MySecondAttribute), nameof(MySecondAttribute), nameof(MySecondAttribute)]);
-        metadata.Metadata[2].Should().BeOfType<MySecondAttribute>().Subject.Value.Should().Be(0);
-        metadata.Metadata[3].Should().BeOfType<MySecondAttribute>().Subject.Value.Should().Be(1);
-        metadata.Metadata[4].Should().BeOfType<MySecondAttribute>().Subject.Value.Should().Be(2);
+        Assert.Equal(5, metadata.Metadata.Count());
+        Assert.Equal([ /* Class */ nameof(MyThirdAttribute),  /* Method */ nameof(MyFirstAttribute), nameof(MySecondAttribute), nameof(MySecondAttribute), nameof(MySecondAttribute)], metadata.Metadata.Select(x => x.GetType().Name));
+        Assert.Equal(0, Assert.IsType<MySecondAttribute>(metadata.Metadata[2]).Value);
+        Assert.Equal(1, Assert.IsType<MySecondAttribute>(metadata.Metadata[3]).Value);
+        Assert.Equal(2, Assert.IsType<MySecondAttribute>(metadata.Metadata[4]).Value);
     }
 
     [Fact]
@@ -323,13 +323,13 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo);
 
         // Assert
-        metadata.StreamingHubImplementationType.Should().Be<MyHub>();
-        metadata.StreamingHubInterfaceType.Should().Be<IMyHub>();
-        metadata.InterfaceMethod.Should().BeSameAs(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_ValueTask)));
-        metadata.ImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.Parameters.Should().BeEmpty();
-        metadata.RequestType.Should().Be<Nil>();
-        metadata.ResponseType.Should().BeNull();
+        Assert.Equal(typeof(MyHub), metadata.StreamingHubImplementationType);
+        Assert.Equal(typeof(IMyHub), metadata.StreamingHubInterfaceType);
+        Assert.Same(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_ValueTask)), metadata.InterfaceMethod);
+        Assert.Same(methodInfo, metadata.ImplementationMethod);
+        Assert.Empty(metadata.Parameters);
+        Assert.Equal(typeof(Nil), metadata.RequestType);
+        Assert.Null(metadata.ResponseType);
     }
 
     [Fact]
@@ -343,13 +343,13 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo);
 
         // Assert
-        metadata.StreamingHubImplementationType.Should().Be<MyHub>();
-        metadata.StreamingHubInterfaceType.Should().Be<IMyHub>();
-        metadata.InterfaceMethod.Should().BeSameAs(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_ValueTaskOfValue)));
-        metadata.ImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.Parameters.Should().BeEmpty();
-        metadata.RequestType.Should().Be<Nil>();
-        metadata.ResponseType.Should().Be<int>();
+        Assert.Equal(typeof(MyHub), metadata.StreamingHubImplementationType);
+        Assert.Equal(typeof(IMyHub), metadata.StreamingHubInterfaceType);
+        Assert.Same(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_ValueTaskOfValue)), metadata.InterfaceMethod);
+        Assert.Same(methodInfo, metadata.ImplementationMethod);
+        Assert.Empty(metadata.Parameters);
+        Assert.Equal(typeof(Nil), metadata.RequestType);
+        Assert.Equal(typeof(int), metadata.ResponseType);
     }
 
     [Fact]
@@ -363,13 +363,13 @@ public class StreamingHubMethodHandlerMetadataFactoryTest
         var metadata = MethodHandlerMetadataFactory.CreateStreamingHubMethodHandlerMetadata(type, methodInfo);
 
         // Assert
-        metadata.StreamingHubImplementationType.Should().Be<MyHub>();
-        metadata.StreamingHubInterfaceType.Should().Be<IMyHub>();
-        metadata.InterfaceMethod.Should().BeSameAs(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_Void)));
-        metadata.ImplementationMethod.Should().BeSameAs(methodInfo);
-        metadata.Parameters.Should().BeEmpty();
-        metadata.RequestType.Should().Be<Nil>();
-        metadata.ResponseType.Should().BeNull();
+        Assert.Equal(typeof(MyHub), metadata.StreamingHubImplementationType);
+        Assert.Equal(typeof(IMyHub), metadata.StreamingHubInterfaceType);
+        Assert.Same(typeof(IMyHub).GetMethod(nameof(IMyHub.Method_Void)), metadata.InterfaceMethod);
+        Assert.Same(methodInfo, metadata.ImplementationMethod);
+        Assert.Empty(metadata.Parameters);
+        Assert.Equal(typeof(Nil), metadata.RequestType);
+        Assert.Null(metadata.ResponseType);
     }
 
     interface IMyHubReceiver

--- a/tests/MagicOnion.Server.Tests/StreamingHubTest.cs
+++ b/tests/MagicOnion.Server.Tests/StreamingHubTest.cs
@@ -144,7 +144,7 @@ public class BasicStreamingHubTest : IMessageReceiver, IDisposable, IClassFixtur
     {
         client = await StreamingHubClient.ConnectAsync<ITestHub, IMessageReceiver>(channel, this, cancellationToken: TestContext.Current.CancellationToken);
         var x = await voidOnConnectedTask.Task;
-        x.Should().Be((123, "foo", 12.3f));
+        Assert.Equal((123, "foo", 12.3f), x);
         await client.DisposeAsync();
     }
 
@@ -177,7 +177,7 @@ public class BasicStreamingHubTest : IMessageReceiver, IDisposable, IClassFixtur
         //var x = await oneTask.Task;
         var y = await voidoneTask.Task;
         //x.Should().Be(100);
-        y.Should().Be(100);
+        Assert.Equal(100, y);
         await client.DisposeAsync();
     }
 
@@ -189,7 +189,7 @@ public class BasicStreamingHubTest : IMessageReceiver, IDisposable, IClassFixtur
         //var x = await moreTask.Task;
         var y = await voidmoreTask.Task;
         //x.Should().Be((100, "foo", 10.3));
-        y.Should().Be((100, "foo", 10.3));
+        Assert.Equal((100, "foo", 10.3), y);
         await client.DisposeAsync();
     }
 
@@ -198,7 +198,7 @@ public class BasicStreamingHubTest : IMessageReceiver, IDisposable, IClassFixtur
     {
         var client = await StreamingHubClient.ConnectAsync<ITestHub, IMessageReceiver>(channel, this, cancellationToken: TestContext.Current.CancellationToken);
         var v = await client.RetrunZeroArgument();
-        v.Should().Be(1000);
+        Assert.Equal(1000, v);
         await client.DisposeAsync();
     }
     [Fact]
@@ -206,7 +206,7 @@ public class BasicStreamingHubTest : IMessageReceiver, IDisposable, IClassFixtur
     {
         var client = await StreamingHubClient.ConnectAsync<ITestHub, IMessageReceiver>(channel, this, cancellationToken: TestContext.Current.CancellationToken);
         var v = await client.RetrunZeroArgument();
-        v.Should().Be(1000);
+        Assert.Equal(1000, v);
         await client.DisposeAsync();
     }
     [Fact]
@@ -214,7 +214,7 @@ public class BasicStreamingHubTest : IMessageReceiver, IDisposable, IClassFixtur
     {
         var client = await StreamingHubClient.ConnectAsync<ITestHub, IMessageReceiver>(channel, this, cancellationToken: TestContext.Current.CancellationToken);
         var v = await client.RetrunMoreArgument(10, "foo", 30.4);
-        v.Should().Be(30.4);
+        Assert.Equal(30.4, v);
         await client.DisposeAsync();
     }
 
@@ -231,9 +231,9 @@ public class BasicStreamingHubTest : IMessageReceiver, IDisposable, IClassFixtur
         }
         {
             var v = await voidone2Task.Task;
-            v.X.Should().Be(10);
-            v.Y.Should().Be(99);
-            v.Z.Should().Be(100);
+            Assert.Equal(10, v.X);
+            Assert.Equal(99, v.Y);
+            Assert.Equal(100, v.Z);
         }
         await client.DisposeAsync();
     }
@@ -242,9 +242,9 @@ public class BasicStreamingHubTest : IMessageReceiver, IDisposable, IClassFixtur
     {
         var client = await StreamingHubClient.ConnectAsync<ITestHub, IMessageReceiver>(channel, this, cancellationToken: TestContext.Current.CancellationToken);
         var v = await client.RetrunOneArgument2(new TestObject() { X = 10, Y = 99, Z = 100 });
-        v.X.Should().Be(10);
-        v.Y.Should().Be(99);
-        v.Z.Should().Be(100);
+        Assert.Equal(10, v.X);
+        Assert.Equal(99, v.Y);
+        Assert.Equal(100, v.Z);
         await client.DisposeAsync();
     }
 
@@ -276,17 +276,17 @@ public class BasicStreamingHubTest : IMessageReceiver, IDisposable, IClassFixtur
         {
             var v = await voidone3Task.Task;
 
-            v[0].X.Should().Be(10);
-            v[0].Y.Should().Be(99);
-            v[0].Z.Should().Be(100);
+            Assert.Equal(10, v[0].X);
+            Assert.Equal(99, v[0].Y);
+            Assert.Equal(100, v[0].Z);
 
-            v[1].X.Should().Be(5);
-            v[1].Y.Should().Be(39);
-            v[1].Z.Should().Be(200);
+            Assert.Equal(5, v[1].X);
+            Assert.Equal(39, v[1].Y);
+            Assert.Equal(200, v[1].Z);
 
-            v[2].X.Should().Be(4);
-            v[2].Y.Should().Be(59);
-            v[2].Z.Should().Be(300);
+            Assert.Equal(4, v[2].X);
+            Assert.Equal(59, v[2].Y);
+            Assert.Equal(300, v[2].Z);
         }
         await client.DisposeAsync();
     }
@@ -301,17 +301,17 @@ public class BasicStreamingHubTest : IMessageReceiver, IDisposable, IClassFixtur
             new TestObject() { X = 4, Y = 59, Z = 300 },
         });
 
-        v[0].X.Should().Be(10);
-        v[0].Y.Should().Be(99);
-        v[0].Z.Should().Be(100);
+        Assert.Equal(10, v[0].X);
+        Assert.Equal(99, v[0].Y);
+        Assert.Equal(100, v[0].Z);
 
-        v[1].X.Should().Be(5);
-        v[1].Y.Should().Be(39);
-        v[1].Z.Should().Be(200);
+        Assert.Equal(5, v[1].X);
+        Assert.Equal(39, v[1].Y);
+        Assert.Equal(200, v[1].Z);
 
-        v[2].X.Should().Be(4);
-        v[2].Y.Should().Be(59);
-        v[2].Z.Should().Be(300);
+        Assert.Equal(4, v[2].X);
+        Assert.Equal(59, v[2].Y);
+        Assert.Equal(300, v[2].Z);
         await client.DisposeAsync();
     }
 
@@ -459,7 +459,7 @@ public class MoreCheckHubTest : IEmptyReceiver, IDisposable, IClassFixture<Serve
             client.ReceiveExceptionAsync().GetAwaiter().GetResult();
         });
 
-        ex.StatusCode.Should().Be(StatusCode.Internal);
+        Assert.Equal(StatusCode.Internal, ex.StatusCode);
         logger.WriteLine(ex.ToString());
 
         await client.DisposeAsync();
@@ -475,7 +475,7 @@ public class MoreCheckHubTest : IEmptyReceiver, IDisposable, IClassFixture<Serve
             client.StatusCodeAsync().GetAwaiter().GetResult();
         });
 
-        ex.StatusCode.Should().Be((StatusCode)99);
+        Assert.Equal((StatusCode)99, ex.StatusCode);
         logger.WriteLine(ex.Status.Detail);
         logger.WriteLine(ex.ToString());
 

--- a/tests/MagicOnion.Server.Tests/UnaryServiceTest.cs
+++ b/tests/MagicOnion.Server.Tests/UnaryServiceTest.cs
@@ -31,7 +31,7 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ReturnTypeIsNilAndNonSuccessResponseAsync(StatusCode.AlreadyExists));
         Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);
         Assert.Equal(nameof(IUnaryTestService.ReturnTypeIsNilAndNonSuccessResponseAsync), ex.Status.Detail);
-        Assert.Equal(1, logs.Count());
+        Assert.Single(logs);
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowAsync());
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);
-        Assert.Equal(1, logs.Count());
+        Assert.Single(logs);
         Assert.Contains("Something went wrong", ex.Message);
     }
 
@@ -56,7 +56,7 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowOneValueTypeParameterReturnNilAsync(1234));
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);
-        Assert.Equal(1, logs.Count());
+        Assert.Single(logs);
         Assert.Contains("Something went wrong", ex.Message);
     }
 
@@ -69,7 +69,7 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowTwoValueTypeParameterReturnNilAsync(1234, 5678));
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);
-        Assert.Equal(1, logs.Count());
+        Assert.Single(logs);
         Assert.Contains("Something went wrong", ex.Message);
     }
 }
@@ -94,7 +94,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowAsync());
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);
-        Assert.Equal(1, logs.Count());
+        Assert.Single(logs);
         Assert.DoesNotContain("Something went wrong", ex.Message);
     }
 
@@ -107,7 +107,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowOneValueTypeParameterReturnNilAsync(1234));
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);
-        Assert.Equal(1, logs.Count());
+        Assert.Single(logs);
         Assert.DoesNotContain("Something went wrong", ex.Message);
     }
 
@@ -120,7 +120,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowTwoValueTypeParameterReturnNilAsync(1234, 5678));
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);
-        Assert.Equal(1, logs.Count());
+        Assert.Single(logs);
         Assert.DoesNotContain("Something went wrong", ex.Message);
     }
 

--- a/tests/MagicOnion.Server.Tests/UnaryServiceTest.cs
+++ b/tests/MagicOnion.Server.Tests/UnaryServiceTest.cs
@@ -29,9 +29,9 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
         logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ReturnTypeIsNilAndNonSuccessResponseAsync(StatusCode.AlreadyExists));
-        ex.StatusCode.Should().Be(StatusCode.AlreadyExists);
-        ex.Status.Detail.Should().Be(nameof(IUnaryTestService.ReturnTypeIsNilAndNonSuccessResponseAsync));
-        logs.Should().HaveCount(1);
+        Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);
+        Assert.Equal(nameof(IUnaryTestService.ReturnTypeIsNilAndNonSuccessResponseAsync), ex.Status.Detail);
+        Assert.Equal(1, logs.Count());
     }
 
     [Fact]
@@ -42,9 +42,9 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
         logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowAsync());
-        ex.StatusCode.Should().Be(StatusCode.Unknown);
-        logs.Should().HaveCount(1);
-        ex.Message.Should().Contain("Something went wrong");
+        Assert.Equal(StatusCode.Unknown, ex.StatusCode);
+        Assert.Equal(1, logs.Count());
+        Assert.Contains("Something went wrong", ex.Message);
     }
 
     [Fact]
@@ -55,9 +55,9 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
         logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowOneValueTypeParameterReturnNilAsync(1234));
-        ex.StatusCode.Should().Be(StatusCode.Unknown);
-        logs.Should().HaveCount(1);
-        ex.Message.Should().Contain("Something went wrong");
+        Assert.Equal(StatusCode.Unknown, ex.StatusCode);
+        Assert.Equal(1, logs.Count());
+        Assert.Contains("Something went wrong", ex.Message);
     }
 
     [Fact]
@@ -68,9 +68,9 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
         logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowTwoValueTypeParameterReturnNilAsync(1234, 5678));
-        ex.StatusCode.Should().Be(StatusCode.Unknown);
-        logs.Should().HaveCount(1);
-        ex.Message.Should().Contain("Something went wrong");
+        Assert.Equal(StatusCode.Unknown, ex.StatusCode);
+        Assert.Equal(1, logs.Count());
+        Assert.Contains("Something went wrong", ex.Message);
     }
 }
 
@@ -93,9 +93,9 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowAsync());
-        ex.StatusCode.Should().Be(StatusCode.Unknown);
-        logs.Should().HaveCount(1);
-        ex.Message.Should().NotContain("Something went wrong");
+        Assert.Equal(StatusCode.Unknown, ex.StatusCode);
+        Assert.Equal(1, logs.Count());
+        Assert.DoesNotContain("Something went wrong", ex.Message);
     }
 
     [Fact]
@@ -106,9 +106,9 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowOneValueTypeParameterReturnNilAsync(1234));
-        ex.StatusCode.Should().Be(StatusCode.Unknown);
-        logs.Should().HaveCount(1);
-        ex.Message.Should().NotContain("Something went wrong");
+        Assert.Equal(StatusCode.Unknown, ex.StatusCode);
+        Assert.Equal(1, logs.Count());
+        Assert.DoesNotContain("Something went wrong", ex.Message);
     }
 
     [Fact]
@@ -119,9 +119,9 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowTwoValueTypeParameterReturnNilAsync(1234, 5678));
-        ex.StatusCode.Should().Be(StatusCode.Unknown);
-        logs.Should().HaveCount(1);
-        ex.Message.Should().NotContain("Something went wrong");
+        Assert.Equal(StatusCode.Unknown, ex.StatusCode);
+        Assert.Equal(1, logs.Count());
+        Assert.DoesNotContain("Something went wrong", ex.Message);
     }
 
     [Fact]
@@ -130,7 +130,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.NoParameterReturnNilAsync()).Should().Be(Nil.Default);
+        Assert.Equal(Nil.Default, (await client.NoParameterReturnNilAsync()));
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.NoParameterReturnValueTypeAsync()).Should().Be(1234);
+        Assert.Equal(1234, (await client.NoParameterReturnValueTypeAsync()));
     }
 
     [Fact]
@@ -148,7 +148,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.NoParameterReturnRefTypeAsync()).Value.Should().Be("1234");
+        Assert.Equal("1234", (await client.NoParameterReturnRefTypeAsync()).Value);
     }
 
     [Fact]
@@ -157,7 +157,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.OneValueTypeParameterReturnNilAsync(123)).Should().Be(Nil.Default);
+        Assert.Equal(Nil.Default, (await client.OneValueTypeParameterReturnNilAsync(123)));
     }
 
     [Fact]
@@ -166,7 +166,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.OneValueTypeParameterReturnValueTypeAsync(123)).Should().Be(123);
+        Assert.Equal(123, (await client.OneValueTypeParameterReturnValueTypeAsync(123)));
     }
 
     [Fact]
@@ -175,7 +175,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.OneValueTypeParameterReturnRefTypeAsync(123)).Value.Should().Be("123");
+        Assert.Equal("123", (await client.OneValueTypeParameterReturnRefTypeAsync(123)).Value);
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.TwoValueTypeParametersReturnNilAsync(123, 456)).Should().Be(Nil.Default);
+        Assert.Equal(Nil.Default, (await client.TwoValueTypeParametersReturnNilAsync(123, 456)));
     }
 
     [Fact]
@@ -193,7 +193,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.TwoValueTypeParametersReturnValueTypeAsync(123, 456)).Should().Be(123 + 456);
+        Assert.Equal(123 + 456, (await client.TwoValueTypeParametersReturnValueTypeAsync(123, 456)));
     }
 
     [Fact]
@@ -202,7 +202,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.TwoValueTypeParametersReturnRefTypeAsync(123, 456)).Value.Should().Be((123 + 456).ToString());
+        Assert.Equal((123 + 456).ToString(), (await client.TwoValueTypeParametersReturnRefTypeAsync(123, 456)).Value);
     }
 
     [Fact]
@@ -212,8 +212,8 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ReturnTypeIsNilAndNonSuccessResponseAsync(StatusCode.AlreadyExists));
-        ex.StatusCode.Should().Be(StatusCode.AlreadyExists);
-        ex.Status.Detail.Should().Be(nameof(IUnaryTestService.ReturnTypeIsNilAndNonSuccessResponseAsync));
+        Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);
+        Assert.Equal(nameof(IUnaryTestService.ReturnTypeIsNilAndNonSuccessResponseAsync), ex.Status.Detail);
     }
 
     [Fact]
@@ -223,8 +223,8 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ReturnTypeIsRefTypeAndNonSuccessResponseAsync(StatusCode.AlreadyExists));
-        ex.StatusCode.Should().Be(StatusCode.AlreadyExists);
-        ex.Status.Detail.Should().Be(nameof(IUnaryTestService.ReturnTypeIsRefTypeAndNonSuccessResponseAsync));
+        Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);
+        Assert.Equal(nameof(IUnaryTestService.ReturnTypeIsRefTypeAndNonSuccessResponseAsync), ex.Status.Detail);
     }
 
     [Fact]
@@ -233,7 +233,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.OneRefTypeParameterReturnNilAsync(new UnaryTestMyRequest(123))).Should().Be(Nil.Default);
+        Assert.Equal(Nil.Default, (await client.OneRefTypeParameterReturnNilAsync(new UnaryTestMyRequest(123))));
     }
 
     [Fact]
@@ -242,7 +242,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.TwoRefTypeParametersReturnNilAsync(new UnaryTestMyRequest(123), new UnaryTestMyRequest(456))).Should().Be(Nil.Default);
+        Assert.Equal(Nil.Default, (await client.TwoRefTypeParametersReturnNilAsync(new UnaryTestMyRequest(123), new UnaryTestMyRequest(456))));
     }
 
     [Fact]
@@ -251,7 +251,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.OneRefTypeParameterReturnValueTypeAsync(new UnaryTestMyRequest(123))).Should().Be(123);
+        Assert.Equal(123, (await client.OneRefTypeParameterReturnValueTypeAsync(new UnaryTestMyRequest(123))));
     }
 
     [Fact]
@@ -260,7 +260,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.TwoRefTypeParametersReturnValueTypeAsync(new UnaryTestMyRequest(123), new UnaryTestMyRequest(456))).Should().Be(123 + 456);
+        Assert.Equal(123 + 456, (await client.TwoRefTypeParametersReturnValueTypeAsync(new UnaryTestMyRequest(123), new UnaryTestMyRequest(456))));
     }
 
     [Fact]
@@ -269,7 +269,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.OneRefTypeParameterReturnRefTypeAsync(new UnaryTestMyRequest(123))).Value.Should().Be("123");
+        Assert.Equal("123", (await client.OneRefTypeParameterReturnRefTypeAsync(new UnaryTestMyRequest(123))).Value);
     }
 
     [Fact]
@@ -278,7 +278,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
 
-        (await client.TwoRefTypeParametersReturnRefTypeAsync(new UnaryTestMyRequest(123), new UnaryTestMyRequest(456))).Value.Should().Be((123 + 456).ToString());
+        Assert.Equal((123 + 456).ToString(), (await client.TwoRefTypeParametersReturnRefTypeAsync(new UnaryTestMyRequest(123), new UnaryTestMyRequest(456))).Value);
     }
 
     [Fact]
@@ -316,7 +316,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
 
         var result = await client.NullResponseAsync(null);
 
-        result.Should().BeNull();
+        Assert.Null(result);
     }
 
 }

--- a/tests/MagicOnion.Server.Tests/_GlobalUsings.cs
+++ b/tests/MagicOnion.Server.Tests/_GlobalUsings.cs
@@ -1,3 +1,2 @@
-global using FluentAssertions;
 global using MagicOnion.Server.InternalTesting;
 global using Xunit;


### PR DESCRIPTION
This PR removes Fluent Assertions dependencies and usages. This is due to an unacceptable license change in v8.

- https://github.com/fluentassertions/fluentassertions/pull/2943