### PR TITLE
ci: add id-token: write for NuGet Trusted Publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,13 +101,14 @@ jobs:
     needs: [update-packagejson, build-dotnet]
     permissions:
       contents: write
+      id-token: write # required for NuGet Trusted Publish
     uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
     with:
       commit-id: ${{ needs.update-packagejson.outputs.sha }}
       dry-run: ${{ inputs.dry-run }}
       tag: ${{ inputs.tag }}
       nuget-push: true
-      release-format: '{0}'
+      release-format: "{0}"
     secrets: inherit
 
   cleanup:


### PR DESCRIPTION
## Summary

This PR enables `release.yaml` to publish NuGet packages via [NuGet Trusted Publish](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/). 
This means we no longer depend on a Personal Access Token (PAT) to publish .nupkg packages.