### PR TITLE
Wait for the queue to complete before completing the request.

### DIFF
--- a/tests/MagicOnion.Integration.Tests/StreamingHubClientResultTest.cs
+++ b/tests/MagicOnion.Integration.Tests/StreamingHubClientResultTest.cs
@@ -332,7 +332,7 @@ public class StreamingHubClientResultTest : IClassFixture<MagicOnionApplicationF
         var task = client.Invoke_CancelPendingTasksOnDisconnect(useGroup: false);
         await Task.Delay(150); // Give some time to process the request.
         await client.DisposeAsync(); // Disconnect from the server.
-        await Task.Delay(150); // Give some time to process the request.
+        await Task.Delay(1500); // Wait for the timeout of the hub method queue processing. (see: StreamingHub.RequestQueueShutdownTimeout)
 
         // Assert
         Assert.Equal((nameof(IStreamingHubClientResultTestHubReceiver.Never), (FakeStreamingHubClientResultTestHubReceiver.ArgumentEmpty)), receiver.Received[0]);
@@ -355,7 +355,7 @@ public class StreamingHubClientResultTest : IClassFixture<MagicOnionApplicationF
         var task = client.Invoke_CancelPendingTasksOnDisconnect(useGroup: true);
         await Task.Delay(150); // Give some time to process the request.
         await client.DisposeAsync(); // Disconnect from the server.
-        await Task.Delay(150); // Give some time to process the request.
+        await Task.Delay(1500); // Wait for the timeout of the hub method queue processing. (see: StreamingHub.RequestQueueShutdownTimeout)
 
         // Assert
         Assert.Equal((nameof(IStreamingHubClientResultTestHubReceiver.Never), (FakeStreamingHubClientResultTestHubReceiver.ArgumentEmpty)), receiver.Received[0]);

--- a/tests/MagicOnion.Server.InternalTesting/MagicOnionApplicationFactory.cs
+++ b/tests/MagicOnion.Server.InternalTesting/MagicOnionApplicationFactory.cs
@@ -20,7 +20,7 @@ public abstract class MagicOnionApplicationFactory : WebApplicationFactory<Progr
 {
     public const string ItemsKey = "MagicOnionApplicationFactory.Items";
     public ConcurrentDictionary<string, object> Items => Services.GetRequiredKeyedService<ConcurrentDictionary<string, object>>(ItemsKey);
-    public List<string> Logs { get; } = new();
+    public ConcurrentBag<string> Logs { get; } = new();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {

--- a/tests/MagicOnion.Server.Tests/StreamingHubDisconnectionTest.cs
+++ b/tests/MagicOnion.Server.Tests/StreamingHubDisconnectionTest.cs
@@ -18,13 +18,12 @@ public class StreamingHubDisconnectionTest : IClassFixture<MagicOnionApplication
     {
         this.factory = factory;
         this.logs = factory.Logs;
+        this.logs.Clear();
     }
 
     [Fact]
     public async Task DisconnectWhileConsumingHubMethodQueue()
     {
-        logs.Clear();
-
         var httpClient = factory.CreateDefaultClient();
         var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() {HttpClient = httpClient});
         var client = await StreamingHubClient.ConnectAsync<IStreamingHubDisconnectionTestHub, IStreamingHubDisconnectionTestHubReceiver>(

--- a/tests/MagicOnion.Server.Tests/StreamingHubDisconnectionTest.cs
+++ b/tests/MagicOnion.Server.Tests/StreamingHubDisconnectionTest.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Concurrent;
+using Grpc.Core;
+using Grpc.Net.Client;
+using MagicOnion.Client;
+using MagicOnion.Server.Hubs;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace MagicOnion.Server.Tests;
+
+public class StreamingHubDisconnectionTest : IClassFixture<MagicOnionApplicationFactory<StreamingHubDisconnectionTestHub>>
+{
+    readonly ConcurrentBag<string> logs;
+    readonly WebApplicationFactory<Program> factory;
+
+    public StreamingHubDisconnectionTest(MagicOnionApplicationFactory<StreamingHubDisconnectionTestHub> factory)
+    {
+        this.factory = factory;
+        this.logs = factory.Logs;
+    }
+
+    [Fact]
+    public async Task DisconnectWhileConsumingHubMethodQueue()
+    {
+        logs.Clear();
+
+        var httpClient = factory.CreateDefaultClient();
+        var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() {HttpClient = httpClient});
+        var client = await StreamingHubClient.ConnectAsync<IStreamingHubDisconnectionTestHub, IStreamingHubDisconnectionTestHubReceiver>(
+            channel,
+            Substitute.For<IStreamingHubDisconnectionTestHubReceiver>());
+
+        client.DoWorkAsync();
+        await Task.Delay(50);
+        client.DoWorkAsync(); // 150ms
+        client.DoWorkAsync(); // 250ms
+        client.DoWorkAsync(); // 350ms
+
+        await client.DisposeAsync();
+        channel.Dispose();
+        httpClient.Dispose();
+
+        await Task.Delay(500);
+
+        var doWorkAsyncCallCount = logs.Count(x => x.Contains("DoWorkAsync:Begin"));
+        var doWorkAsyncDoneCallCount = logs.Count(x => x.Contains("DoWorkAsync:Done"));
+        Assert.True(doWorkAsyncCallCount < 3);
+        Assert.True(doWorkAsyncCallCount == doWorkAsyncDoneCallCount);
+    }
+}
+
+public interface IStreamingHubDisconnectionTestHub : IStreamingHub<IStreamingHubDisconnectionTestHub, IStreamingHubDisconnectionTestHubReceiver>
+{
+    Task DoWorkAsync();
+}
+
+public interface IStreamingHubDisconnectionTestHubReceiver;
+
+public class StreamingHubDisconnectionTestHub(ILogger<StreamingHubDisconnectionTestHub> logger) :
+        StreamingHubBase<IStreamingHubDisconnectionTestHub, IStreamingHubDisconnectionTestHubReceiver>,
+        IStreamingHubDisconnectionTestHub
+{
+    public async Task DoWorkAsync()
+    {
+        logger.LogInformation("DoWorkAsync:Begin");
+        await Task.Delay(100);
+        _ = this.Context.CallContext.GetHttpContext().Features;
+        logger.LogInformation("DoWorkAsync:Done");
+    }
+}

--- a/tests/MagicOnion.Server.Tests/UnaryServiceTest.cs
+++ b/tests/MagicOnion.Server.Tests/UnaryServiceTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Grpc.Core;
 using Grpc.Net.Client;
 using MagicOnion.Client;
@@ -8,7 +9,7 @@ namespace MagicOnion.Server.Tests;
 
 public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOnionApplicationFactory<UnaryTestService>>
 {
-    readonly List<string> logs;
+    readonly ConcurrentBag<string> logs;
     readonly WebApplicationFactory<Program> factory;
 
     public UnaryServiceTest_ReturnExceptionStackTrace(MagicOnionApplicationFactory<UnaryTestService> factory)
@@ -76,7 +77,7 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
 
 public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<UnaryTestService>>
 {
-    readonly List<string> logs;
+    readonly ConcurrentBag<string> logs;
     readonly WebApplicationFactory<Program> factory;
 
     public UnaryServiceTest(MagicOnionApplicationFactory<UnaryTestService> factory)

--- a/tests/MagicOnion.Server.Tests/UnaryServiceTest.cs
+++ b/tests/MagicOnion.Server.Tests/UnaryServiceTest.cs
@@ -20,6 +20,7 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
         });
 
         this.logs = factory.Logs;
+        this.logs.Clear();
     }
 
     [Fact]
@@ -27,7 +28,6 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
     {
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
-        logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ReturnTypeIsNilAndNonSuccessResponseAsync(StatusCode.AlreadyExists));
         Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);
@@ -40,7 +40,6 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
     {
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
-        logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowAsync());
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);
@@ -53,7 +52,6 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
     {
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
-        logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowOneValueTypeParameterReturnNilAsync(1234));
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);
@@ -66,7 +64,6 @@ public class UnaryServiceTest_ReturnExceptionStackTrace : IClassFixture<MagicOni
     {
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
-        logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowTwoValueTypeParameterReturnNilAsync(1234, 5678));
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);
@@ -84,6 +81,7 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
     {
         this.factory = factory;
         this.logs = factory.Logs;
+        this.logs.Clear();
     }
 
     [Fact]
@@ -91,7 +89,6 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
     {
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
-        logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowAsync());
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);
@@ -104,7 +101,6 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
     {
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient }));
-        logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowOneValueTypeParameterReturnNilAsync(1234));
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);
@@ -117,7 +113,6 @@ public class UnaryServiceTest : IClassFixture<MagicOnionApplicationFactory<Unary
     {
         var httpClient = factory.CreateDefaultClient();
         var client = MagicOnionClient.Create<IUnaryTestService>(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions() { HttpClient = httpClient })); logs.Clear();
-        logs.Clear();
 
         var ex = await Assert.ThrowsAsync<RpcException>(async () => await client.ThrowTwoValueTypeParameterReturnNilAsync(1234, 5678));
         Assert.Equal(StatusCode.Unknown, ex.StatusCode);


### PR DESCRIPTION
This PR fixes an issue where ASP.NET Core requests would complete first when a client disconnected while there were Hub method queues consuming or waiting.