### PR TITLE
Update Multicaster package version to 2.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <MessagePackVersion>3.1.1</MessagePackVersion>
     <MicrosoftCodeAnalysisVersion>4.3.1</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisVersionUnity>3.9.0</MicrosoftCodeAnalysisVersionUnity>
-    <MulticasterVersion>2.0.1</MulticasterVersion>
+    <MulticasterVersion>2.1.0</MulticasterVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />


### PR DESCRIPTION
Updated the version of the `Multicaster` package from `2.0.1` to `2.1.0` in the `Directory.Packages.props` file.

- https://github.com/Cysharp/Multicaster/pull/24