### PR TITLE
ci: enable bot token for update-packagejson

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -34,4 +34,5 @@ jobs:
         ./src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion.Client.Unity/package.json
         ./Directory.Build.props
       tag: ${{ needs.new-version.outputs.version }}
+      use-bot-token: true
       dry-run: false


### PR DESCRIPTION
## Summary

Because of status check, required bot token to commit directly into default branch.

This fixes https://github.com/Cysharp/MagicOnion/actions/runs/28487007671/job/84435564683