### PR TITLE
Deprecate UnsafeDirectBlit

### DIFF
--- a/src/MagicOnion.Serialization.MessagePack/UnsafeDirectBlitResolver.cs
+++ b/src/MagicOnion.Serialization.MessagePack/UnsafeDirectBlitResolver.cs
@@ -1,4 +1,4 @@
-using MessagePack;
+﻿using MessagePack;
 using System.Buffers;
 using MessagePack.Formatters;
 using System.Runtime.CompilerServices;
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace MagicOnion.Serialization.MessagePack
 {
+    [Obsolete("Do not use UnsafeDirectBlit because it poses a high security risk.")]
     public class UnsafeDirectBlitResolver : IFormatterResolver
     {
         public static readonly UnsafeDirectBlitResolver Instance = new UnsafeDirectBlitResolver();
@@ -53,6 +54,7 @@ namespace MagicOnion.Serialization.MessagePack
         }
     }
 
+    [Obsolete("Do not use UnsafeDirectBlit because it poses a high security risk.")]
     public class UnsafeDirectBlitArrayFormatter<T> : IMessagePackFormatter<T[]?>
         where T : unmanaged
     {
@@ -153,6 +155,7 @@ namespace MagicOnion.Serialization.MessagePack
         }
     }
 
+    [Obsolete("Do not use UnsafeDirectBlit because it poses a high security risk.")]
     public class UnsafeDirectBlitFormatter<T> : IMessagePackFormatter<T>
         where T : unmanaged
     {

--- a/tests/MagicOnion.Serialization.MessagePack.Tests/UnsafeDirectBlitResolverTest.cs
+++ b/tests/MagicOnion.Serialization.MessagePack.Tests/UnsafeDirectBlitResolverTest.cs
@@ -1,5 +1,6 @@
-using MessagePack;
+﻿using MessagePack;
 using MessagePack.Resolvers;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace MagicOnion.Serialization.MessagePack.Tests;
 


### PR DESCRIPTION
<!-- Instructions for AI coding agents: Before creating a PR, verify that it complies with the PR policies defined in `AGENTS.md`. -->
The `UnsafeDirectBlit` formatters have been deprecated. They are considered unsafe because they rely on the memory layout of types and make it easy for untrusted serialized data to cause memory corruption during deserialization.

`UnsafeDirectBlit` will be removed in the next major version. You may copy and use the existing code, but it will no longer be supported or maintained by the project.
