### PR TITLE
ci: add post-release workflow to increment on main branch.

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -3,6 +3,12 @@ name: Post Release
 on:
   release:
     types: [published]
+  workflow_dispatch: # debug trigger
+    inputs:
+      tag:
+        description: "Tag version"
+        required: true
+        default: ""
 
 jobs:
   new-version:
@@ -12,7 +18,7 @@ jobs:
     uses: Cysharp/Actions/.github/workflows/increment-version.yaml@main
     with:
       ref: ${{ github.event.repository.default_branch }}
-      tag: ${{ github.ref_name }} # tag value will here. 1.2.1
+      tag: ${{ inputs.tag || github.ref_name }} # tag value will here. 1.2.1
       type: patch
       suffix: "-dev"
 


### PR DESCRIPTION
## Summary

The package.json and Directory.Build.props files contain the latest release version. However, on the main branch, we want to add the -dev suffix to indicate that it’s a development build.
This workflow updates these files with the appropriate suffix after a GitHub release is published.
