### PR TITLE
ci: avoid using run-inputs-context-direct-use detected by seiton

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,9 @@ jobs:
         with:
           user: ${{ secrets.NUGET_USER }}
       # WORKAROUND: NuGet.org rejects `.snupkg` that do not contian `.pdb` files.
-      - run: rm ./publish/MagicOnion.${{ inputs.tag }}.snupkg
+      - run: rm ./publish/MagicOnion.${TAG}.snupkg
+        env:
+          TAG: ${{ inputs.tag }}
       - run: dotnet nuget push "./publish/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
         if: ${{ !inputs.dry-run }}
         env:


### PR DESCRIPTION
## Summary

Detected https://github.com/Cysharp/Actions/actions/runs/27591468007/job/81572898917#step:5:6