### PR TITLE
chore: benchmark cleanup timeout often happen on many clients scenario

### DIFF
--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -257,13 +257,14 @@ async Task<PerformanceResult> RunScenarioAsync(ScenarioType scenario, ScenarioCo
         }
         catch (TimeoutException)
         {
-            WriteLog($"Cleanup timed out after {cleanupTimeout.TotalSeconds}s, skipping remaining cleanup.");
+            WriteLog($"...Cleanup timed out after {cleanupTimeout.TotalSeconds}s, skipping remaining cleanup.");
         }
         catch (NullReferenceException)
         {
             // ignore
         }
     }
+    WriteLog($"...Cleanup scenarios, stop loop and notify server.");
     await ctx.CleanupAsync();
     await controlService.CreateMemoryProfilerSnapshotAsync("Completed");
     WriteLog("Cleanup completed");
@@ -371,13 +372,22 @@ public class ProfileService
             }
             finally
             {
-                // flush
-                var r = hardwareReporter.GetResultAndClear();
-                await datadog.PutClientHardwareMetricsAsync(scenario, ApplicationInformation.Current, r);
-
                 hardwareReporter.Stop();
 
-                periodicTask.TrySetResult(true);
+                try
+                {
+                    // flush
+                    var r = hardwareReporter.GetResultAndClear();
+                    await datadog.PutClientHardwareMetricsAsync(scenario, ApplicationInformation.Current, r).WaitAsync(TimeSpan.FromSeconds(5));
+                }
+                catch (TimeoutException)
+                {
+                    // ignore
+                }
+                finally
+                {
+                    periodicTask.TrySetResult(true);
+                }
             }
         }, ct);
     }
@@ -385,7 +395,7 @@ public class ProfileService
     public async Task StopAsync()
     {
         cts.Cancel();
-        await periodicTask.Task;
+        await periodicTask.Task.WaitAsync(TimeSpan.FromSeconds(8));
 
         cts.Dispose();
         timer.Dispose();

--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -247,11 +247,10 @@ async Task<PerformanceResult> RunScenarioAsync(ScenarioType scenario, ScenarioCo
     WriteLog("Completed");
 
     WriteLog("Cleaning up...");
-    var chunks = Math.Clamp(scenarios.Count / 3, 1, scenarios.Count);
     var cleanupTimeout = TimeSpan.FromSeconds(30);
-    foreach (var s in scenarios.Chunk(chunks))
+    foreach (var s in scenarios.Chunk(Math.Clamp(scenarios.Count / 3, 1, scenarios.Count)))
     {
-        WriteLog($"...Cleaning up ({cleanIndex++}/{chunks})");
+        WriteLog($"...Cleaning up {s.Length}/{scenarios.Count} ({cleanIndex++})");
         try
         {
             await Task.WhenAll(s.Select(x => x.CompleteAsync())).WaitAsync(cleanupTimeout);

--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -247,12 +247,18 @@ async Task<PerformanceResult> RunScenarioAsync(ScenarioType scenario, ScenarioCo
     WriteLog("Completed");
 
     WriteLog("Cleaning up...");
-    foreach (var s in scenarios.Chunk(Math.Clamp(scenarios.Count / 3, 1, scenarios.Count)))
+    var chunks = Math.Clamp(scenarios.Count / 3, 1, scenarios.Count);
+    var cleanupTimeout = TimeSpan.FromSeconds(30);
+    foreach (var s in scenarios.Chunk(chunks))
     {
-        WriteLog($"...Cleaning up ({cleanIndex++})");
+        WriteLog($"...Cleaning up ({cleanIndex++}/{chunks})");
         try
         {
-            await Task.WhenAll(s.Select(x => x.CompleteAsync()));
+            await Task.WhenAll(s.Select(x => x.CompleteAsync())).WaitAsync(cleanupTimeout);
+        }
+        catch (TimeoutException)
+        {
+            WriteLog($"Cleanup timed out after {cleanupTimeout.TotalSeconds}s, skipping remaining cleanup.");
         }
         catch (NullReferenceException)
         {

--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -361,6 +361,11 @@ public class ProfileService
         aggregator = new();
     }
 
+    static void WriteLog(string value)
+    {
+        Console.WriteLine($"[{DateTime.Now:s}] {value}");
+    }
+
     public void Start()
     {
         hardwareReporter.Start();
@@ -380,6 +385,7 @@ public class ProfileService
             finally
             {
                 hardwareReporter.Stop();
+                periodicTask.TrySetResult(true);
 
                 try
                 {
@@ -389,11 +395,7 @@ public class ProfileService
                 }
                 catch (TimeoutException)
                 {
-                    // ignore
-                }
-                finally
-                {
-                    periodicTask.TrySetResult(true);
+                    WriteLog("... Sending datadog metrics timed out.");
                 }
             }
         }, ct);
@@ -402,7 +404,7 @@ public class ProfileService
     public async Task StopAsync()
     {
         cts.Cancel();
-        await periodicTask.Task.WaitAsync(TimeSpan.FromSeconds(8));
+        await periodicTask.Task;
 
         cts.Dispose();
         timer.Dispose();

--- a/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Client/Program.cs
@@ -108,7 +108,14 @@ async Task Main(
     WriteLog($"Saving metrics...");
     foreach (var (s, results) in resultsByScenario)
     {
-        await datadog.PutClientBenchmarkMetricsAsync(s, ApplicationInformation.Current, results);
+        try
+        {
+            await datadog.PutClientBenchmarkMetricsAsync(s, ApplicationInformation.Current, results);
+        }
+        catch (TaskCanceledException)
+        {
+            WriteLog($"... Sending datadog metrics canceled. scenario: {s}, count: {results.Count}");
+        }
     }
 
     if (!string.IsNullOrWhiteSpace(report))

--- a/perf/BenchmarkApp/PerformanceTest.Shared/Reporting/DatadogMetricsRecorder.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Shared/Reporting/DatadogMetricsRecorder.cs
@@ -109,7 +109,19 @@ public class DatadogMetricsRecorder
         // sequential handling to avoid Datadog API quota
         while (backgroundQueue.TryDequeue(out var task))
         {
+            if (task.IsCanceled)
+            {
+                WriteLog("... Task was canceled, go next.");
+                continue;
+            }
+            if (task.IsFaulted)
+            {
+                WriteLog($"... Task was faulted with exception: {task.Exception}, go next.");
+                continue;
+            }
+
             await task;
+
             if (backgroundQueue.Count == 0)
             {
                 break;
@@ -163,8 +175,13 @@ public class DatadogMetricsRecorder
         {
             // don't want to throw, show error message when failed instead
             var responseContent = await response.Content.ReadAsStringAsync();
-            Console.WriteLine($"Failed to post metrics to Datadog. StatusCode: {(int)response.StatusCode}, Response: {responseContent}");
+            WriteLog($"... Failed to post metrics to Datadog. StatusCode: {(int)response.StatusCode}, Response: {responseContent}");
         }
+    }
+
+    static void WriteLog(string value)
+    {
+        Console.WriteLine($"[{DateTime.Now:s}] {value}");
     }
 }
 


### PR DESCRIPTION
## Summary

Cleanup often times out when running a large number of clients. This forces us to wait 10 minutes for the scenario to complete.

This PR relaxes the timeout and forces the process to proceed to the next step. Since the server is shut down for each benchmark, this does not cause any issues.

## Sample workflow log

https://github.com/Cysharp/MagicOnion/actions/runs/22657333963/job/65669834109

<img width="795" height="248" alt="image" src="https://github.com/user-attachments/assets/68886f6d-7c24-4d18-b197-0d7ad9e77d46" />
