### PR TITLE
docs: fix Unary client example in getting-started.md (remove await and receiver)

### DIFF
--- a/docs/docs/unary/getting-started.md
+++ b/docs/docs/unary/getting-started.md
@@ -62,7 +62,7 @@ To call the Unary service method from the client, use the `MagicOnionClient.Crea
 
 ```csharp
 var channel = GrpcChannel.ForAddress("https://localhost:5001");
-var client = await MagicOnionClient.Create<IGreeterService>(channel, receiver);
+var client = MagicOnionClient.Create<IGreeterService>(channel);
 ```
 
 Call the method of the Unary service using the generated client proxy.


### PR DESCRIPTION
Fixes #1070.

The Unary client example read:

```csharp
var client = await MagicOnionClient.Create<IGreeterService>(channel, receiver);
```

Two issues, both contradicted by the surrounding prose in the same section:

1. **`await`** — the doc states "At this point, no request is sent to the server", i.e. `Create<T>` is synchronous and returns the client proxy directly, so it shouldn't be awaited.
2. **`receiver` argument** — the doc states `Create<T>` "takes a Unary service interface and a `GrpcChannel` object". A `receiver` is a StreamingHub concept and isn't a parameter of the Unary `Create<T>`.

Corrected to:

```csharp
var client = MagicOnionClient.Create<IGreeterService>(channel);
```