### PR TITLE
ci: use GitHub App Bot token to push packages.json

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
       tag: ${{ inputs.tag }}
       dry-run: ${{ inputs.dry-run }}
       ref: ${{ github.ref }}
+      use-bot-token: true
+    secrets: inherit
 
   build-dotnet:
     needs: [update-packagejson]


### PR DESCRIPTION
## Summary

Change from the GitHub Actions auto-token to GitHub App's token.