### PR TITLE
chore: benchmark NuGet server publish failed, due to API change

### DIFF
--- a/perf/BenchmarkApp/PerformanceTest.Server/PerfTestBroadcastHub.cs
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerfTestBroadcastHub.cs
@@ -7,7 +7,12 @@ public class PerfTestBroadcastHub(PerfGroupService groupService) : StreamingHubB
 {
     public async ValueTask<string> JoinGroupAsync()
     {
+#if MAGICONION_NUGET_SERVER
+        var group = await Group.AddAsync("PerformanceTestBroadcast");
+        groupService.AddMember(Context.ContextId, BroadcastToSelf(group));
+#else
         groupService.AddMember(Context.ContextId, Client);
+#endif
         return $"{Context.ContextId} joined.";
     }
 

--- a/perf/BenchmarkApp/PerformanceTest.Server/PerformanceTest.Server.csproj
+++ b/perf/BenchmarkApp/PerformanceTest.Server/PerformanceTest.Server.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,6 +9,7 @@
 
   <PropertyGroup Condition="'$(UseNuGetServer)' != ''">
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <DefineConstants>$(DefineConstants);MAGICONION_NUGET_SERVER</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="'$(UseNuGetServer)' != ''">
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcVersion)"/>


### PR DESCRIPTION
## Summary

Due to API change, `dotnet publish` failed when running benchmark with `-p:UseNuGetServer=6.1.4`.  This PR fix build error.

Error

```
  /home/azure-user/github/MagicOnion/perf/BenchmarkApp/PerformanceTest.Server/PerfTestBroadcastHub.cs(10,51): error CS0103: The name 'Client' does not exist in the current context [/home/azure-user/github/MagicOnion/perf/BenchmarkApp/PerformanceTest.Server/PerformanceTest.Server.csproj]
```

see: https://github.com/Cysharp/MagicOnion/actions/runs/22878995304/job/66379175872#step:19:103