### PR TITLE
docs: missing group name

### DIFF
--- a/docs/docs/streaminghub/group-application-managed.md
+++ b/docs/docs/streaminghub/group-application-managed.md
@@ -74,7 +74,7 @@ The following is an example of creating a single group in advance, adding/removi
 public class GroupService(IMulticastGroupProvider groupProvider) : IDisposable
 {
     // NOTE: You can also manage multiple groups using a dictionary, etc.
-    private readonly IMulticastSyncGroup<Guid, IMyReceiver> _group = groupProvider.GetOrAddSynchronousGroup<Guid, IMyHubReceiver>();
+    private readonly IMulticastSyncGroup<Guid, IMyReceiver> _group = groupProvider.GetOrAddSynchronousGroup<Guid, IMyHubReceiver>("MyGroup");
 
     public void SendMessageToAll(string message) => _group.All.OnMessage(message);
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/streaminghub/group-application-managed.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/streaminghub/group-application-managed.md
@@ -74,7 +74,7 @@ _group.Single(ConnectionId).OnMessage("Hello, world! to me");
 public class GroupService(IMulticastGroupProvider groupProvider) : IDisposable
 {
     // NOTE: You can also manage multiple groups using a dictionary, etc.
-    private readonly IMulticastSyncGroup<Guid, IMyReceiver> _group = groupProvider.GetOrAddSynchronousGroup<Guid, IMyHubReceiver>();
+    private readonly IMulticastSyncGroup<Guid, IMyReceiver> _group = groupProvider.GetOrAddSynchronousGroup<Guid, IMyHubReceiver>("MyGroup");
 
     public void SendMessageToAll(string message) => _group.All.OnMessage(message);
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/streaminghub/group-application-managed.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/streaminghub/group-application-managed.md
@@ -74,7 +74,7 @@ _group.Single(ConnectionId).OnMessage("Hello, world! to me");
 public class GroupService(IMulticastGroupProvider groupProvider) : IDisposable
 {
     // NOTE: You can also manage multiple groups using a dictionary, etc.
-    private readonly IMulticastSyncGroup<Guid, IMyReceiver> _group = groupProvider.GetOrAddSynchronousGroup<Guid, IMyHubReceiver>();
+    private readonly IMulticastSyncGroup<Guid, IMyReceiver> _group = groupProvider.GetOrAddSynchronousGroup<Guid, IMyHubReceiver>("MyGroup");
 
     public void SendMessageToAll(string message) => _group.All.OnMessage(message);
 


### PR DESCRIPTION
## Summary

Instruction missing group name for `groupProvider.GetOrAddSynchronousGroup<T, TReciever>("GROUP")`.