### PR TITLE
ci: enable pr-harness license check

### DIFF
--- a/.github/workflows/pr-harness.yaml
+++ b/.github/workflows/pr-harness.yaml
@@ -16,4 +16,3 @@ jobs:
       license-check: true
       exclude-license-input-paths: |
         docs/
-        samples/

--- a/.github/workflows/pr-harness.yaml
+++ b/.github/workflows/pr-harness.yaml
@@ -3,6 +3,8 @@ name: PR Harness
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [harness]
 
 jobs:
   harness:
@@ -10,3 +12,5 @@ jobs:
       contents: read
       pull-requests: read
     uses: Cysharp/Actions/.github/workflows/pr-harness.yaml@main
+    with:
+      license-check: true

--- a/.github/workflows/pr-harness.yaml
+++ b/.github/workflows/pr-harness.yaml
@@ -14,3 +14,5 @@ jobs:
     uses: Cysharp/Actions/.github/workflows/pr-harness.yaml@main
     with:
       license-check: true
+      exclude-license-input-paths: |
+        docs/

--- a/.github/workflows/pr-harness.yaml
+++ b/.github/workflows/pr-harness.yaml
@@ -16,3 +16,4 @@ jobs:
       license-check: true
       exclude-license-input-paths: |
         docs/
+        samples/

--- a/.github/workflows/pr-harness.yaml
+++ b/.github/workflows/pr-harness.yaml
@@ -3,8 +3,6 @@ name: PR Harness
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [harness]
 
 jobs:
   harness:


### PR DESCRIPTION
## Summary

Introduce license checks for NuGet/npm package changes.

Use [ol](https://github.com/guitarrapc/ol) to check added or updated NuGet/npm packages. This safeguards MagicOnion against unintentionally introducing dependencies with unapproved licenses.

- When a package version changes, its license may have changed even if the package is already present. The `license-check` job verifies that the new license is still on the allowlist.
- When a package is added, the `license-check` job verifies that its license is on the allowlist.

ol checks both direct and transitive NuGet/npm dependencies, so all resolved 3rd-party packages are validated.

## Allowed licenses

Currently `Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,MIT,MPL-2.0` are allowed.

## Execution sample

https://github.com/Cysharp/MagicOnion/actions/runs/32964960867/job/98165404954#step:14:59

<img width="1237" height="221" alt="image" src="https://github.com/user-attachments/assets/ef68166f-d427-40cd-8036-bf6db724462b" />
