### PR TITLE
Fix Box.Create returning Box<bool> for Nullable<bool> values

### DIFF
--- a/src/MagicOnion.Abstractions/Internal/Box.cs
+++ b/src/MagicOnion.Abstractions/Internal/Box.cs
@@ -41,11 +41,17 @@ public sealed class Box<T> : IEquatable<Box<T>>
 public static class Box
 {
     private static readonly Box<MessagePack.Nil> Nil = new Box<MessagePack.Nil>(MessagePack.Nil.Default);
+    private static readonly Box<bool?> NullableBoolTrue = new Box<bool?>(true);
+    private static readonly Box<bool?> NullableBoolFalse = new Box<bool?>(false);
     private static readonly Box<bool> BoolTrue = new Box<bool>(true);
     private static readonly Box<bool> BoolFalse = new Box<bool>(false);
 
     public static Box<T> Create<T>(T value)
-        => (value is MessagePack.Nil) ? (Box<T>)(object)Nil
-            : (value is bool b) ? (Box<T>)(object)(b ? BoolTrue : BoolFalse)
-            : new Box<T>(value);
+        => (value is MessagePack.Nil)
+            ? (Box<T>)(object)Nil
+            : (value is bool b)
+                ? typeof(T) == typeof(bool?)
+                    ? (Box<T>)(object)(b ? NullableBoolTrue : NullableBoolFalse)
+                    : (Box<T>)(object)(b ? BoolTrue : BoolFalse)
+                : new Box<T>(value);
 }

--- a/tests/MagicOnion.Abstractions.Tests/BoxTest.cs
+++ b/tests/MagicOnion.Abstractions.Tests/BoxTest.cs
@@ -80,4 +80,65 @@ public class BoxTest
         Assert.Equal(box2.Value, box1.Value);
         Assert.Same(box2, box1);
     }
+
+    [Fact]
+    public void CacheNullableBool()
+    {
+        // Act
+        var box1 = Box.Create<bool?>(true);
+        var box2 = Box.Create<bool?>(false);
+
+        // Assert
+        Assert.True(box1.Value);
+        Assert.False(box2.Value);
+        Assert.NotEqual(box2.Value, box1.Value);
+        Assert.NotSame(box2, box1);
+    }
+
+    [Fact]
+    public void CacheNullableBoolTrue()
+    {
+        // Act
+        var box1 = Box.Create<bool?>(true);
+        var box2 = Box.Create<bool?>(true);
+
+        // Assert
+        Assert.True(box1.Value);
+        Assert.Equal(box2.Value, box1.Value);
+        Assert.Same(box2, box1);
+    }
+
+    [Fact]
+    public void CacheNullableBoolFalse()
+    {
+        // Act
+        var box1 = Box.Create<bool?>(false);
+        var box2 = Box.Create<bool?>(false);
+
+        // Assert
+        Assert.False(box1.Value);
+        Assert.Equal(box2.Value, box1.Value);
+        Assert.Same(box2, box1);
+    }
+
+    [Fact]
+    public void CacheNullableBoolIsSeparatedFromBool()
+    {
+        // Act
+        var box1 = Box.Create(true);
+        var box2 = Box.Create<bool?>(true);
+
+        // Assert
+        Assert.NotSame(box1, box2);
+    }
+
+    [Fact]
+    public void NullableBoolNull()
+    {
+        // Act
+        var box = Box.Create<bool?>(null);
+
+        // Assert
+        Assert.Null(box.Value);
+    }
 }


### PR DESCRIPTION
Any unary method with a non-null `bool?` parameter or return value fails with ```InvalidCastException: Unable to cast object of type 'Box`1[System.Boolean]' to type 'Box`1[System.Nullable`1[System.Boolean]]'```.

<details><summary>Minimal repro app</summary>
<p>

<details><summary>Server</summary>
<p>

```csharp
#nullable enable
using MagicOnion;
using MagicOnion.Server;
using MessagePack;
using Microsoft.AspNetCore.Builder;
using Microsoft.AspNetCore.Hosting;
using Microsoft.AspNetCore.Http;
using Microsoft.Extensions.DependencyInjection;

var url = "https://localhost:9000/";

MessagePackSerializer.DefaultOptions = MessagePack.Resolvers.ContractlessStandardResolver.Options;

var builder = WebApplication.CreateBuilder();

builder.WebHost.ConfigureKestrel((context, options) =>
{
	options.ListenAnyIP(9000, listenOptions =>
	{
		listenOptions.UseHttps();
	});
});

builder.Services.AddGrpc();
builder.Services.AddMagicOnion();

var app = builder.Build();
app.MapMagicOnionService();
app.MapGet("/", async context =>
{
	await context.Response.WriteAsync("Server<br>");
});

app.Run(url);

public interface IFirstService : IService<IFirstService>
{
	UnaryResult<bool?> NBoolTest(bool returnNull = false);
}

public class FirstService : ServiceBase<IFirstService>, IFirstService
{
	public UnaryResult<bool?> NBoolTest(bool returnNull = false)
	{
		if (returnNull)
		{
			return UnaryResult.FromResult((bool?)null);
		}

		return UnaryResult.FromResult((bool?)false);
	}
}
```

</p>
</details> 

<details><summary>Client</summary>
<p>

```csharp
#nullable enable
using System;
using Grpc.Net.Client;
using MagicOnion;
using MagicOnion.Client;
using MessagePack;

var url = "https://localhost:9000/";

MessagePackSerializer.DefaultOptions = MessagePack.Resolvers.ContractlessStandardResolver.Options;

var channel = GrpcChannel.ForAddress(url);
var client = MagicOnionClient.Create<IFirstService>(channel);

Console.WriteLine($"NBoolTest(returnNull=true)={await client.NBoolTest(returnNull: true)}");
Console.WriteLine($"NBoolTest(returnNull=false)={await client.NBoolTest(returnNull: false)}"); // fails here

public interface IFirstService : IService<IFirstService>
{
	UnaryResult<bool?> NBoolTest(bool returnNull = false);
}
```

</p>
</details> 

</p>
</details>

Full exception without the patch:
```
fail: Grpc.AspNetCore.Server.ServerCallHandler[6]
      Error when executing service method 'NBoolTest'.
      System.InvalidCastException: Unable to cast object of type 'MagicOnion.Internal.Box`1[System.Boolean]' to type 'MagicOnion.Internal.Box`1[System.Nullable`1[System.Boolean]]'.
         at MagicOnion.Internal.Box.Create[T](T value)
         at MagicOnion.Server.Binder.Internal.MagicOnionGrpcMethodHandler`1.<>c__DisplayClass10_0`4.<<BuildUnaryMethod>g__InvokeAsync|1>d.MoveNext()
      --- End of stack trace from previous location ---
         at Grpc.Shared.Server.UnaryServerMethodInvoker`3.AwaitInvoker(Task`1 invokerTask, GrpcActivatorHandle`1 serviceHandle) in /_/src/Shared/Server/UnaryServerMethodInvoker.cs:line 154
         at Grpc.Shared.Server.UnaryServerMethodInvoker`3.AwaitInvoker(Task`1 invokerTask, GrpcActivatorHandle`1 serviceHandle) in /_/src/Shared/Server/UnaryServerMethodInvoker.cs:line 160
         at Grpc.AspNetCore.Server.Internal.CallHandlers.UnaryServerCallHandler`3.HandleCallAsyncCore(HttpContext httpContext, HttpContextServerCallContext serverCallContext) in /_/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs:line 50
         at Grpc.AspNetCore.Server.Internal.CallHandlers.ServerCallHandlerBase`3.<HandleCallAsync>g__AwaitHandleCall|8_0(HttpContextServerCallContext serverCallContext, Method`2 method, Task handleCall) in /_/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs:line 100
```