### PR TITLE
Fix an AggregateException exception occurring during connection attempt

### DIFF
--- a/src/MagicOnion.Client/StreamingHubClientBase.cs
+++ b/src/MagicOnion.Client/StreamingHubClientBase.cs
@@ -211,7 +211,7 @@ public abstract class StreamingHubClientBase<TStreamingHub, TReceiver> : IStream
                 return;
             }
 
-            var headers = responseHeadersTask.Result;
+            var headers = await responseHeadersTask.ConfigureAwait(false);
             messageVersion = headers.FirstOrDefault(x => x.Key == StreamingHubVersionHeaderKey);
 
             // Check message version of StreamingHub.

--- a/tests/MagicOnion.Client.Tests/StreamingHubTest.cs
+++ b/tests/MagicOnion.Client.Tests/StreamingHubTest.cs
@@ -743,13 +743,14 @@ public class StreamingHubTest
         var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var helper = new StreamingHubClientTestHelper<IGreeterHub, IGreeterHubReceiver>(
             factoryProvider: DynamicStreamingHubClientFactoryProvider.Instance,
-            onResponseHeaderAsync: metadata => throw new HttpRequestException());
+            onResponseHeaderAsync: metadata => throw new RpcException(new Status(StatusCode.Internal, "Something went wrong.")));
 
         // Act
         var ex = await Record.ExceptionAsync(async () => await helper.ConnectAsync(timeout.Token));
 
         // Assert
         Assert.NotNull(ex);
+        Assert.IsType<RpcException>(ex);
     }
 
     [Fact]


### PR DESCRIPTION
This PR fixes the behavior of throwing exceptions during connection attempts. This is a regression fix.

In previous versions, when an exception occurred during a connection attempt, an RpcException was primarily thrown, but there were cases where an AggregateException was thrown unintentionally.
