### PR TITLE
Update Multicaster package version to 2.1.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <MessagePackVersion>3.1.1</MessagePackVersion>
     <MicrosoftCodeAnalysisVersion>4.3.1</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisVersionUnity>3.9.0</MicrosoftCodeAnalysisVersionUnity>
-    <MulticasterVersion>2.1.0</MulticasterVersion>
+    <MulticasterVersion>2.1.1</MulticasterVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />


### PR DESCRIPTION
Updated the `Multicaster` package version from `2.1.0` to `2.1.1` in the `Directory.Packages.props` file to incorporate the latest improvements and fixes.

- https://github.com/Cysharp/Multicaster/pull/25